### PR TITLE
Check out final_revision explicitly in example script

### DIFF
--- a/bazel-diff-example.sh
+++ b/bazel-diff-example.sh
@@ -36,7 +36,7 @@ git -C $workspace_path checkout $previous_revision --quiet
 echo "Generating Hashes for Revision '$previous_revision'"
 $bazel_diff generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
 
-git -C $workspace_path checkout - --quiet
+git -C $workspace_path checkout $final_revision --quiet
 
 echo "Generating Hashes for Revision '$final_revision'"
 $bazel_diff generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json


### PR DESCRIPTION
I ran into an issue where `bazel-diff-example` was run with a final commit that wasn't `HEAD`, which cause the script to checkout `HEAD` instead of the specified final commit. I think it would be better to explicitly checkout `final_revision` to prevent issues with this and thinking that the tool doesn't work.