### PR TITLE
Support Universe Query in Bazel-Diff command

### DIFF
--- a/integration/WORKSPACE
+++ b/integration/WORKSPACE
@@ -19,32 +19,3 @@ maven_install(
         "https://jcenter.bintray.com/",
     ]
 )
-
-http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "1698624e878b0607052ae6131aa216d45ebb63871ec497f26c67455b34119c80",
-    strip_prefix = "rules_docker-0.15.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.15.0/rules_docker-v0.15.0.tar.gz"],
-)
-
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
-)
-container_repositories()
-
-load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
-
-container_deps()
-
-load(
-    "@io_bazel_rules_docker//container:container.bzl",
-    "container_pull",
-)
-
-container_pull(
-    name = "openjdk_11_slim",
-    digest = "sha256:28b59dc9a129c75349418e3b75508fd8eef3b33dd7d796079d1d19445d907776",
-    registry = "index.docker.io",
-    repository = "library/openjdk",
-)

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -12,7 +12,7 @@ final_hashes_json="$output_dir/final_hashes.json"
 impacted_targets_path="$output_dir/impacted_targets.txt"
 shared_flags=""
 
-export USE_BAZEL_VERSION=4.0.0
+export USE_BAZEL_VERSION=last_downstream_green
 
 containsElement () {
   local e match="$1"

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -10,10 +10,9 @@ modified_filepaths_output="$workspace_path/modified_filepaths.txt"
 starting_hashes_json="$output_dir/starting_hashes.json"
 final_hashes_json="$output_dir/final_hashes.json"
 impacted_targets_path="$output_dir/impacted_targets.txt"
-shared_flags="--config=verbose"
-command_options="--incompatible_restrict_string_escapes=false"
+shared_flags=""
 
-export USE_BAZEL_VERSION=last_downstream_green
+export USE_BAZEL_VERSION=4.0.0
 
 containsElement () {
   local e match="$1"
@@ -22,13 +21,13 @@ containsElement () {
   return 1
 }
 
-$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json -co $command_options
+$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
 
-$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json -co $command_options
+$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json
 
 awk '{gsub(/:StringGenerator.java": \"\w+\"/,"modifiedhash");print}' $final_hashes_json > /dev/null
 
-$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)" -co $command_options
+$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)"
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
 target1="//test/java/com/integration:bazel-diff-integration-test-lib"

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 
 interface BazelClient {
     List<BazelTarget> queryAllTargets() throws IOException;
-    Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery) throws IOException;
+    Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery, String universeQuery) throws IOException;
     Set<BazelSourceFileTarget> convertFilepathsToSourceTargets(Set<Path> filepaths) throws IOException, NoSuchAlgorithmException;
     Set<BazelSourceFileTarget> queryAllSourcefileTargets() throws IOException, NoSuchAlgorithmException;
 }
@@ -47,12 +47,12 @@ class BazelClientImpl implements BazelClient {
     }
 
     @Override
-    public Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery) throws IOException {
+    public Set<String> queryForImpactedTargets(Set<String> impactedTargets, String avoidQuery, String universeQuery) throws IOException {
         Set<String> impactedTargetNames = new HashSet<>();
         String targetQuery = impactedTargets.stream()
                                             .map(target -> String.format("'%s'", target))
                                             .collect(Collectors.joining(" + "));
-        String query = query = String.format("rdeps(//... except '//external:all-targets', %s)", targetQuery);
+        String query = query = String.format("rdeps(%s except '//external:all-targets', %s)", universeQuery, targetQuery);
         if (avoidQuery != null) {
             query = String.format("(%s) except (%s)", query, avoidQuery);
         }

--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -12,7 +12,7 @@ import com.google.common.primitives.Bytes;
 interface TargetHashingClient {
     Map<String, String> hashAllBazelTargets(Set<Path> modifiedFilepaths, Set<Path> seedFilepaths) throws IOException, NoSuchAlgorithmException;
     Map<String, String> hashAllBazelTargetsAndSourcefiles(Set<Path> seedFilepaths) throws IOException, NoSuchAlgorithmException;
-    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes, String avoidQuery, Boolean hashAllTargets) throws IOException;
+    Set<String> getImpactedTargets(Map<String, String> startHashes, Map<String, String> endHashes, String avoidQuery, String universeQuery, Boolean hashAllTargets) throws IOException;
 }
 
 class TargetHashingClientImpl implements TargetHashingClient {
@@ -41,6 +41,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
         Map<String, String> startHashes,
         Map<String, String> endHashes,
         String avoidQuery,
+        String universeQuery,
         Boolean hashAllTargets)
     throws IOException {
         Set<String> impactedTargets = new HashSet<>();
@@ -53,7 +54,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
         if (hashAllTargets != null && hashAllTargets && avoidQuery == null) {
             return impactedTargets;
         }
-        return bazelClient.queryForImpactedTargets(impactedTargets, avoidQuery);
+        return bazelClient.queryForImpactedTargets(impactedTargets, avoidQuery, universeQuery);
     }
 
     private byte[] createDigestForTarget(

--- a/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -163,7 +163,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject())).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject(), anyObject())).thenReturn(
                 new HashSet<>(Arrays.asList("rule1", "rule3"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
@@ -174,7 +174,7 @@ public class TargetHashingClientImplTests {
         hash2.put("rule1", "differentrule1hash");
         hash2.put("rule2", "rule2hash");
         hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null, false);
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null, null, false);
         Set<String> expectedSet = new HashSet<>();
         expectedSet.add("rule1");
         expectedSet.add("rule3");
@@ -183,7 +183,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets_withAvoidQuery() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"))).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"), eq("universe_query"))).thenReturn(
                 new HashSet<>(Arrays.asList("rule1"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
@@ -194,7 +194,7 @@ public class TargetHashingClientImplTests {
         hash2.put("rule1", "differentrule1hash");
         hash2.put("rule2", "rule2hash");
         hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query", false);
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query", "universe_query", false);
         Set<String> expectedSet = new HashSet<>();
         expectedSet.add("rule1");
         assertEquals(expectedSet, impactedTargets);
@@ -202,7 +202,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets_withHashAllTargets() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject())).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject(), anyObject())).thenReturn(
                 new HashSet<>(Arrays.asList("rule1"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
@@ -213,7 +213,7 @@ public class TargetHashingClientImplTests {
         hash2.put("rule1", "differentrule1hash");
         hash2.put("rule2", "rule2hash");
         hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null, true);
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null, null, true);
         Set<String> expectedSet = new HashSet<>();
         expectedSet.add("rule1");
         expectedSet.add("rule3");
@@ -222,7 +222,7 @@ public class TargetHashingClientImplTests {
 
     @Test
     public void getImpactedTargets_withHashAllTargets_withAvoidQuery() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"))).thenReturn(
+        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"), anyObject())).thenReturn(
                 new HashSet<>(Arrays.asList("rule1"))
         );
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
@@ -233,7 +233,7 @@ public class TargetHashingClientImplTests {
         hash2.put("rule1", "differentrule1hash");
         hash2.put("rule2", "rule2hash");
         hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query", true);
+        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query", null, true);
         Set<String> expectedSet = new HashSet<>();
         expectedSet.add("rule1");
         assertEquals(expectedSet, impactedTargets);


### PR DESCRIPTION
Allows users to specify a universe query when running the bazel-diff
command. This universe query is used when we execute an rdeps query.
This flag is ignored when using the
hash all filepaths option