### PR TITLE
Avoid rdeps when using hash all targets

### DIFF
--- a/bazel-diff-example.sh
+++ b/bazel-diff-example.sh
@@ -9,7 +9,6 @@ previous_revision=$3
 # Final Revision SHA
 final_revision=$4
 
-modified_filepaths_output="/tmp/modified_filepaths.txt"
 starting_hashes_json="/tmp/starting_hashes.json"
 final_hashes_json="/tmp/final_hashes.json"
 impacted_targets_path="/tmp/impacted_targets.txt"
@@ -23,29 +22,21 @@ shared_flags=""
 
 $bazel_path run :bazel-diff $shared_flags --script_path="$bazel_diff"
 
-$bazel_diff modified-filepaths $previous_revision $final_revision -w $workspace_path -b $bazel_path $modified_filepaths_output
-
-IFS=$'\n' read -d '' -r -a modified_filepaths < $modified_filepaths_output
-formatted_filepaths=$(IFS=$'\n'; echo "${modified_filepaths[*]}")
-echo "Modified Filepaths:"
-echo $formatted_filepaths
-echo ""
-
 git -C $workspace_path checkout $previous_revision --quiet
 
 echo "Generating Hashes for Revision '$previous_revision'"
-$bazel_diff generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
+$bazel_diff generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json -a
 
 git -C $workspace_path checkout $final_revision --quiet
 
 echo "Generating Hashes for Revision '$final_revision'"
-$bazel_diff generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json
+$bazel_diff generate-hashes -w $workspace_path -b $bazel_path $final_hashes_json -a
 
 echo "Determining Impacted Targets"
-$bazel_diff -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path
+$bazel_diff -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -a
 
 echo "Determining Impacted Test Targets"
-$bazel_diff -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_test_targets_path --avoid-query "//... except tests(//...)"
+$bazel_diff -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_test_targets_path -a --avoid-query "//... except tests(//...)"
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
 formatted_impacted_targets=$(IFS=$'\n'; echo "${impacted_targets[*]}")

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 
 interface BazelClient {
     List<BazelTarget> queryAllTargets() throws IOException;
-    Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery, Boolean hashAllTargets) throws IOException;
+    Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery) throws IOException;
     Set<BazelSourceFileTarget> convertFilepathsToSourceTargets(Set<Path> filepaths) throws IOException, NoSuchAlgorithmException;
     Set<BazelSourceFileTarget> queryAllSourcefileTargets() throws IOException, NoSuchAlgorithmException;
 }
@@ -47,17 +47,12 @@ class BazelClientImpl implements BazelClient {
     }
 
     @Override
-    public Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery, Boolean hashAllTargets) throws IOException {
+    public Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery) throws IOException {
         Set<String> impactedTargetNames = new HashSet<>();
         String targetQuery = impactedTargets.stream()
                                             .map(target -> String.format("'%s'", target))
                                             .collect(Collectors.joining(" + "));
-        String query = "";
-        if (hashAllTargets != null && hashAllTargets) {
-            query = targetQuery;
-        } else {
-            query = String.format("rdeps(//... except '//external:all-targets', %s)", targetQuery);
-        }
+        String query = query = String.format("rdeps(//... except '//external:all-targets', %s)", targetQuery);
         if (avoidQuery != null) {
             query = String.format("(%s) except (%s)", query, avoidQuery);
         }

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 
 interface BazelClient {
     List<BazelTarget> queryAllTargets() throws IOException;
-    Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery) throws IOException;
+    Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery, Boolean hashAllTargets) throws IOException;
     Set<BazelSourceFileTarget> convertFilepathsToSourceTargets(Set<Path> filepaths) throws IOException, NoSuchAlgorithmException;
     Set<BazelSourceFileTarget> queryAllSourcefileTargets() throws IOException, NoSuchAlgorithmException;
 }
@@ -47,12 +47,17 @@ class BazelClientImpl implements BazelClient {
     }
 
     @Override
-    public Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery) throws IOException {
+    public Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery, Boolean hashAllTargets) throws IOException {
         Set<String> impactedTargetNames = new HashSet<>();
         String targetQuery = impactedTargets.stream()
                                             .map(target -> String.format("'%s'", target))
                                             .collect(Collectors.joining(" + "));
-        String query = String.format("rdeps(//... except '//external:all-targets', %s)", targetQuery);
+        String query = "";
+        if (hashAllTargets) {
+            query = targetQuery;
+        } else {
+            query = String.format("rdeps(//... except '//external:all-targets', %s)", targetQuery);
+        }
         if (avoidQuery != null) {
             query = String.format("(%s) except (%s)", query, avoidQuery);
         }

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -53,7 +53,7 @@ class BazelClientImpl implements BazelClient {
                                             .map(target -> String.format("'%s'", target))
                                             .collect(Collectors.joining(" + "));
         String query = "";
-        if (hashAllTargets) {
+        if (hashAllTargets != null && hashAllTargets) {
             query = targetQuery;
         } else {
             query = String.format("rdeps(//... except '//external:all-targets', %s)", targetQuery);

--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 interface TargetHashingClient {
     Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths) throws IOException, NoSuchAlgorithmException;
     Map<String, String> hashAllBazelTargetsAndSourcefiles() throws IOException, NoSuchAlgorithmException;
-    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes, String avoidQuery) throws IOException;
+    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes, String avoidQuery, Boolean hashAllTargets) throws IOException;
 }
 
 class TargetHashingClientImpl implements TargetHashingClient {
@@ -36,7 +36,8 @@ class TargetHashingClientImpl implements TargetHashingClient {
     public Set<String> getImpactedTargets(
         Map<String, String> startHashes,
         Map<String, String> endHashes,
-        String avoidQuery)
+        String avoidQuery,
+        Boolean hashAllTargets)
     throws IOException {
         Set<String> impactedTargets = new HashSet<>();
         for (Map.Entry<String,String> entry : endHashes.entrySet()) {
@@ -45,7 +46,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
                 impactedTargets.add(entry.getKey());
             }
         }
-        return bazelClient.queryForImpactedTargets(impactedTargets, avoidQuery);
+        return bazelClient.queryForImpactedTargets(impactedTargets, avoidQuery, hashAllTargets);
     }
 
     private byte[] createDigestForTarget(

--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -46,7 +46,10 @@ class TargetHashingClientImpl implements TargetHashingClient {
                 impactedTargets.add(entry.getKey());
             }
         }
-        return bazelClient.queryForImpactedTargets(impactedTargets, avoidQuery, hashAllTargets);
+        if (hashAllTargets != null && hashAllTargets && avoidQuery == null) {
+            return impactedTargets;
+        }
+        return bazelClient.queryForImpactedTargets(impactedTargets, avoidQuery);
     }
 
     private byte[] createDigestForTarget(

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -158,6 +158,9 @@ class BazelDiff implements Callable<Integer> {
     @Option(names = {"-o", "--output"}, scope = ScopeType.LOCAL, description = "Filepath to write the impacted Bazel targets to, newline separated")
     File outputPath;
 
+    @Option(names = {"-a", "--all-sourcefiles"}, description = "Experimental: Hash all sourcefile targets (instead of relying on --modifiedFilepaths), Warning: Performance may degrade from reading all source files")
+    Boolean hashAllSourcefiles;
+
     @Option(names = {"-aq", "--avoid-query"}, scope = ScopeType.LOCAL, description = "A Bazel query string, any targets that pass this query will be removed from the returned set of targets")
     String avoidQuery;
 
@@ -207,7 +210,7 @@ class BazelDiff implements Callable<Integer> {
         Map<String, String > gsonHash = new HashMap<>();
         Map<String, String> startingHashes = gson.fromJson(startingFileReader, gsonHash.getClass());
         Map<String, String> finalHashes = gson.fromJson(finalFileReader, gsonHash.getClass());
-        Set<String> impactedTargets = hashingClient.getImpactedTargets(startingHashes, finalHashes, avoidQuery);
+        Set<String> impactedTargets = hashingClient.getImpactedTargets(startingHashes, finalHashes, avoidQuery, hashAllSourcefiles);
         try {
             FileWriter myWriter = new FileWriter(outputPath);
             myWriter.write(impactedTargets.stream().collect(Collectors.joining(System.lineSeparator())));

--- a/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -118,7 +118,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject())).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject(), Matchers.eq(false))).thenReturn(
                 new HashSet<>(Arrays.asList("rule1", "rule3"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
@@ -129,7 +129,7 @@ public class TargetHashingClientImplTests {
         hash2.put("rule1", "differentrule1hash");
         hash2.put("rule2", "rule2hash");
         hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null);
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null, false);
         Set<String> expectedSet = new HashSet<>();
         expectedSet.add("rule1");
         expectedSet.add("rule3");
@@ -138,7 +138,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets_withAvoidQuery() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"))).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"), Matchers.eq(false))).thenReturn(
                 new HashSet<>(Arrays.asList("rule1"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
@@ -149,7 +149,45 @@ public class TargetHashingClientImplTests {
         hash2.put("rule1", "differentrule1hash");
         hash2.put("rule2", "rule2hash");
         hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query");
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query", false);
+        Set<String> expectedSet = new HashSet<>();
+        expectedSet.add("rule1");
+        assertEquals(expectedSet, impactedTargets);
+    }
+
+    @Test
+    public void getImpactedTargets_withHashAllTargets() throws IOException {
+        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject(), Matchers.eq(true))).thenReturn(
+                new HashSet<>(Arrays.asList("rule1"))
+        );
+        TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
+        Map<String, String> hash1 = new HashMap<>();
+        hash1.put("rule1", "rule1hash");
+        hash1.put("rule2", "rule2hash");
+        Map<String, String> hash2 = new HashMap<>();
+        hash2.put("rule1", "differentrule1hash");
+        hash2.put("rule2", "rule2hash");
+        hash2.put("rule3", "rule3hash");
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null, true);
+        Set<String> expectedSet = new HashSet<>();
+        expectedSet.add("rule1");
+        assertEquals(expectedSet, impactedTargets);
+    }
+
+    @Test
+    public void getImpactedTargets_withHashAllTargets_withAvoidQuery() throws IOException {
+        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"), Matchers.eq(true))).thenReturn(
+                new HashSet<>(Arrays.asList("rule1"))
+        );
+        TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
+        Map<String, String> hash1 = new HashMap<>();
+        hash1.put("rule1", "rule1hash");
+        hash1.put("rule2", "rule2hash");
+        Map<String, String> hash2 = new HashMap<>();
+        hash2.put("rule1", "differentrule1hash");
+        hash2.put("rule2", "rule2hash");
+        hash2.put("rule3", "rule3hash");
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query", true);
         Set<String> expectedSet = new HashSet<>();
         expectedSet.add("rule1");
         assertEquals(expectedSet, impactedTargets);

--- a/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -118,7 +118,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject(), Matchers.eq(false))).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject())).thenReturn(
                 new HashSet<>(Arrays.asList("rule1", "rule3"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
@@ -138,7 +138,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets_withAvoidQuery() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"), Matchers.eq(false))).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"))).thenReturn(
                 new HashSet<>(Arrays.asList("rule1"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
@@ -157,7 +157,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets_withHashAllTargets() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject(), Matchers.eq(true))).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject())).thenReturn(
                 new HashSet<>(Arrays.asList("rule1"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);
@@ -171,12 +171,13 @@ public class TargetHashingClientImplTests {
         Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null, true);
         Set<String> expectedSet = new HashSet<>();
         expectedSet.add("rule1");
+        expectedSet.add("rule3");
         assertEquals(expectedSet, impactedTargets);
     }
 
     @Test
     public void getImpactedTargets_withHashAllTargets_withAvoidQuery() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"), Matchers.eq(true))).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"))).thenReturn(
                 new HashSet<>(Arrays.asList("rule1"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock);


### PR DESCRIPTION
When using hash all targets it is overkill to use rdeps to query the
impacted targets, since we know at the end of hashing what was
affected.