### PR TITLE
Add new `-a` flag to hash all source files

### DIFF
--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -11,6 +11,7 @@ starting_hashes_json="$output_dir/starting_hashes.json"
 final_hashes_json="$output_dir/final_hashes.json"
 impacted_targets_path="$output_dir/impacted_targets.txt"
 shared_flags="--config=verbose"
+command_options="--incompatible_restrict_string_escapes=false"
 
 export USE_BAZEL_VERSION=last_downstream_green
 
@@ -68,13 +69,13 @@ container_image(
 EOF
 }
 
-$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
+$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json -co $command_options
 
-$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json
+$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json -co $command_options
 
 awk '{gsub(/:StringGenerator.java": \"\w+\"/,"modifiedhash");print}' $final_hashes_json > /dev/null
 
-$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)"
+$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)" -co $command_options
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
 target1="//test/java/com/integration:bazel-diff-integration-test-lib"
@@ -104,15 +105,15 @@ docker_modified_filepaths_output=/tmp/docker_modified_filepaths_output.txt
 
 createDockerBuildfileContent wget
 
-$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
+$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json -co $command_options
 
 createDockerBuildfileContent curl
 
 echo "BUILD.bazel" >> $docker_modified_filepaths_output
 
-$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path -m $docker_modified_filepaths_output $final_hashes_json
+$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path -m $docker_modified_filepaths_output $final_hashes_json -co $command_options
 
-$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)"
+$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)" -co $command_options
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
 target1="//:base_packages"

--- a/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
+++ b/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
@@ -1,7 +1,12 @@
 package com.bazel_diff;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.io.IOException;
 
 interface BazelSourceFileTarget {
     String getName();
@@ -13,9 +18,22 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
     private String name;
     private byte[] digest;
 
-    BazelSourceFileTargetImpl(String name, byte[] digest) {
+    BazelSourceFileTargetImpl(String name, byte[] digest, Path workingDirectory) throws IOException {
         this.name = name;
-        this.digest = digest;
+        if (workingDirectory != null && name.startsWith("//")) {
+            String filenameSubstring = name.substring(2);
+            String filenamePath = filenameSubstring.replaceFirst(":", "/");
+            File sourceFile = new File(workingDirectory.toString(), filenamePath);
+            if (sourceFile.canRead()) {
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                outputStream.write(Files.readAllBytes(sourceFile.toPath()));
+                outputStream.write(digest);
+                this.digest = outputStream.toByteArray();
+                outputStream.close();
+            }
+        } else {
+            this.digest = digest;
+        }
     }
 
     @Override


### PR DESCRIPTION
Adds a new flag `-a` to the `generate-hashes` command to hash all source
files by reading all file sources. This flag is exclusive with the `-m`
flag, i.e. only one can be chosen at a time