### PR TITLE
Throw exception if Bazel query isn't successful

### DIFF
--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -8,9 +8,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 interface TargetHashingClient {
-    Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException;
-    Map<String, String> hashAllBazelTargetsAndSourcefiles() throws IOException, NoSuchAlgorithmException;
-    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes, String avoidQuery) throws IOException;
+    Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, BazelClientException, NoSuchAlgorithmException;
+    Map<String, String> hashAllBazelTargetsAndSourcefiles() throws IOException, BazelClientException, NoSuchAlgorithmException;
+    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes, String avoidQuery) throws IOException, BazelClientException;
 }
 
 class TargetHashingClientImpl implements TargetHashingClient {
@@ -21,13 +21,13 @@ class TargetHashingClientImpl implements TargetHashingClient {
     }
 
     @Override
-    public Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException {
+    public Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, BazelClientException, NoSuchAlgorithmException {
         Set<BazelSourceFileTarget> bazelSourcefileTargets = bazelClient.convertFilepathsToSourceTargets(modifiedFilepaths);
         return hashAllTargets(bazelSourcefileTargets);
     }
 
     @Override
-    public Map<String, String> hashAllBazelTargetsAndSourcefiles() throws IOException, NoSuchAlgorithmException {
+    public Map<String, String> hashAllBazelTargetsAndSourcefiles() throws IOException, BazelClientException, NoSuchAlgorithmException {
         Set<BazelSourceFileTarget> bazelSourcefileTargets = bazelClient.queryAllSourcefileTargets();
         return hashAllTargets(bazelSourcefileTargets);
     }
@@ -37,7 +37,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
         Map<String, String> startHashes,
         Map<String, String> endHashes,
         String avoidQuery)
-    throws IOException {
+    throws IOException, BazelClientException {
         Set<String> impactedTargets = new HashSet<>();
         for (Map.Entry<String,String> entry : endHashes.entrySet()) {
             String startHashValue = startHashes.get(entry.getKey());
@@ -134,7 +134,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
         return null;
     }
 
-    private Map<String, String> hashAllTargets(Set<BazelSourceFileTarget> bazelSourcefileTargets) throws IOException, NoSuchAlgorithmException {
+    private Map<String, String> hashAllTargets(Set<BazelSourceFileTarget> bazelSourcefileTargets) throws IOException, BazelClientException, NoSuchAlgorithmException {
         List<BazelTarget> allTargets = bazelClient.queryAllTargets();
         Map<String, String> targetHashes = new HashMap<>();
         Map<String, byte[]> ruleHashes = new HashMap<>();

--- a/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -31,21 +31,19 @@ public class TargetHashingClientImplTests {
     }
 
     @Test
-    public void hashAllBazelTargets_noTargets() throws IOException {
+    public void hashAllBazelTargets_noTargets() throws IOException, BazelClientException {
         when(bazelClientMock.queryAllTargets()).thenReturn(new ArrayList<>());
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
         try {
             Map<String, String> hash = client.hashAllBazelTargets(new HashSet<>());
             assertEquals(hash.size(), 0);
-        } catch (IOException e) {
-            assertTrue(false);
-        } catch (NoSuchAlgorithmException e) {
+        } catch (IOException | BazelClientException | NoSuchAlgorithmException e) {
             assertTrue(false);
         }
     }
 
     @Test
-    public void hashAllBazelTargets_ruleTargets() throws IOException {
+    public void hashAllBazelTargets_ruleTargets() throws IOException, BazelClientException {
         when(bazelClientMock.queryAllTargets()).thenReturn(defaultTargets);
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
         try {
@@ -59,7 +57,7 @@ public class TargetHashingClientImplTests {
     }
 
     @Test
-    public void hashAllBazelTargets_ruleTargets_ruleInputs() throws IOException, NoSuchAlgorithmException {
+    public void hashAllBazelTargets_ruleTargets_ruleInputs() throws IOException, BazelClientException, NoSuchAlgorithmException {
         List<String> ruleInputs = new ArrayList<>();
         ruleInputs.add("rule1");
         BazelTarget rule3 = createRuleTarget("rule3", ruleInputs, "digest");
@@ -81,7 +79,7 @@ public class TargetHashingClientImplTests {
     }
 
     @Test
-    public void hashAllBazelTargets_sourceTargets_unmodifiedSources() throws IOException {
+    public void hashAllBazelTargets_sourceTargets_unmodifiedSources() throws IOException, BazelClientException {
         defaultTargets.add(createSourceTarget("sourceFile1"));
         when(bazelClientMock.queryAllTargets()).thenReturn(defaultTargets);
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
@@ -97,7 +95,7 @@ public class TargetHashingClientImplTests {
     }
 
     @Test
-    public void hashAllBazelTargets_sourceTargets_modifiedSources() throws IOException, NoSuchAlgorithmException {
+    public void hashAllBazelTargets_sourceTargets_modifiedSources() throws IOException, BazelClientException, NoSuchAlgorithmException {
         createSourceTarget("sourceFile1");
         defaultTargets.add(createSourceTarget("sourceFile1"));
         Set<BazelSourceFileTarget> modifiedFileTargets = new HashSet<>();
@@ -117,7 +115,7 @@ public class TargetHashingClientImplTests {
     }
 
     @Test
-    public void getImpactedTargets() throws IOException {
+    public void getImpactedTargets() throws IOException, BazelClientException {
         when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject())).thenReturn(
                 new HashSet<>(Arrays.asList("rule1", "rule3"))
         );
@@ -137,7 +135,7 @@ public class TargetHashingClientImplTests {
     }
 
     @Test
-    public void getImpactedTargets_withAvoidQuery() throws IOException {
+    public void getImpactedTargets_withAvoidQuery() throws IOException, BazelClientException {
         when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"))).thenReturn(
                 new HashSet<>(Arrays.asList("rule1"))
         );


### PR DESCRIPTION
This is the second time I encountered an issue in Bazel queries that caused `bazel-diff` to fail silently, throwing me into multi-hour debugging sessions, so I decided to try and avoid this from happening to other people.

**The problem**: in cases Bazel queries fail, the `startingHashesJSON` and `finalHashesJSON` are created correctly, but the impacted targets will just be empty. This is probably not what we want, since `bazel-diff` will continue to produce empty changesets for all commits that fail the query. There are a bunch of reasons why Bazel queries could start to fail (we had three occasions so far). For example, a `select` statement that is in theory never reached (but still evaluated via `bazel query` which references a non-existing target, will cause the query to fail).

**Proposed solution**: my proposed solution is to throw an exception when a `bazel query` process exits with a status code different than 0. We then attach the stderr to the exception to be printed out to the console.

I tested this patch in our project and it allowed us to much more quickly address the described issue.
Let me know what you think.