### PR TITLE
Enable debug logging

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
-run --show_loading_progress=false --show_progress=false --ui_event_filters='ERROR'
+run -c opt --show_loading_progress=false --show_progress=false --ui_event_filters='ERROR'
+run:verbose -c dbg --show_loading_progress=true --show_progress=true --ui_event_filters='INFO,ERROR,DEBUG'

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Open `bazel-diff-example.sh` to see how this is implemented. This is purely an e
 `bazel-diff` Command
 
 ```terminal
-Usage: bazel-diff [-htV] -b=<bazelPath> [-co=<bazelCommandOptions>]
-                  [-fh=<finalHashesJSONPath>] [-o=<outputPath>]
-                  [-sh=<startingHashesJSONPath>] [-so=<bazelStartupOptions>]
-                  -w=<workspacePath> [COMMAND]
+Usage: bazel-diff [-hV] [-aq=<avoidQuery>] -b=<bazelPath>
+                  [-co=<bazelCommandOptions>] [-fh=<finalHashesJSONPath>]
+                  [-o=<outputPath>] [-sh=<startingHashesJSONPath>]
+                  [-so=<bazelStartupOptions>] -w=<workspacePath> [COMMAND]
 Writes to a file the impacted targets between two Bazel graph JSON files
       -aq, --avoid-query=<avoidQuery>
                   A Bazel query string, any targets that pass this query will
@@ -164,6 +164,14 @@ To run the project
 
 ```terminal
 bazel run :bazel-diff -- bazel-diff -h
+```
+
+#### Debugging
+
+To run `bazel-diff` with debug logging, run your commands with the `verbose` config like so:
+
+```terminal
+bazel run :bazel-diff --config=verbose -- bazel-diff -h
 ```
 
 ### Run Via JAR Release

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -6,10 +6,11 @@ bazel_path=$(which bazelisk)
 previous_revision="HEAD^"
 final_revision="HEAD"
 output_dir="/tmp"
-modified_filepaths_output="$PWD/integration/modified_filepaths.txt"
+modified_filepaths_output="$workspace_path/modified_filepaths.txt"
 starting_hashes_json="$output_dir/starting_hashes.json"
 final_hashes_json="$output_dir/final_hashes_json.json"
 impacted_targets_path="$output_dir/impacted_targets.txt"
+shared_flags="--config=verbose"
 
 export USE_BAZEL_VERSION=last_downstream_green
 
@@ -20,13 +21,13 @@ containsElement () {
   return 1
 }
 
-$bazel_path run :bazel-diff -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
+$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
 
-$bazel_path run :bazel-diff -- generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json
+$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json
 
 ruby ./integration/update_final_hashes.rb
 
-$bazel_path run :bazel-diff -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)"
+$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)"
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
 target1="//test/java/com/integration:bazel-diff-integration-test-lib"

--- a/src/main/java/com/bazel_diff/BUILD
+++ b/src/main/java/com/bazel_diff/BUILD
@@ -1,11 +1,22 @@
 load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
+config_setting(
+    name = "enable_verbose",
+    values = {
+        "compilation_mode": "dbg",
+    },
+)
+
 java_binary(
     name = "bazel-diff",
     main_class = "com.bazel_diff.BazelDiff",
     runtime_deps = [":java-bazel-diff-lib"],
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    jvm_flags = select({
+        ":enable_verbose": ["-DVERBOSE=true"],
+        "//conditions:default": [],
+    }),
 )
 
 java_library(
@@ -18,6 +29,10 @@ java_library(
         "@bazel_diff_maven//:com_google_code_gson_gson",
         "@bazel_diff_maven//:com_google_guava_guava"
     ],
+    javacopts = select({
+        ":enable_verbose": ["-AVERBOSE=true"],
+        "//conditions:default": [],
+    }),
     visibility = ["//test/java/com/bazel_diff:__pkg__"]
 )
 

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -27,14 +27,16 @@ interface BazelClient {
 class BazelClientImpl implements BazelClient {
     private Path workingDirectory;
     private Path bazelPath;
+    private Boolean verbose;
     private List<String> startupOptions;
     private List<String> commandOptions;
 
-    BazelClientImpl(Path workingDirectory, Path bazelPath, String startupOptions, String commandOptions) {
+    BazelClientImpl(Path workingDirectory, Path bazelPath, String startupOptions, String commandOptions, Boolean verbose) {
         this.workingDirectory = workingDirectory.normalize();
         this.bazelPath = bazelPath;
         this.startupOptions = startupOptions != null ? Arrays.asList(startupOptions.split(" ")): new ArrayList<String>();
         this.commandOptions = commandOptions != null ? Arrays.asList(commandOptions.split(" ")): new ArrayList<String>();
+        this.verbose = verbose;
     }
 
     @Override
@@ -94,13 +96,15 @@ class BazelClientImpl implements BazelClient {
 
         List<String> cmd = new ArrayList<String>();
         cmd.add((bazelPath.toString()));
+        if (verbose) {
+            System.out.println(String.format("Executing Query: %s", query));
+            cmd.add("--bazelrc=/dev/null");
+        }
         cmd.addAll(this.startupOptions);
         cmd.add("query");
         cmd.add("--output");
         cmd.add("streamed_proto");
         cmd.add("--order_output=no");
-        cmd.add("--show_progress=false");
-        cmd.add("--show_loading_progress=false");
         cmd.add("--keep_going");
         cmd.addAll(this.commandOptions);
         cmd.add("--query_file");

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -88,7 +88,7 @@ class GenerateHashes implements Callable<Integer> {
     @Override
     public Integer call() {
         GitClient gitClient = new GitClientImpl(parent.workspacePath);
-        BazelClient bazelClient = new BazelClientImpl(parent.workspacePath, parent.bazelPath, parent.bazelStartupOptions, parent.bazelCommandOptions);
+        BazelClient bazelClient = new BazelClientImpl(parent.workspacePath, parent.bazelPath, parent.bazelStartupOptions, parent.bazelCommandOptions, BazelDiff.isVerbose());
         TargetHashingClient hashingClient = new TargetHashingClientImpl(bazelClient);
         try {
             gitClient.ensureAllChangesAreCommitted();
@@ -161,7 +161,7 @@ class BazelDiff implements Callable<Integer> {
             return ExitCode.USAGE;
         }
         GitClient gitClient = new GitClientImpl(workspacePath);
-        BazelClient bazelClient = new BazelClientImpl(workspacePath, bazelPath, bazelStartupOptions, bazelCommandOptions);
+        BazelClient bazelClient = new BazelClientImpl(workspacePath, bazelPath, bazelStartupOptions, bazelCommandOptions, BazelDiff.isVerbose());
         TargetHashingClient hashingClient = new TargetHashingClientImpl(bazelClient);
         try {
             gitClient.ensureAllChangesAreCommitted();
@@ -200,6 +200,11 @@ class BazelDiff implements Callable<Integer> {
             return ExitCode.SOFTWARE;
         }
         return ExitCode.OK;
+    }
+
+    static Boolean isVerbose() {
+        String verboseFlag = System.getProperty("VERBOSE", "false");
+        return verboseFlag.equals("true");
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Fixes #36

Allows users to specify the `--config=verbose` when running `bazel-diff` from source on the command line to enable logging.