### PR TITLE
Use --script_path to build bazel-diff only once

### DIFF
--- a/bazel-diff-example.sh
+++ b/bazel-diff-example.sh
@@ -14,13 +14,16 @@ starting_hashes_json="/tmp/starting_hashes.json"
 final_hashes_json="/tmp/final_hashes.json"
 impacted_targets_path="/tmp/impacted_targets.txt"
 impacted_test_targets_path="/tmp/impacted_test_targets.txt"
+bazel_diff="/tmp/bazel_diff"
 
 shared_flags=""
 
 # Uncomment the line below to see debug information
 # shared_flags="--config=verbose"
 
-$bazel_path run :bazel-diff $shared_flags -- modified-filepaths $previous_revision $final_revision -w $workspace_path -b $bazel_path $modified_filepaths_output
+$bazel_path run :bazel-diff $shared_flags --script_path="$bazel_diff"
+
+$bazel_diff modified-filepaths $previous_revision $final_revision -w $workspace_path -b $bazel_path $modified_filepaths_output
 
 IFS=$'\n' read -d '' -r -a modified_filepaths < $modified_filepaths_output
 formatted_filepaths=$(IFS=$'\n'; echo "${modified_filepaths[*]}")
@@ -31,18 +34,18 @@ echo ""
 git -C $workspace_path checkout $previous_revision --quiet
 
 echo "Generating Hashes for Revision '$previous_revision'"
-$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
+$bazel_diff generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
 
 git -C $workspace_path checkout - --quiet
 
 echo "Generating Hashes for Revision '$final_revision'"
-$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json
+$bazel_diff generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json
 
 echo "Determining Impacted Targets"
-$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path
+$bazel_diff -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path
 
 echo "Determining Impacted Test Targets"
-$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_test_targets_path --avoid-query "//... except tests(//...)"
+$bazel_diff -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_test_targets_path --avoid-query "//... except tests(//...)"
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
 formatted_impacted_targets=$(IFS=$'\n'; echo "${impacted_targets[*]}")


### PR DESCRIPTION
This PR proposes to change the example script to only invoke `bazel run` once instead of every time. It also fixes an issue where it wouldn't be possible to pass it a `bazel wrapper` instead of `bazelisk` directly due to some path redaction going on when executing things with `bazel run` directly. 