### PR TITLE
Allows disabling `--keep_going` flag in queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ out
 user.bazelrc
 !bazel-diff-example.sh
 .DS_Store
-integration/BUILD.bazel

--- a/integration/src/main/java/com/integration/BUILD
+++ b/integration/src/main/java/com/integration/BUILD
@@ -4,7 +4,7 @@ java_library(
     name = "bazel-diff-integration-lib",
     srcs = glob(["*.java"]),
     deps = [
-        "//src/main/java/com/integration/submodule:Submodule"
+        "//integration/src/main/java/com/integration/submodule:Submodule"
     ],
     visibility = ["//visibility:public"]
 )

--- a/integration/test/java/com/integration/BUILD
+++ b/integration/test/java/com/integration/BUILD
@@ -9,8 +9,9 @@ java_test(
 java_library(
     name = "bazel-diff-integration-test-lib",
     srcs = glob(["*.java"]),
+    testonly = True,
     deps = [
-        "//src/main/java/com/integration:bazel-diff-integration-lib",
+        "//integration/src/main/java/com/integration:bazel-diff-integration-lib",
         "@bazel_diff_maven//:junit_junit"
     ]
 )

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -38,7 +38,13 @@ class GenerateHashes implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        BazelClient bazelClient = new BazelClientImpl(parent.workspacePath, parent.bazelPath, parent.bazelStartupOptions, parent.bazelCommandOptions, BazelDiff.isVerbose());
+        BazelClient bazelClient = new BazelClientImpl(
+                parent.workspacePath,
+                parent.bazelPath,
+                parent.bazelStartupOptions,
+                parent.bazelCommandOptions,
+                BazelDiff.isVerbose(),
+                parent.keepGoing);
         TargetHashingClient hashingClient = new TargetHashingClientImpl(bazelClient, new FilesClientImp());
         try {
             Set<Path> seedFilepathsSet = new HashSet<>();
@@ -92,6 +98,9 @@ class BazelDiff implements Callable<Integer> {
     @Option(names = {"-co", "--bazelCommandOptions"}, description = "Additional space separated Bazel command options used when invoking Bazel", scope = ScopeType.INHERIT)
     String bazelCommandOptions;
 
+    @Option(names = {"-k", "--keep_going"}, negatable = true, description = "This flag controls if `bazel query` will be executed with the `--keep_going` flag or not. Disabling this flag allows you to catch configuration issues in your Bazel graph, but may not work for some Bazel setups. Defaults to `true`")
+    Boolean keepGoing = true;
+
     @Override
     public Integer call() throws IOException {
         if (startingHashesJSONPath == null || !startingHashesJSONPath.canRead()) {
@@ -103,7 +112,14 @@ class BazelDiff implements Callable<Integer> {
             return ExitCode.USAGE;
         }
         GitClient gitClient = new GitClientImpl(workspacePath);
-        BazelClient bazelClient = new BazelClientImpl(workspacePath, bazelPath, bazelStartupOptions, bazelCommandOptions, BazelDiff.isVerbose());
+        BazelClient bazelClient = new BazelClientImpl(
+                workspacePath,
+                bazelPath,
+                bazelStartupOptions,
+                bazelCommandOptions,
+                BazelDiff.isVerbose(),
+                keepGoing
+        );
         TargetHashingClient hashingClient = new TargetHashingClientImpl(bazelClient, new FilesClientImp());
         try {
             gitClient.ensureAllChangesAreCommitted();


### PR DESCRIPTION
Adds a new flag `-k` that can negated to prevent bazel queries from using the `--keep_going` flag