### PR TITLE
Hash all targets null pointer

### DIFF
--- a/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
+++ b/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
@@ -44,7 +44,9 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
     @Override
     public byte[] getDigest() throws NoSuchAlgorithmException {
         MessageDigest finalDigest = MessageDigest.getInstance("SHA-256");
-        finalDigest.update(digest);
+        if (digest != null) {
+            finalDigest.update(digest);
+        }
         finalDigest.update(name.getBytes());
         return finalDigest.digest();
     }

--- a/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
+++ b/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
@@ -24,7 +24,7 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
             String filenameSubstring = name.substring(2);
             String filenamePath = filenameSubstring.replaceFirst(":", "/");
             File sourceFile = new File(workingDirectory.toString(), filenamePath);
-            if (sourceFile.canRead()) {
+            if (sourceFile.isFile() && sourceFile.canRead()) {
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                 outputStream.write(Files.readAllBytes(sourceFile.toPath()));
                 outputStream.write(digest);


### PR DESCRIPTION
Fixes 2 issues when using `-a` hash all targets mode.

1. Attempting to read a directory path
2. Attempting to read a null digest