### PR TITLE
Remove modified filepaths and avoid query options

### DIFF
--- a/bazel-diff-example.sh
+++ b/bazel-diff-example.sh
@@ -25,27 +25,18 @@ $bazel_path run :bazel-diff $shared_flags --script_path="$bazel_diff"
 git -C $workspace_path checkout $previous_revision --quiet
 
 echo "Generating Hashes for Revision '$previous_revision'"
-$bazel_diff generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json -a
+$bazel_diff generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
 
 git -C $workspace_path checkout $final_revision --quiet
 
 echo "Generating Hashes for Revision '$final_revision'"
-$bazel_diff generate-hashes -w $workspace_path -b $bazel_path $final_hashes_json -a
+$bazel_diff generate-hashes -w $workspace_path -b $bazel_path $final_hashes_json
 
 echo "Determining Impacted Targets"
-$bazel_diff -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -a
-
-echo "Determining Impacted Test Targets"
-$bazel_diff -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_test_targets_path -a --avoid-query "//... except tests(//...)"
+$bazel_diff -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
 formatted_impacted_targets=$(IFS=$'\n'; echo "${impacted_targets[*]}")
 echo "Impacted Targets between $previous_revision and $final_revision:"
 echo $formatted_impacted_targets
-echo ""
-
-IFS=$'\n' read -d '' -r -a impacted_test_targets < $impacted_test_targets_path
-formatted_impacted_test_targets=$(IFS=$'\n'; echo "${impacted_test_targets[*]}")
-echo "Impacted Test Targets between $previous_revision and $final_revision:"
-echo $formatted_impacted_test_targets
 echo ""

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -12,7 +12,7 @@ final_hashes_json="$output_dir/final_hashes.json"
 impacted_targets_path="$output_dir/impacted_targets.txt"
 shared_flags=""
 
-export USE_BAZEL_VERSION=last_downstream_green
+export USE_BAZEL_VERSION=4.1.0
 
 containsElement () {
   local e match="$1"
@@ -23,28 +23,19 @@ containsElement () {
 
 $bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path $starting_hashes_json
 
-$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path -m $modified_filepaths_output $final_hashes_json
+$bazel_path run :bazel-diff $shared_flags -- generate-hashes -w $workspace_path -b $bazel_path $final_hashes_json
 
-awk '{gsub(/:StringGenerator.java": \"\w+\"/,"modifiedhash");print}' $final_hashes_json > /dev/null
+final_tmp=$(mktemp)
+awk '{gsub(/32c874ad651f0dd234d712b7f1dce6b54aa36cf16380da763a8eb7bb7c1f9514/,"modifiedhash");print}' $final_hashes_json > $final_tmp
+cp $final_tmp $final_hashes_json
 
-$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path -aq "attr('tags', 'manual', //...)"
+$bazel_path run :bazel-diff $shared_flags -- -sh $starting_hashes_json -fh $final_hashes_json -w $workspace_path -b $bazel_path -o $impacted_targets_path
 
 IFS=$'\n' read -d '' -r -a impacted_targets < $impacted_targets_path
-target1="//test/java/com/integration:bazel-diff-integration-test-lib"
-target2="//src/main/java/com/integration:bazel-diff-integration-lib"
-target3="//test/java/com/integration:bazel-diff-integration-tests"
-target4="//src/main/java/com/integration/submodule:Submodule"
-if containsElement $target1 "${impacted_targets[@]}" && \
-    containsElement $target2 "${impacted_targets[@]}" && \
-    containsElement $target3 "${impacted_targets[@]}"
+target1="//src/main/java/com/integration:StringGenerator.java"
+if containsElement $target1 "${impacted_targets[@]}"
 then
-    if containsElement $target4 "${impacted_targets[@]}"
-    then
-        echo "FAILURE Incorrect impacted targets: ${impacted_targets[@]}"
-        exit 1
-    else
-        echo "SUCCESS: Correct impacted targets: ${impacted_targets[@]}"
-    fi
+    echo "SUCCESS: Correct impacted targets: ${impacted_targets[@]}"
 else
     echo "FAILURE: Incorrect impacted targets: ${impacted_targets[@]}"
     exit 1

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -18,57 +18,6 @@ import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import static picocli.CommandLine.*;
-@Command(
-        name = "modified-filepaths",
-        mixinStandardHelpOptions = true,
-        description = "Writes to the file the modified filepaths between two revisions.",
-        versionProvider = VersionProvider.class
-)
-class FetchModifiedFilepaths implements Callable<Integer> {
-
-    @Parameters(index = "0", description = "The starting Git revision, e.g. \"HEAD^\"")
-    String startingGitRevision;
-
-    @Parameters(index = "1", description = "The final Git revision, e.g. \"HEAD\"")
-    String endingGitRevision;
-
-    @Parameters(index = "2", description = "Path that the list of modified files will be written to")
-    File outputPath;
-
-    @ParentCommand
-    private BazelDiff parent;
-
-    @Override
-    public Integer call() {
-        GitClient gitClient = new GitClientImpl(parent.workspacePath);
-        try {
-            gitClient.ensureAllChangesAreCommitted();
-        } catch (IOException | InterruptedException e) {
-            e.printStackTrace();
-            return ExitCode.SOFTWARE;
-        } catch (GitClientException e) {
-            System.out.println(String.format("There are active changes in '%s', please commit these changes before running modified-filepaths", parent.workspacePath));
-            return ExitCode.USAGE;
-        }
-        try {
-            Set<String> modifiedFilepaths = gitClient
-                    .getModifiedFilepaths(startingGitRevision, endingGitRevision)
-                    .stream()
-                    .map(Path::toString)
-                    .collect(Collectors.toSet());
-            FileWriter myWriter = new FileWriter(outputPath);
-            for (String line : modifiedFilepaths) {
-                myWriter.write(line);
-                myWriter.write(System.lineSeparator());
-            }
-            myWriter.close();
-            return ExitCode.OK;
-        } catch (IOException | InterruptedException e) {
-            e.printStackTrace();
-            return ExitCode.SOFTWARE;
-        }
-    }
-}
 
 @Command(
         name = "generate-hashes",
@@ -81,17 +30,6 @@ class GenerateHashes implements Callable<Integer> {
     @ParentCommand
     private BazelDiff parent;
 
-    @ArgGroup(exclusive = true)
-    Exclusive exclusive;
-
-    static class Exclusive {
-        @Option(names = {"-m", "--modifiedFilepaths"}, description = "The path to a file containing the list of modified filepaths in the workspace, you can use the 'modified-filepaths' command to get this list")
-        File modifiedFilepaths;
-
-        @Option(names = {"-a", "--all-sourcefiles"}, description = "Experimental: Hash all sourcefile targets (instead of relying on --modifiedFilepaths), Warning: Performance may degrade from reading all source files")
-        Boolean hashAllSourcefiles;
-    }
-
     @Option(names = {"-s", "--seed-filepaths"}, description = "A text file containing a newline separated list of filepaths, each of these filepaths will be read and used as a seed for all targets.")
     File seedFilepaths;
 
@@ -100,12 +38,9 @@ class GenerateHashes implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        GitClient gitClient = new GitClientImpl(parent.workspacePath);
         BazelClient bazelClient = new BazelClientImpl(parent.workspacePath, parent.bazelPath, parent.bazelStartupOptions, parent.bazelCommandOptions, BazelDiff.isVerbose());
         TargetHashingClient hashingClient = new TargetHashingClientImpl(bazelClient, new FilesClientImp());
         try {
-            gitClient.ensureAllChangesAreCommitted();
-            Set<Path> modifiedFilepathsSet = new HashSet<>();
             Set<Path> seedFilepathsSet = new HashSet<>();
             if (seedFilepaths != null) {
                 FileReader fileReader = new FileReader(seedFilepaths);
@@ -114,31 +49,13 @@ class GenerateHashes implements Callable<Integer> {
                                                 .map( line -> new File(line).toPath())
                                                 .collect(Collectors.toSet());
             }
-            Map<String, String> hashes = new HashMap<>();
-            if (exclusive != null) {
-                if (exclusive.modifiedFilepaths != null) {
-                    FileReader fileReader = new FileReader(exclusive.modifiedFilepaths);
-                    BufferedReader bufferedReader = new BufferedReader(fileReader);
-                    modifiedFilepathsSet = bufferedReader
-                            .lines()
-                            .map( line -> new File(line).toPath())
-                            .collect(Collectors.toSet());
-                    hashes = hashingClient.hashAllBazelTargets(modifiedFilepathsSet, seedFilepathsSet);
-                } else if (exclusive.hashAllSourcefiles) {
-                    hashes = hashingClient.hashAllBazelTargetsAndSourcefiles(seedFilepathsSet);
-                }
-            } else {
-                hashes = hashingClient.hashAllBazelTargets(modifiedFilepathsSet, seedFilepathsSet);
-            }
+            Map<String, String> hashes = hashingClient.hashAllBazelTargetsAndSourcefiles(seedFilepathsSet);
             Gson gson = new GsonBuilder().setPrettyPrinting().create();
             FileWriter myWriter = new FileWriter(outputPath);
             myWriter.write(gson.toJson(hashes));
             myWriter.close();
             return ExitCode.OK;
-        } catch (GitClientException e) {
-            System.out.println(String.format("There are active changes in '%s', please commit these changes before running generate-hashes", parent.workspacePath));
-            return ExitCode.USAGE;
-        } catch (IOException | InterruptedException | NoSuchAlgorithmException e) {
+        } catch (IOException | NoSuchAlgorithmException e) {
             e.printStackTrace();
             return ExitCode.SOFTWARE;
         }
@@ -148,20 +65,11 @@ class GenerateHashes implements Callable<Integer> {
 @Command(
         name = "bazel-diff",
         description = "Writes to a file the impacted targets between two Bazel graph JSON files",
-        subcommands = { GenerateHashes.class, FetchModifiedFilepaths.class },
+        subcommands = { GenerateHashes.class },
         mixinStandardHelpOptions = true,
         versionProvider = VersionProvider.class
 )
 class BazelDiff implements Callable<Integer> {
-    @ArgGroup(exclusive = true)
-    Exclusive exclusive;
-    static class Exclusive {
-        @Option(names = {"-a", "--all-sourcefiles"}, description = "Experimental: Hash all sourcefile targets (instead of relying on --modifiedFilepaths), Warning: Performance may degrade from reading all source files")
-        Boolean hashAllSourcefiles;
-
-        @Option(names = {"-u", "--universeQuery"}, description = "The universe query to use when executing `rdeps()` queries, use this to limit the search scope of impacted targets i.e. ignore external targets and such")
-        String universeRdepsQuery;
-    }
 
     @Option(names = {"-w", "--workspacePath"}, description = "Path to Bazel workspace directory.", scope = ScopeType.INHERIT, required = true)
     Path workspacePath;
@@ -177,9 +85,6 @@ class BazelDiff implements Callable<Integer> {
 
     @Option(names = {"-o", "--output"}, scope = ScopeType.LOCAL, description = "Filepath to write the impacted Bazel targets to, newline separated")
     File outputPath;
-
-    @Option(names = {"-aq", "--avoid-query"}, scope = ScopeType.LOCAL, description = "A Bazel query string, any targets that pass this query will be removed from the returned set of targets")
-    String avoidQuery;
 
     @Option(names = {"-so", "--bazelStartupOptions"}, description = "Additional space separated Bazel client startup options used when invoking Bazel", scope = ScopeType.INHERIT)
     String bazelStartupOptions;
@@ -227,16 +132,7 @@ class BazelDiff implements Callable<Integer> {
         Map<String, String > gsonHash = new HashMap<>();
         Map<String, String> startingHashes = gson.fromJson(startingFileReader, gsonHash.getClass());
         Map<String, String> finalHashes = gson.fromJson(finalFileReader, gsonHash.getClass());
-        Boolean shouldHashAllSourceFiles = false;
-        String universeQuery = "//...";
-        if (exclusive != null) {
-            if (exclusive.hashAllSourcefiles != null) {
-                shouldHashAllSourceFiles = exclusive.hashAllSourcefiles;
-            } else {
-                universeQuery = exclusive.universeRdepsQuery;
-            }
-        }
-        Set<String> impactedTargets = hashingClient.getImpactedTargets(startingHashes, finalHashes, avoidQuery, universeQuery, shouldHashAllSourceFiles);
+        Set<String> impactedTargets = hashingClient.getImpactedTargets(startingHashes, finalHashes);
         try {
             FileWriter myWriter = new FileWriter(outputPath);
             myWriter.write(impactedTargets.stream().collect(Collectors.joining(System.lineSeparator())));

--- a/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -40,7 +40,7 @@ public class TargetHashingClientImplTests {
         when(bazelClientMock.queryAllTargets()).thenReturn(new ArrayList<>());
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
         try {
-            Map<String, String> hash = client.hashAllBazelTargets(new HashSet<>(), new HashSet<>());
+            Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
             assertEquals(hash.size(), 0);
         } catch (IOException e) {
             assertTrue(false);
@@ -54,7 +54,7 @@ public class TargetHashingClientImplTests {
         when(bazelClientMock.queryAllTargets()).thenReturn(defaultTargets);
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
         try {
-            Map<String, String> hash = client.hashAllBazelTargets(new HashSet<>(), new HashSet<>());
+            Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
             assertEquals(2, hash.size());
             assertEquals("2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775", hash.get("rule1"));
             assertEquals("bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9", hash.get("rule2"));
@@ -71,7 +71,7 @@ public class TargetHashingClientImplTests {
         when(bazelClientMock.queryAllTargets()).thenReturn(defaultTargets);
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
         try {
-            Map<String, String> hash = client.hashAllBazelTargets(new HashSet<>(), seedFilepaths);
+            Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(seedFilepaths);
             assertEquals(2, hash.size());
             assertEquals("0404d80eadcc2dbfe9f0d7935086e1115344a06bd76d4e16af0dfd7b4913ee60", hash.get("rule1"));
             assertEquals("6fe63fa16340d18176e6d6021972c65413441b72135247179362763508ebddfe", hash.get("rule2"));
@@ -91,7 +91,7 @@ public class TargetHashingClientImplTests {
         when(bazelClientMock.queryAllTargets()).thenReturn(defaultTargets);
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
         try {
-            Map<String, String> hash = client.hashAllBazelTargets(new HashSet<>(), new HashSet<>());
+            Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
             assertEquals(4, hash.size());
             assertEquals("2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775", hash.get("rule1"));
             assertEquals("bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9", hash.get("rule2"));
@@ -100,143 +100,6 @@ public class TargetHashingClientImplTests {
         } catch (IOException | NoSuchAlgorithmException e) {
             fail(e.getMessage());
         }
-    }
-
-    @Test
-    public void hashAllBazelTargets_sourceTargets_unmodifiedSources() throws IOException {
-        defaultTargets.add(createSourceTarget("sourceFile1"));
-        when(bazelClientMock.queryAllTargets()).thenReturn(defaultTargets);
-        TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
-        try {
-            Map<String, String> hash = client.hashAllBazelTargets(new HashSet<>(), new HashSet());
-            assertEquals(3, hash.size());
-            assertEquals("2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775", hash.get("rule1"));
-            assertEquals("bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9", hash.get("rule2"));
-            assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hash.get("sourceFile1"));
-        } catch (IOException | NoSuchAlgorithmException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    @Test
-    public void hashAllBazelTargets_sourceTargets_modifiedSources() throws IOException, NoSuchAlgorithmException {
-        createSourceTarget("sourceFile1");
-        defaultTargets.add(createSourceTarget("sourceFile1"));
-        Set<BazelSourceFileTarget> modifiedFileTargets = new HashSet<>();
-        modifiedFileTargets.add(createSourceFileTarget("sourceFile1", "digest"));
-        when(bazelClientMock.queryAllTargets()).thenReturn(defaultTargets);
-        when(bazelClientMock.convertFilepathsToSourceTargets(anySet())).thenReturn(modifiedFileTargets);
-        TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
-        try {
-            Map<String, String> hash = client.hashAllBazelTargets(new HashSet<>(), new HashSet<>());
-            assertEquals(3, hash.size());
-            assertEquals("2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775", hash.get("rule1"));
-            assertEquals("bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9", hash.get("rule2"));
-            assertEquals("0bf474896363505e5ea5e5d6ace8ebfb13a760a409b1fb467d428fc716f9f284", hash.get("sourceFile1"));
-        } catch (IOException | NoSuchAlgorithmException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    @Test
-    public void hashAllBazelTargets_sourceTargets_modifiedSources_seedFilepaths() throws IOException, NoSuchAlgorithmException {
-        Set<Path> seedFilepaths = new HashSet<>();
-        seedFilepaths.add(Paths.get("somefile.txt"));
-        when(filesClientMock.readFile(anyObject())).thenReturn("somecontent".getBytes());
-        createSourceTarget("sourceFile1");
-        defaultTargets.add(createSourceTarget("sourceFile1"));
-        Set<BazelSourceFileTarget> modifiedFileTargets = new HashSet<>();
-        modifiedFileTargets.add(createSourceFileTarget("sourceFile1", "digest"));
-        when(bazelClientMock.queryAllTargets()).thenReturn(defaultTargets);
-        when(bazelClientMock.convertFilepathsToSourceTargets(anySet())).thenReturn(modifiedFileTargets);
-        TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
-        try {
-            Map<String, String> hash = client.hashAllBazelTargets(new HashSet<>(), seedFilepaths);
-            assertEquals(3, hash.size());
-            assertEquals("0404d80eadcc2dbfe9f0d7935086e1115344a06bd76d4e16af0dfd7b4913ee60", hash.get("rule1"));
-            assertEquals("6fe63fa16340d18176e6d6021972c65413441b72135247179362763508ebddfe", hash.get("rule2"));
-            assertEquals("e0c3b2abd374fa00c23696c561b3797038fd8cf05de09377aef6a5dcd7529b13", hash.get("sourceFile1"));
-        } catch (IOException | NoSuchAlgorithmException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    @Test
-    public void getImpactedTargets() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject(), anyObject())).thenReturn(
-                new HashSet<>(Arrays.asList("rule1", "rule3"))
-        );
-        TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
-        Map<String, String> hash1 = new HashMap<>();
-        hash1.put("rule1", "rule1hash");
-        hash1.put("rule2", "rule2hash");
-        Map<String, String> hash2 = new HashMap<>();
-        hash2.put("rule1", "differentrule1hash");
-        hash2.put("rule2", "rule2hash");
-        hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null, null, false);
-        Set<String> expectedSet = new HashSet<>();
-        expectedSet.add("rule1");
-        expectedSet.add("rule3");
-        assertEquals(expectedSet, impactedTargets);
-    }
-
-    @Test
-    public void getImpactedTargets_withAvoidQuery() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"), eq("universe_query"))).thenReturn(
-                new HashSet<>(Arrays.asList("rule1"))
-        );
-        TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
-        Map<String, String> hash1 = new HashMap<>();
-        hash1.put("rule1", "rule1hash");
-        hash1.put("rule2", "rule2hash");
-        Map<String, String> hash2 = new HashMap<>();
-        hash2.put("rule1", "differentrule1hash");
-        hash2.put("rule2", "rule2hash");
-        hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query", "universe_query", false);
-        Set<String> expectedSet = new HashSet<>();
-        expectedSet.add("rule1");
-        assertEquals(expectedSet, impactedTargets);
-    }
-
-    @Test
-    public void getImpactedTargets_withHashAllTargets() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), anyObject(), anyObject())).thenReturn(
-                new HashSet<>(Arrays.asList("rule1"))
-        );
-        TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
-        Map<String, String> hash1 = new HashMap<>();
-        hash1.put("rule1", "rule1hash");
-        hash1.put("rule2", "rule2hash");
-        Map<String, String> hash2 = new HashMap<>();
-        hash2.put("rule1", "differentrule1hash");
-        hash2.put("rule2", "rule2hash");
-        hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, null, null, true);
-        Set<String> expectedSet = new HashSet<>();
-        expectedSet.add("rule1");
-        expectedSet.add("rule3");
-        assertEquals(expectedSet, impactedTargets);
-    }
-
-    @Test
-    public void getImpactedTargets_withHashAllTargets_withAvoidQuery() throws IOException {
-        when(bazelClientMock.queryForImpactedTargets(anySet(), eq("some_query"), anyObject())).thenReturn(
-                new HashSet<>(Arrays.asList("rule1"))
-        );
-        TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
-        Map<String, String> hash1 = new HashMap<>();
-        hash1.put("rule1", "rule1hash");
-        hash1.put("rule2", "rule2hash");
-        Map<String, String> hash2 = new HashMap<>();
-        hash2.put("rule1", "differentrule1hash");
-        hash2.put("rule2", "rule2hash");
-        hash2.put("rule3", "rule3hash");
-        Set<String> impactedTargets = client.getImpactedTargets(hash1, hash2, "some_query", null, true);
-        Set<String> expectedSet = new HashSet<>();
-        expectedSet.add("rule1");
-        assertEquals(expectedSet, impactedTargets);
     }
 
     private BazelTarget createRuleTarget(String ruleName, List<String> ruleInputs, String ruleDigest) throws NoSuchAlgorithmException {


### PR DESCRIPTION
Removes modified filepaths options.
We have used hash all targets for
awhile and have not noticed
a large performance penalty. Removing
this forking in the code.

Avoid query also does not work in a hash all targets world. This logic
was trivial to implement and was removed.