### PR TITLE
Change directory layout to be a standard Maven directory layout

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
 alias(
     name = "bazel-diff",
-    actual = "//src/main/java/com/bazel-diff:bazel-diff"
+    actual = "//src/main/java/com/bazel_diff:bazel-diff"
 )

--- a/src/main/java/com/bazel_diff/BUILD
+++ b/src/main/java/com/bazel_diff/BUILD
@@ -21,7 +21,7 @@ java_library(
         "@bazel_diff_maven//:com_google_code_gson_gson",
         "@bazel_diff_maven//:com_google_guava_guava"
     ],
-    visibility = ["//test/java/com/bazel-diff:__pkg__"]
+    visibility = ["//src/test/java/com/bazel_diff:__pkg__"]
 )
 
 java_proto_library(

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -1,3 +1,5 @@
+package com.bazel_diff;
+
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
 
 import com.google.common.collect.Iterables;

--- a/src/main/java/com/bazel_diff/BazelRule.java
+++ b/src/main/java/com/bazel_diff/BazelRule.java
@@ -1,3 +1,5 @@
+package com.bazel_diff;
+
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;

--- a/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
+++ b/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
@@ -1,3 +1,5 @@
+package com.bazel_diff;
+
 import java.security.MessageDigest;
 
 interface BazelSourceFileTarget {

--- a/src/main/java/com/bazel_diff/BazelTarget.java
+++ b/src/main/java/com/bazel_diff/BazelTarget.java
@@ -1,3 +1,5 @@
+package com.bazel_diff;
+
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
 
 interface BazelTarget {

--- a/src/main/java/com/bazel_diff/Constants.java
+++ b/src/main/java/com/bazel_diff/Constants.java
@@ -1,3 +1,5 @@
+package com.bazel_diff;
+
 public class Constants {
     public static final String Version = "1.0";
 }

--- a/src/main/java/com/bazel_diff/GitClient.java
+++ b/src/main/java/com/bazel_diff/GitClient.java
@@ -1,3 +1,5 @@
+package com.bazel_diff;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -1,3 +1,5 @@
+package com.bazel_diff;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.MessageDigest;

--- a/src/main/java/com/bazel_diff/VersionProvider.java
+++ b/src/main/java/com/bazel_diff/VersionProvider.java
@@ -1,3 +1,5 @@
+package com.bazel_diff;
+
 import picocli.CommandLine.IVersionProvider;
 
 class VersionProvider implements IVersionProvider {

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -1,3 +1,5 @@
+package com.bazel_diff;
+
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;

--- a/src/test/java/com/bazel_diff/BUILD
+++ b/src/test/java/com/bazel_diff/BUILD
@@ -3,14 +3,14 @@ load("@rules_java//java:defs.bzl", "java_library", "java_test")
 java_test(
     name = "java-bazel-diff-tests",
     runtime_deps = [":java-bazel-diff-test-lib"],
-    test_class = "TargetHashingClientImplTests"
+    test_class = "com.bazel_diff.TargetHashingClientImplTests"
 )
 
 java_library(
     name = "java-bazel-diff-test-lib",
     srcs = glob(["*.java"]),
     deps = [
-        "//src/main/java/com/bazel-diff:java-bazel-diff-lib",
+        "//src/main/java/com/bazel_diff:java-bazel-diff-lib",
         "@bazel_diff_maven//:org_mockito_mockito_core",
         "@bazel_diff_maven//:junit_junit"
     ]

--- a/src/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/src/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -1,3 +1,5 @@
+package com.bazel_diff;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
## What?
This PR changes the layout of the project so that it adheres to the maven directory layout, which is recommended by the Bazel authors.
Also change the java package name to `com.bazel_diff` instead of `com.bazel-diff` because hyphens are not allowed in java package names.

## Why?
I wanted to experiment with the project so I opened it in IntelliJ with the Bazel plugin and nothing worked.
By using this folder structure and adding package names to all files it works very well.

If there is already some way to get an IDE working with this project that is not documented then I would love to hear about it and this PR can be closed.