### PR TITLE
Add bazel options

### DIFF
--- a/src/main/java/com/bazel-diff/BazelClient.java
+++ b/src/main/java/com/bazel-diff/BazelClient.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.Arrays;
 
 interface BazelClient {
     List<BazelTarget> queryAllTargets() throws IOException;
@@ -23,10 +24,14 @@ interface BazelClient {
 class BazelClientImpl implements BazelClient {
     private Path workingDirectory;
     private Path bazelPath;
+    private List<String> startupOptions;
+    private List<String> commandOptions;
 
-    BazelClientImpl(Path workingDirectory, Path bazelPath) {
+    BazelClientImpl(Path workingDirectory, Path bazelPath, String startupOptions, String commandOptions) {
         this.workingDirectory = workingDirectory.normalize();
         this.bazelPath = bazelPath;
+        this.startupOptions = Arrays.asList(startupOptions.split(" "));
+        this.commandOptions = Arrays.asList(commandOptions.split(" "));
     }
 
     @Override
@@ -94,15 +99,28 @@ class BazelClientImpl implements BazelClient {
     }
 
     private List<Build.Target> performBazelQuery(String query) throws IOException {
-        ProcessBuilder pb = new ProcessBuilder(bazelPath.toString(),
-                "query",
-                query,
-                "--output",
-                "streamed_proto",
-                "--order_output=no",
-                "--show_progress=false",
-                "--show_loading_progress=false"
-        ).directory(workingDirectory.toFile());
+        List<String> cmd = new ArrayList<String>();
+        
+        cmd.add((bazelPath.toString()));
+
+        if(this.startupOptions != null) {
+            cmd.addAll(this.startupOptions);
+        }
+
+        cmd.add("query");
+        cmd.add("--output");
+        cmd.add("streamed_proto");
+        cmd.add("--order_output=no");
+        cmd.add("--show_progress=false");
+        cmd.add("--show_loading_progress=false");
+
+        if(this.commandOptions != null) {
+            cmd.addAll(this.commandOptions);
+        }
+
+        cmd.add(query);
+
+        ProcessBuilder pb = new ProcessBuilder(cmd).directory(workingDirectory.toFile());
         Process process = pb.start();
         ArrayList<Build.Target> targets = new ArrayList<>();
         while (true) {

--- a/src/main/java/com/bazel-diff/BazelClient.java
+++ b/src/main/java/com/bazel-diff/BazelClient.java
@@ -30,8 +30,8 @@ class BazelClientImpl implements BazelClient {
     BazelClientImpl(Path workingDirectory, Path bazelPath, String startupOptions, String commandOptions) {
         this.workingDirectory = workingDirectory.normalize();
         this.bazelPath = bazelPath;
-        this.startupOptions = Arrays.asList(startupOptions.split(" "));
-        this.commandOptions = Arrays.asList(commandOptions.split(" "));
+        this.startupOptions = startupOptions != null ? Arrays.asList(startupOptions.split(" ")): new ArrayList<String>();
+        this.commandOptions = commandOptions != null ? Arrays.asList(commandOptions.split(" ")): new ArrayList<String>();
     }
 
     @Override
@@ -102,22 +102,14 @@ class BazelClientImpl implements BazelClient {
         List<String> cmd = new ArrayList<String>();
         
         cmd.add((bazelPath.toString()));
-
-        if(this.startupOptions != null) {
-            cmd.addAll(this.startupOptions);
-        }
-
+        cmd.addAll(this.startupOptions);
         cmd.add("query");
         cmd.add("--output");
         cmd.add("streamed_proto");
         cmd.add("--order_output=no");
         cmd.add("--show_progress=false");
         cmd.add("--show_loading_progress=false");
-
-        if(this.commandOptions != null) {
-            cmd.addAll(this.commandOptions);
-        }
-
+        cmd.addAll(this.commandOptions);
         cmd.add(query);
 
         ProcessBuilder pb = new ProcessBuilder(cmd).directory(workingDirectory.toFile());

--- a/src/main/java/com/bazel-diff/main.java
+++ b/src/main/java/com/bazel-diff/main.java
@@ -80,19 +80,13 @@ class GenerateHashes implements Callable<Integer> {
     @Option(names = {"-m", "--modifiedFilepaths"}, description = "The path to a file containing the list of modified filepaths in the workspace, you can use the 'modified-filepaths' command to get this list")
     File modifiedFilepaths;
 
-    @Option(names = {"-so", "--bazelStartupOptions"}, description = "Additional Bazel client startup options used when invoking Bazel")
-    String bazelStartupOptions;
-
-    @Option(names = {"-co", "--bazelCommandOptions"}, description = "Additional Bazel command options used when invoking Bazel")
-    String bazelCommandOptions;
-
     @Parameters(index = "0", description = "The filepath to write the resulting JSON of dictionary target => SHA-256 values")
     File outputPath;
 
     @Override
     public Integer call() {
         GitClient gitClient = new GitClientImpl(parent.workspacePath);
-        BazelClient bazelClient = new BazelClientImpl(parent.workspacePath, parent.bazelPath, bazelStartupOptions, bazelCommandOptions);
+        BazelClient bazelClient = new BazelClientImpl(parent.workspacePath, parent.bazelPath, parent.bazelStartupOptions, parent.bazelCommandOptions);
         TargetHashingClient hashingClient = new TargetHashingClientImpl(bazelClient);
         try {
             gitClient.ensureAllChangesAreCommitted();

--- a/src/main/java/com/bazel-diff/main.java
+++ b/src/main/java/com/bazel-diff/main.java
@@ -142,10 +142,10 @@ class BazelDiff implements Callable<Integer> {
     @Option(names = {"-t", "--tests"}, scope = ScopeType.LOCAL, description = "Return only targets of kind 'test')")
     boolean testTargets;
 
-    @Option(names = {"-so", "--bazelStartupOptions"}, description = "Additional space separated Bazel client startup options used when invoking Bazel")
+    @Option(names = {"-so", "--bazelStartupOptions"}, description = "Additional space separated Bazel client startup options used when invoking Bazel", scope = ScopeType.INHERIT)
     String bazelStartupOptions;
 
-    @Option(names = {"-co", "--bazelCommandOptions"}, description = "Additional space separated Bazel command options used when invoking Bazel")
+    @Option(names = {"-co", "--bazelCommandOptions"}, description = "Additional space separated Bazel command options used when invoking Bazel", scope = ScopeType.INHERIT)
     String bazelCommandOptions;
 
     @Override

--- a/src/main/java/com/bazel-diff/main.java
+++ b/src/main/java/com/bazel-diff/main.java
@@ -80,13 +80,19 @@ class GenerateHashes implements Callable<Integer> {
     @Option(names = {"-m", "--modifiedFilepaths"}, description = "The path to a file containing the list of modified filepaths in the workspace, you can use the 'modified-filepaths' command to get this list")
     File modifiedFilepaths;
 
+    @Option(names = {"-so", "--bazelStartupOptions"}, description = "Additional Bazel client startup options used when invoking Bazel")
+    String bazelStartupOptions;
+
+    @Option(names = {"-co", "--bazelCommandOptions"}, description = "Additional Bazel command options used when invoking Bazel")
+    String bazelCommandOptions;
+
     @Parameters(index = "0", description = "The filepath to write the resulting JSON of dictionary target => SHA-256 values")
     File outputPath;
 
     @Override
     public Integer call() {
         GitClient gitClient = new GitClientImpl(parent.workspacePath);
-        BazelClient bazelClient = new BazelClientImpl(parent.workspacePath, parent.bazelPath);
+        BazelClient bazelClient = new BazelClientImpl(parent.workspacePath, parent.bazelPath, bazelStartupOptions, bazelCommandOptions);
         TargetHashingClient hashingClient = new TargetHashingClientImpl(bazelClient);
         try {
             gitClient.ensureAllChangesAreCommitted();
@@ -142,6 +148,13 @@ class BazelDiff implements Callable<Integer> {
     @Option(names = {"-t", "--tests"}, scope = ScopeType.LOCAL, description = "Return only targets of kind 'test')")
     boolean testTargets;
 
+    @Option(names = {"-so", "--bazelStartupOptions"}, description = "Additional space separated Bazel client startup options used when invoking Bazel")
+    String bazelStartupOptions;
+
+    @Option(names = {"-co", "--bazelCommandOptions"}, description = "Additional space separated Bazel command options used when invoking Bazel")
+    String bazelCommandOptions;
+
+    @Override
     public Integer call() throws IOException {
         if (startingHashesJSONPath == null || !startingHashesJSONPath.canRead()) {
             System.out.println("startingHashesJSONPath does not exist! Exiting");
@@ -152,7 +165,7 @@ class BazelDiff implements Callable<Integer> {
             return ExitCode.USAGE;
         }
         GitClient gitClient = new GitClientImpl(workspacePath);
-        BazelClient bazelClient = new BazelClientImpl(workspacePath, bazelPath);
+        BazelClient bazelClient = new BazelClientImpl(workspacePath, bazelPath, bazelStartupOptions, bazelCommandOptions);
         TargetHashingClient hashingClient = new TargetHashingClientImpl(bazelClient);
         try {
             gitClient.ensureAllChangesAreCommitted();


### PR DESCRIPTION
## What?
Adds options to forward additional bazel startup/command options to the bazel client

# Why?
You might have multiple Bazel invocation in your CI script and you want to use the same flags for all of them so that we can use the same Bazel server for the whole run