### PR TITLE
Fix non-bazel & bazel file query error

### DIFF
--- a/src/main/java/com/bazel-diff/BazelClient.java
+++ b/src/main/java/com/bazel-diff/BazelClient.java
@@ -52,7 +52,7 @@ class BazelClientImpl implements BazelClient {
     @Override
     public Set<BazelSourceFileTarget> convertFilepathsToSourceTargets(Set<Path> filepaths) throws IOException, NoSuchAlgorithmException {
         Set<BazelSourceFileTarget> sourceTargets = new HashSet<>();
-        for (List<Path> partition : Iterables.partition(filepaths, 100)) {
+        for (List<Path> partition : Iterables.partition(filepaths, 1)) {
             String targetQuery = partition
                     .stream()
                     .map(path -> path.toString())


### PR DESCRIPTION
When we mix files that are tracked by Bazel with files that are not tracked by Bazel, `bazel query` fails. Even with `--keep-going` enabled we are getting a non zero exit code and that is preventing us from reading from our output proto stream.

This stopgap solution should be fine for now. We need to find a way to get back to our optimized query 

Fixes  #8