### PR TITLE
Update readme to use 2.1.4 for "Integrate into your project"

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 http_jar(
     name = "bazel_diff",
     urls = [
-        "https://github.com/Tinder/bazel-diff/releases/download/2.1.2/bazel-diff_deploy.jar",
+        "https://github.com/Tinder/bazel-diff/releases/download/2.1.4/bazel-diff_deploy.jar",
     ],
-    sha256 = "a01d8e26dc0abfacd282f44a72434613d9799270bff406848e0ba8df7bae2081"
+    sha256 = "6c2a6e16db10db79837a74bfaa2a101461cd0330598fb1dc54778a86057eb131",
 )
 ```
 


### PR DESCRIPTION
Was upgrading to the latest version to see if https://github.com/Tinder/bazel-diff/issues/47 would solve an issue I was having, and noticed that target definition in the README still pointed to 2.1.2.

I wonder if it would be better to include the target definition with github releases for each version, rather than keeping only latest in the README?