### PR TITLE
Add single quotes to every query file line

### DIFF
--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -68,7 +68,7 @@ class BazelClientImpl implements BazelClient {
         for (List<Path> partition : Iterables.partition(filepaths, 100)) {
             String targetQuery = partition
                     .stream()
-                    .map(path -> path.toString())
+                    .map(path -> String.format("'%s'", path.toString()))
                     .collect(Collectors.joining(" + "));
             List<Build.Target> targets = performBazelQuery(targetQuery);
             for (Build.Target target : targets) {


### PR DESCRIPTION
I verified that this fixes #42 in case some filenames contain characters that aren't correctly parsed by Bazel.