### PR TITLE
Add support for `avoid_query`

### DIFF
--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -5,11 +5,11 @@ bazel_path=$(which bazelisk)
 
 previous_revision="HEAD^"
 final_revision="HEAD"
+output_dir=$(mktemp -d)
 modified_filepaths_output="$PWD/integration/modified_filepaths.txt"
-starting_hashes_json="/tmp/starting_hashes.json"
-final_hashes_json="/tmp/final_hashes_json.json"
-impacted_targets_path="/tmp/impacted_targets.txt"
-impacted_test_targets_path="/tmp/impacted_test_targets.txt"
+starting_hashes_json="$output_dir/starting_hashes.json"
+final_hashes_json="$output_dir/final_hashes_json.json"
+impacted_targets_path="$output_dir/impacted_targets.txt"
 
 export USE_BAZEL_VERSION=last_downstream_green
 
@@ -26,31 +26,26 @@ $bazel_path run :bazel-diff -- generate-hashes -w $workspace_path -b $bazel_path
 
 ruby ./integration/update_final_hashes.rb
 
-$bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path
-
-$bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_test_targets_path -t
+$bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)"
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
 target1="//test/java/com/integration:bazel-diff-integration-test-lib"
 target2="//src/main/java/com/integration:bazel-diff-integration-lib"
 target3="//test/java/com/integration:bazel-diff-integration-tests"
+target4="//src/main/java/com/integration/submodule:Submodule"
 if containsElement $target1 "${impacted_targets[@]}" && \
     containsElement $target2 "${impacted_targets[@]}" && \
     containsElement $target3 "${impacted_targets[@]}"
 then
-    echo "Correct impacted targets"
+    if containsElement $target4 "${impacted_targets[@]}"
+    then
+        echo "Incorrect impacted targets: ${impacted_targets[@]}"
+        exit 1
+    else
+        echo "Correct impacted targets: ${impacted_targets[@]}"
+        exit 0
+    fi
 else
     echo "Incorrect impacted targets: ${impacted_targets[@]}"
-    exit 1
-fi
-
-IFS=$'\n' read -d '' -r -a impacted_test_targets < $impacted_test_targets_path
-target="//test/java/com/integration:bazel-diff-integration-tests"
-if containsElement $target "${impacted_test_targets[@]}";
-then
-    echo "Correct first impacted test target"
-else
-    echo "Impacted test targets: ${impacted_test_targets[@]}"
-    echo "Incorrect first impacted test target: ${target}"
     exit 1
 fi

--- a/integration/modified_filepaths.txt
+++ b/integration/modified_filepaths.txt
@@ -1,2 +1,3 @@
 README.md
 src/main/java/com/integration/StringGenerator.java
+src/main/java/com/integration/submodule/Submodule.java

--- a/integration/src/main/java/com/integration/submodule/BUILD
+++ b/integration/src/main/java/com/integration/submodule/BUILD
@@ -1,10 +1,10 @@
 load("@rules_java//java:defs.bzl", "java_library")
 
 java_library(
-    name = "bazel-diff-integration-lib",
+    name = "Submodule",
     srcs = glob(["*.java"]),
-    deps = [
-        "//src/main/java/com/integration/submodule:Submodule"
+    tags = [
+        "manual"
     ],
     visibility = ["//visibility:public"]
 )

--- a/integration/src/main/java/com/integration/submodule/Submodule.java
+++ b/integration/src/main/java/com/integration/submodule/Submodule.java
@@ -1,0 +1,3 @@
+public class Submodule {
+
+}

--- a/src/main/java/com/bazel_diff/VersionProvider.java
+++ b/src/main/java/com/bazel_diff/VersionProvider.java
@@ -5,7 +5,7 @@ import picocli.CommandLine.IVersionProvider;
 class VersionProvider implements IVersionProvider {
     public String[] getVersion() throws Exception {
         return new String[] {
-            "1.2.1"
+            "2.0.0"
         };
     }
 }

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -141,8 +141,8 @@ class BazelDiff implements Callable<Integer> {
     @Option(names = {"-o", "--output"}, scope = ScopeType.LOCAL, description = "Filepath to write the impacted Bazel targets to, newline separated")
     File outputPath;
 
-    @Option(names = {"-t", "--tests"}, scope = ScopeType.LOCAL, description = "Return only targets of kind 'test'")
-    boolean testTargets;
+    @Option(names = {"-aq", "--avoid-query"}, scope = ScopeType.LOCAL, description = "A Bazel query string, any targets that pass this query will be removed from the returned set of targets")
+    String avoidQuery;
 
     @Option(names = {"-so", "--bazelStartupOptions"}, description = "Additional space separated Bazel client startup options used when invoking Bazel", scope = ScopeType.INHERIT)
     String bazelStartupOptions;
@@ -190,12 +190,7 @@ class BazelDiff implements Callable<Integer> {
         Map<String, String > gsonHash = new HashMap<>();
         Map<String, String> startingHashes = gson.fromJson(startingFileReader, gsonHash.getClass());
         Map<String, String> finalHashes = gson.fromJson(finalFileReader, gsonHash.getClass());
-        Set<String> impactedTargets;
-        if (testTargets) {
-            impactedTargets = hashingClient.getImpactedTestTargets(startingHashes, finalHashes);
-        } else {
-            impactedTargets = hashingClient.getImpactedTargets(startingHashes, finalHashes);
-        }
+        Set<String> impactedTargets = hashingClient.getImpactedTargets(startingHashes, finalHashes, avoidQuery);
         try {
             FileWriter myWriter = new FileWriter(outputPath);
             myWriter.write(impactedTargets.stream().collect(Collectors.joining(System.lineSeparator())));

--- a/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -115,7 +115,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet())).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject())).thenReturn(
                 new HashSet<>(Arrays.asList("rule1", "rule3"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
@@ -126,7 +126,7 @@ public class TargetHashingClientImplTests {
         hash2.put("rule1", "differentrule1hash");
         hash2.put("rule2", "rule2hash");
         hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2);
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null);
         Set<String> expectedSet = new HashSet<>();
         expectedSet.add("rule1");
         expectedSet.add("rule3");
@@ -134,9 +134,9 @@ public class TargetHashingClientImplTests {
     }
 
     @Test
-    public void getImpactedTestTargets() throws IOException {
-        when(bazelClientMock.queryForTestTargets(anySet())).thenReturn(
-                new HashSet<>(Arrays.asList("rule1test", "rule3test", "someothertest"))
+    public void getImpactedTargets_withAvoidQuery() throws IOException {
+        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"))).thenReturn(
+                new HashSet<>(Arrays.asList("rule1"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
         Map<String, String> hash1 = new HashMap<>();
@@ -146,12 +146,10 @@ public class TargetHashingClientImplTests {
         hash2.put("rule1", "differentrule1hash");
         hash2.put("rule2", "rule2hash");
         hash2.put("rule3", "rule3hash");
-        Set <String> impactedTestTargets = client.getImpactedTestTargets(hash1, hash2);
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query");
         Set<String> expectedSet = new HashSet<>();
-        expectedSet.add("rule1test");
-        expectedSet.add("someothertest");
-        expectedSet.add("rule3test");
-        assertEquals(expectedSet, impactedTestTargets);
+        expectedSet.add("rule1");
+        assertEquals(expectedSet, impactedTargets);
     }
 
     private BazelTarget createRuleTarget(String ruleName, List<String> ruleInputs, String ruleDigest) throws NoSuchAlgorithmException {


### PR DESCRIPTION
Adds the ability for a user to avoid returning certain targets based on
a Bazel query. Any targets that pass this query will __not__ be included
in the final impacted set of targets

Closes #28