### PR TITLE
task: performance improvement when fetching digest for target

### DIFF
--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -12,15 +12,15 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.Arrays;
 
 interface BazelClient {
     List<BazelTarget> queryAllTargets() throws IOException;
-    Set<BazelSourceFileTarget> queryAllSourcefileTargets() throws IOException, NoSuchAlgorithmException;
+    Map<String, BazelSourceFileTarget> queryAllSourcefileTargets() throws IOException, NoSuchAlgorithmException;
 }
 
 class BazelClientImpl implements BazelClient {
@@ -54,12 +54,12 @@ class BazelClientImpl implements BazelClient {
     }
 
     @Override
-    public Set<BazelSourceFileTarget> queryAllSourcefileTargets() throws IOException, NoSuchAlgorithmException {
+    public Map<String, BazelSourceFileTarget> queryAllSourcefileTargets() throws IOException, NoSuchAlgorithmException {
         return processBazelSourcefileTargets(performBazelQuery("kind('source file', deps(//...))"), true);
     }
 
-    private Set<BazelSourceFileTarget> processBazelSourcefileTargets(List<Build.Target> targets, Boolean readSourcefileTargets) throws IOException, NoSuchAlgorithmException {
-        Set<BazelSourceFileTarget> sourceTargets = new HashSet<>();
+    private Map<String, BazelSourceFileTarget> processBazelSourcefileTargets(List<Build.Target> targets, Boolean readSourcefileTargets) throws IOException, NoSuchAlgorithmException {
+        Map<String, BazelSourceFileTarget> sourceTargets = new HashMap<>();
         for (Build.Target target : targets) {
             Build.SourceFile sourceFile = target.getSourceFile();
             if (sourceFile != null) {
@@ -73,7 +73,7 @@ class BazelClientImpl implements BazelClient {
                         digest.digest().clone(),
                         readSourcefileTargets ? workingDirectory : null
                 );
-                sourceTargets.add(sourceFileTarget);
+                sourceTargets.put(sourceFileTarget.getName(), sourceFileTarget);
             }
         }
         return sourceTargets;

--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -25,7 +25,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
 
     @Override
     public Map<String, String> hashAllBazelTargetsAndSourcefiles(Set<Path> seedFilepaths) throws IOException, NoSuchAlgorithmException {
-        Set<BazelSourceFileTarget> bazelSourcefileTargets = bazelClient.queryAllSourcefileTargets();
+        Map<String, BazelSourceFileTarget> bazelSourcefileTargets = bazelClient.queryAllSourcefileTargets();
         return hashAllTargets(createSeedForFilepaths(seedFilepaths), bazelSourcefileTargets);
     }
 
@@ -47,7 +47,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
     private byte[] createDigestForTarget(
             BazelTarget target,
             Map<String, BazelRule> allRulesMap,
-            Set<BazelSourceFileTarget> bazelSourcefileTargets,
+            Map<String, BazelSourceFileTarget> bazelSourcefileTargets,
             Map<String, byte[]> ruleHashes,
             byte[] seedHash
     ) throws NoSuchAlgorithmException {
@@ -73,7 +73,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
             BazelRule rule,
             Map<String, BazelRule> allRulesMap,
             Map<String, byte[]> ruleHashes,
-            Set<BazelSourceFileTarget> bazelSourcefileTargets,
+            Map<String, BazelSourceFileTarget> bazelSourcefileTargets,
             byte[] seedHash
     ) throws NoSuchAlgorithmException {
         byte[] existingByteArray = ruleHashes.get(rule.getName());
@@ -122,14 +122,10 @@ class TargetHashingClientImpl implements TargetHashingClient {
 
     private byte[] getDigestForSourceTargetName(
             String sourceTargetName,
-            Set<BazelSourceFileTarget> bazelSourcefileTargets
+            Map<String, BazelSourceFileTarget> bazelSourcefileTargets
     ) throws NoSuchAlgorithmException {
-        for (BazelSourceFileTarget sourceFileTarget : bazelSourcefileTargets) {
-            if (sourceFileTarget.getName().equals(sourceTargetName)) {
-                return sourceFileTarget.getDigest();
-            }
-        }
-        return null;
+        BazelSourceFileTarget target = bazelSourcefileTargets.get(sourceTargetName);
+        return target != null ? target.getDigest() : null;
     }
 
     private String convertByteArrayToString(byte[] bytes) {
@@ -150,7 +146,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
         return null;
     }
 
-    private Map<String, String> hashAllTargets(byte[] seedHash, Set<BazelSourceFileTarget> bazelSourcefileTargets) throws IOException, NoSuchAlgorithmException {
+    private Map<String, String> hashAllTargets(byte[] seedHash, Map<String, BazelSourceFileTarget> bazelSourcefileTargets) throws IOException, NoSuchAlgorithmException {
         List<BazelTarget> allTargets = bazelClient.queryAllTargets();
         Map<String, String> targetHashes = new HashMap<>();
         Map<String, byte[]> ruleHashes = new HashMap<>();


### PR DESCRIPTION
After the change to hash all source files, we noticed a significant performance drop; generating all hashes for two different revisions took upwards of 2 minutes locally, and 6 minutes on our CI machines (which are not that powerful).

I noticed that we were looking for a target name in `bazelSourceFileTargets`, but this lookup was a linear one each time, and this method is called for every target we're creating a digest for. Since this set is only used here, I've changed it to a map, so we can simply lookup the target in constant time.

This is significantly faster for us, bring down the time to ~10s locally, and ~1.5mins on our CI.