### PR TITLE
Fix detection of generated files

### DIFF
--- a/src/main/java/com/bazel_diff/BazelTarget.java
+++ b/src/main/java/com/bazel_diff/BazelTarget.java
@@ -7,6 +7,9 @@ interface BazelTarget {
     BazelRule getRule();
     boolean hasSourceFile();
     String getSourceFileName();
+    boolean hasGeneratedFile();
+    String getGeneratedFileName();
+    String getGeneratingRuleName();
 }
 
 class BazelTargetImpl implements BazelTarget {
@@ -38,6 +41,27 @@ class BazelTargetImpl implements BazelTarget {
     public String getSourceFileName() {
         if (this.hasSourceFile()) {
             return this.target.getSourceFile().getName();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean hasGeneratedFile() {
+        return target.hasGeneratedFile();
+    }
+
+    @Override
+    public String getGeneratedFileName() {
+        if (this.hasGeneratedFile()) {
+            return this.target.getGeneratedFile().getName();
+        }
+        return null;
+    }
+
+    @Override
+    public String getGeneratingRuleName() {
+        if (this.hasGeneratedFile()) {
+            return this.target.getGeneratedFile().getGeneratingRule();
         }
         return null;
     }

--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -67,7 +67,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
         }
         if (target.hasGeneratedFile()){
             byte[] generatingRuleDigest = ruleHashes.get(target.getGeneratingRuleName());
-            if(generatingRuleDigest == null) {
+            if (generatingRuleDigest == null) {
                 return createDigestForRule(allRulesMap.get(target.getGeneratingRuleName()), allRulesMap, ruleHashes, bazelSourcefileTargets, seedHash);
             }
             return ruleHashes.get(target.getGeneratingRuleName()).clone();


### PR DESCRIPTION
## What?
This fixes an issue where if you depend on a label that is a single generated file it will not be properly detected

The exact use case was in rules_docker where if you have the target

```
rust_image(
    name = "awesome_image"
)
```

You can depend on `//:awesome_image.digest` which is a generated file which contains the image digest

## How?
Added explicit handling of generated files