### PR TITLE
Seed Hashfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,31 +134,39 @@ Writes to the file the modified filepaths between two revisions.
 `generate-hashes` Command
 
 ```terminal
-Usage: bazel-diff generate-hashes [-hV] -b=<bazelPath>
-                                  [-co=<bazelCommandOptions>]
-                                  [-m=<modifiedFilepaths>]
+Usage: bazel-diff generate-hashes [-m=<modifiedFilepaths> | -a] [-hV]
+                                  -b=<bazelPath> [-co=<bazelCommandOptions>]
+                                  [-s=<seedFilepaths>]
                                   [-so=<bazelStartupOptions>]
                                   -w=<workspacePath> <outputPath>
 Writes to a file the SHA256 hashes for each Bazel Target in the provided
 workspace.
-      <outputPath>   The filepath to write the resulting JSON of dictionary
-                       target => SHA-256 values
+      <outputPath>        The filepath to write the resulting JSON of
+                            dictionary target => SHA-256 values
+  -a, --all-sourcefiles   Experimental: Hash all sourcefile targets (instead of
+                            relying on --modifiedFilepaths), Warning:
+                            Performance may degrade from reading all source
+                            files
   -b, --bazelPath=<bazelPath>
-                     Path to Bazel binary
+                          Path to Bazel binary
       -co, --bazelCommandOptions=<bazelCommandOptions>
-                     Additional space separated Bazel command options used when
-                       invoking Bazel
-  -h, --help         Show this help message and exit.
+                          Additional space separated Bazel command options used
+                            when invoking Bazel
+  -h, --help              Show this help message and exit.
   -m, --modifiedFilepaths=<modifiedFilepaths>
-                     The path to a file containing the list of modified
-                       filepaths in the workspace, you can use the
-                       'modified-filepaths' command to get this list
+                          The path to a file containing the list of modified
+                            filepaths in the workspace, you can use the
+                            'modified-filepaths' command to get this list
+  -s, --seed-filepaths=<seedFilepaths>
+                          A text file containing a newline separated list of
+                            filepaths, each of these filepaths will be read and
+                            used as a seed for all targets.
       -so, --bazelStartupOptions=<bazelStartupOptions>
-                     Additional space separated Bazel client startup options
-                       used when invoking Bazel
-  -V, --version      Print version information and exit.
+                          Additional space separated Bazel client startup
+                            options used when invoking Bazel
+  -V, --version           Print version information and exit.
   -w, --workspacePath=<workspacePath>
-                     Path to Bazel workspace directory.
+                          Path to Bazel workspace directory.
 ```
 
 ## Installing

--- a/src/main/java/com/bazel_diff/Files.java
+++ b/src/main/java/com/bazel_diff/Files.java
@@ -1,0 +1,21 @@
+package com.bazel_diff;
+
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.io.IOException;
+
+interface FilesClient {
+    byte[] readFile(Path path) throws IOException;
+}
+
+class FilesClientImp implements FilesClient {
+    FilesClientImp() {}
+
+    @Override
+    public byte[] readFile(Path path) throws IOException {
+        if (path.toFile().exists() && path.toFile().canRead()) {
+            return Files.readAllBytes(path);
+        }
+        return new byte[0];
+    }
+}

--- a/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -66,7 +66,7 @@ public class TargetHashingClientImplTests {
     @Test
     public void hashAllBazelTargets_ruleTargets_seedFilepaths() throws IOException {
         Set<Path> seedFilepaths = new HashSet<>();
-        seedFilepaths.add(Path.of("somefile.txt"));
+        seedFilepaths.add(Paths.get("somefile.txt"));
         when(filesClientMock.readFile(anyObject())).thenReturn("somecontent".getBytes());
         when(bazelClientMock.queryAllTargets()).thenReturn(defaultTargets);
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
@@ -141,7 +141,7 @@ public class TargetHashingClientImplTests {
     @Test
     public void hashAllBazelTargets_sourceTargets_modifiedSources_seedFilepaths() throws IOException, NoSuchAlgorithmException {
         Set<Path> seedFilepaths = new HashSet<>();
-        seedFilepaths.add(Path.of("somefile.txt"));
+        seedFilepaths.add(Paths.get("somefile.txt"));
         when(filesClientMock.readFile(anyObject())).thenReturn("somecontent".getBytes());
         createSourceTarget("sourceFile1");
         defaultTargets.add(createSourceTarget("sourceFile1"));


### PR DESCRIPTION
Allows users to specify a file containing a list of newline
separated file paths, this file will be read and the SHA256 value
for the content of each file will be used as the seed for all targets

Fixes #58