### PR TITLE
fix: stack overflow error when generating hashes

### DIFF
--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -89,7 +89,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
             digest.update(ruleInput.getBytes());
             BazelRule inputRule = allRulesMap.get(ruleInput);
             byte[] sourceFileDigest = getDigestForSourceTargetName(ruleInput, bazelSourcefileTargets);
-            if (inputRule != null) {
+            if (inputRule != null && !inputRule.getName().equals(rule.getName())) {
                 byte[] ruleInputHash = createDigestForRule(
                         inputRule,
                         allRulesMap,


### PR DESCRIPTION
This can happen if a rule ends up depending on itself.

To check for this we simply avoid trying to create a digest for a rule
of the same name as the current one we're working on.

Fixes: #71