### PR TITLE
Fix bug during registration of generating targets

### DIFF
--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -166,13 +166,16 @@ class TargetHashingClientImpl implements TargetHashingClient {
             if (targetName == null) {
                 continue;
             }
-            if(target.hasGeneratedFile()) {
-                allRulesMap.put(targetName, allRulesMap.get(target.getGeneratingRuleName()));
-            }
             if(target.hasRule()) {
                 allRulesMap.put(targetName, target.getRule());
             }
         }
+        for (BazelTarget target: allTargets) {
+            if(target.hasGeneratedFile()) {
+                allRulesMap.put(getNameForTarget(target), allRulesMap.get(target.getGeneratingRuleName()));
+            }
+        }
+
         for (BazelTarget target : allTargets) {
             String targetName = getNameForTarget(target);
             if (targetName == null) {


### PR DESCRIPTION
Fixes a bug where if the generating rule name is lexicographically after
the generated rule, changes in the generating rule are not picked up by
targets that depend on the generated rule.

When this happens between a generating rule and generated rule,
the generated rule's entry in `allRulesMap` is null, as the generating
rule hasn't been processed yet. If a rule has no entry in `allRulesMap`,
it's hash is unable to be used as a dependency in `createDigestForRule`,
resulting in missing impacted targets.

Test plan:
Added unit test demonstrating buggy behavior.