### PR TITLE
Collapse impacted-tests into bazel-diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,13 @@ Open `bazel-diff-example.sh` to see how this is implemented. This is purely an e
 
 * Next we checkout the initial revision, then we run `generate-hashes` with the file output of `modified-filepaths` and write that JSON to a file. Now we have our final hashmap representation for the Bazel graph.
 
-* We run `bazel-diff` on the starting and final JSON hash filepaths to get our affected set of targets. This impacted set of targets is written to a file
-
-* Finally we run `impacted-tests` with the filepath to the list of impacted targets. This returns us the impacted test targets.
+* We run `bazel-diff` on the starting and final JSON hash filepaths to get our impacted set of targets. This impacted set of targets is written to a file. You can also pass the `-t` flag to only return tests
 
 ## CLI Interface
 
 `bazel-diff` Command
 ~~~
-Usage: bazel-diff [-hV] -b=<bazelPath> [-fh=<finalHashesJSONPath>]
+Usage: bazel-diff [-htV] -b=<bazelPath> [-fh=<finalHashesJSONPath>]
                   [-o=<outputPath>] [-sh=<startingHashesJSONPath>]
                   -w=<workspacePath> [COMMAND]
 Writes to a file the impacted targets between two Bazel graph JSON files
@@ -76,26 +74,10 @@ Writes to a file the impacted targets between two Bazel graph JSON files
       -sh, --startingHashes=<startingHashesJSONPath>
                   The path to the JSON file of target hashes for the initial
                     revision. Run 'generate-hashes' to get this value.
+  -t, --tests     Return only targets of kind 'test')
   -V, --version   Print version information and exit.
   -w, --workspacePath=<workspacePath>
                   Path to Bazel workspace directory.
-~~~
-
-`impacted-tests` Command
-~~~
-Usage: bazel-diff impacted-tests [-hV] -b=<bazelPath> -w=<workspacePath>
-                                 <impactedBazelTargetsPath> <outputPath>
-Write to a file the impacted test targets for the list of Bazel targets in the
-provided file
-      <impactedBazelTargetsPath>
-                     The filepath to a newline separated list of Bazel targets
-      <outputPath>   The filepath to write the impacted test targets to
-  -b, --bazelPath=<bazelPath>
-                     Path to Bazel binary
-  -h, --help         Show this help message and exit.
-  -V, --version      Print version information and exit.
-  -w, --workspacePath=<workspacePath>
-                     Path to Bazel workspace directory.
 ~~~
 
 `modified-filepaths` Command

--- a/bazel-diff-example.sh
+++ b/bazel-diff-example.sh
@@ -11,7 +11,7 @@ final_revision=$4
 
 modified_filepaths_output="/tmp/modified_filepaths.txt"
 starting_hashes_json="/tmp/starting_hashes.json"
-final_hashes_json="/tmp/final_hashes_json.json"
+final_hashes_json="/tmp/final_hashes.json"
 impacted_targets_path="/tmp/impacted_targets.txt"
 impacted_test_targets_path="/tmp/impacted_test_targets.txt"
 
@@ -28,7 +28,7 @@ git -C $workspace_path checkout $previous_revision --quiet
 echo "Generating Hashes for Revision '$previous_revision'"
 $bazel_path run :bazel-diff -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
 
-git -C $workspace_path checkout -  --quiet
+git -C $workspace_path checkout - --quiet
 
 echo "Generating Hashes for Revision '$final_revision'"
 $bazel_path run :bazel-diff -- generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json
@@ -37,7 +37,7 @@ echo "Determining Impacted Targets"
 $bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path
 
 echo "Determining Impacted Test Targets"
-$bazel_path run :bazel-diff -- impacted-tests -w $workspace_path -b $bazel_path $impacted_targets_path $impacted_test_targets_path
+$bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_test_targets_path -t
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
 formatted_impacted_targets=$(IFS=$'\n'; echo "${impacted_targets[*]}")

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -28,16 +28,19 @@ ruby ./integration/update_final_hashes.rb
 
 $bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path
 
-$bazel_path run :bazel-diff -- impacted-tests -w $workspace_path -b $bazel_path $impacted_targets_path $impacted_test_targets_path
+$bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_test_targets_path -t
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
-target="//src/main/java/com/integration:StringGenerator.java"
-if containsElement $target "${impacted_targets[@]}";
+target1="//test/java/com/integration:bazel-diff-integration-test-lib"
+target2="//src/main/java/com/integration:bazel-diff-integration-lib"
+target3="//test/java/com/integration:bazel-diff-integration-tests"
+if containsElement $target1 "${impacted_targets[@]}" && \
+    containsElement $target2 "${impacted_targets[@]}" && \
+    containsElement $target3 "${impacted_targets[@]}"
 then
-    echo "Correct first impacted target"
+    echo "Correct impacted targets"
 else
-    echo "Impacted Targets: ${impacted_targets[@]}"
-    echo "Incorrect first impacted target: ${target}"
+    echo "Incorrect impacted targets: ${impacted_targets[@]}"
     exit 1
 fi
 

--- a/src/main/java/com/bazel-diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel-diff/TargetHashingClient.java
@@ -6,7 +6,7 @@ import java.util.*;
 
 interface TargetHashingClient {
     Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException;
-    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes);
+    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException;
     Set<String> getImpactedTestTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException;
 }
 
@@ -50,7 +50,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
     }
 
     @Override
-    public Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) {
+    public Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException {
         Set<String> impactedTargets = new HashSet<>();
         for ( Map.Entry<String,String> entry : endHashes.entrySet()) {
             String startHashValue = startHashes.get(entry.getKey());
@@ -58,13 +58,13 @@ class TargetHashingClientImpl implements TargetHashingClient {
                 impactedTargets.add(entry.getKey());
             }
         }
-        return impactedTargets;
+        return bazelClient.queryForImpactedTargets(impactedTargets);
     }
 
     @Override
     public Set<String> getImpactedTestTargets(Map<String, String> startHashes, Map<String, String> endHashes) throws IOException {
         Set<String> impactedTargets = getImpactedTargets(startHashes, endHashes);
-        return bazelClient.queryForImpactedTestTargets(impactedTargets);
+        return bazelClient.queryForTestTargets(impactedTargets);
     }
 
     private MessageDigest createDigestForTarget(

--- a/src/main/java/com/bazel-diff/VersionProvider.java
+++ b/src/main/java/com/bazel-diff/VersionProvider.java
@@ -3,7 +3,7 @@ import picocli.CommandLine.IVersionProvider;
 class VersionProvider implements IVersionProvider {
     public String[] getVersion() throws Exception {
         return new String[] {
-            "1.0.2"
+            "1.1.0"
         };
     }
 }

--- a/test/java/com/bazel-diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel-diff/TargetHashingClientImplTests.java
@@ -112,7 +112,10 @@ public class TargetHashingClientImplTests {
     }
 
     @Test
-    public void getImpactedTargets() {
+    public void getImpactedTargets() throws IOException {
+        when(bazelClientMock.queryForImpactedTargets(anySet())).thenReturn(
+                new HashSet<>(Arrays.asList("rule1", "rule3"))
+        );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
         Map<String, String> hash1 = new HashMap<>();
         hash1.put("rule1", "rule1hash");
@@ -130,7 +133,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTestTargets() throws IOException {
-        when(bazelClientMock.queryForImpactedTestTargets(anySet())).thenReturn(
+        when(bazelClientMock.queryForTestTargets(anySet())).thenReturn(
                 new HashSet<>(Arrays.asList("rule1test", "rule3test", "someothertest"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);


### PR DESCRIPTION
Collapses down the `impacted-tests` command into a flag on `bazel-diff`

Also `bazel-diff` now performs `rdeps` queries as expected, fixes #7 