### PR TITLE
Display elapsed time for bazel query and content hash calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ workspace.
   -V, --version           Print version information and exit.
   -w, --workspacePath=<workspacePath>
                           Path to Bazel workspace directory.
-  --display-elapsed-time  This flag controls whether to print out elapsed time
+  --displayElapsedTime    This flag controls whether to print out elapsed time
                           for bazel query and content hashing
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ workspace.
   -V, --version           Print version information and exit.
   -w, --workspacePath=<workspacePath>
                           Path to Bazel workspace directory.
+  --display-elapsed-time  This flag controls whether to print out elapsed time
+                          for bazel query and content hashing
 ```
 
 ## Installing

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -59,7 +59,7 @@ class BazelClientImpl implements BazelClient {
         Instant queryEndTime = Instant.now();
         if (displayElapsedTime) {
             long querySeconds = Duration.between(queryStartTime, queryEndTime).getSeconds();
-            System.out.printf("all targets queried in %d seconds%n", querySeconds);
+            System.out.printf("BazelDiff: All targets queried in %d seconds%n", querySeconds);
         }
         return targets.stream().map( target -> new BazelTargetImpl(target)).collect(Collectors.toList());
     }
@@ -74,8 +74,8 @@ class BazelClientImpl implements BazelClient {
         if (displayElapsedTime) {
             long querySeconds = Duration.between(queryStartTime, queryEndTime).getSeconds();
             long contentHashSeconds = Duration.between(queryEndTime, contentHashEndTime).getSeconds();
-            System.out.printf("all source files queried in %d seconds%n", querySeconds);
-            System.out.printf("content hash calculated in %d seconds%n", contentHashSeconds);
+            System.out.printf("BazelDiff: All source files queried in %d seconds%n", querySeconds);
+            System.out.printf("BazelDiff: Content hash calculated in %d seconds%n", contentHashSeconds);
         }
         return sourceFileTargets;
     }

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -11,6 +11,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +30,7 @@ class BazelClientImpl implements BazelClient {
     private Path bazelPath;
     private Boolean verbose;
     private Boolean keepGoing;
+    private Boolean displayElapsedTime;
     private List<String> startupOptions;
     private List<String> commandOptions;
 
@@ -37,7 +40,8 @@ class BazelClientImpl implements BazelClient {
             String startupOptions,
             String commandOptions,
             Boolean verbose,
-            Boolean keepGoing
+            Boolean keepGoing,
+            Boolean displayElapsedTime
     ) {
         this.workingDirectory = workingDirectory.normalize();
         this.bazelPath = bazelPath;
@@ -45,17 +49,35 @@ class BazelClientImpl implements BazelClient {
         this.commandOptions = commandOptions != null ? Arrays.asList(commandOptions.split(" ")): new ArrayList<String>();
         this.verbose = verbose;
         this.keepGoing = keepGoing;
+        this.displayElapsedTime = displayElapsedTime;
     }
 
     @Override
     public List<BazelTarget> queryAllTargets() throws IOException {
+        Instant queryStartTime = Instant.now();
         List<Build.Target> targets = performBazelQuery("'//external:all-targets' + '//...:all-targets'");
+        Instant queryEndTime = Instant.now();
+        if (displayElapsedTime) {
+            long querySeconds = Duration.between(queryStartTime, queryEndTime).toSeconds();
+            System.out.printf("all targets queried in %d seconds%n", querySeconds);
+        }
         return targets.stream().map( target -> new BazelTargetImpl(target)).collect(Collectors.toList());
     }
 
     @Override
     public Map<String, BazelSourceFileTarget> queryAllSourcefileTargets() throws IOException, NoSuchAlgorithmException {
-        return processBazelSourcefileTargets(performBazelQuery("kind('source file', //...:all-targets)"), true);
+        Instant queryStartTime = Instant.now();
+        List<Build.Target> targets = performBazelQuery("kind('source file', //...:all-targets)");
+        Instant queryEndTime = Instant.now();
+        Map<String, BazelSourceFileTarget> sourceFileTargets = processBazelSourcefileTargets(targets, true);
+        Instant contentHashEndTime = Instant.now();
+        if (displayElapsedTime) {
+            long querySeconds = Duration.between(queryStartTime, queryEndTime).toSeconds();
+            long contentHashSeconds = Duration.between(queryEndTime, contentHashEndTime).toSeconds();
+            System.out.printf("all source files queried in %d seconds%n", querySeconds);
+            System.out.printf("content hash calculated in %d seconds%n", contentHashSeconds);
+        }
+        return sourceFileTargets;
     }
 
     private Map<String, BazelSourceFileTarget> processBazelSourcefileTargets(List<Build.Target> targets, Boolean readSourcefileTargets) throws IOException, NoSuchAlgorithmException {

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -58,7 +58,7 @@ class BazelClientImpl implements BazelClient {
         List<Build.Target> targets = performBazelQuery("'//external:all-targets' + '//...:all-targets'");
         Instant queryEndTime = Instant.now();
         if (displayElapsedTime) {
-            long querySeconds = Duration.between(queryStartTime, queryEndTime).toSeconds();
+            long querySeconds = Duration.between(queryStartTime, queryEndTime).getSeconds();
             System.out.printf("all targets queried in %d seconds%n", querySeconds);
         }
         return targets.stream().map( target -> new BazelTargetImpl(target)).collect(Collectors.toList());
@@ -72,8 +72,8 @@ class BazelClientImpl implements BazelClient {
         Map<String, BazelSourceFileTarget> sourceFileTargets = processBazelSourcefileTargets(targets, true);
         Instant contentHashEndTime = Instant.now();
         if (displayElapsedTime) {
-            long querySeconds = Duration.between(queryStartTime, queryEndTime).toSeconds();
-            long contentHashSeconds = Duration.between(queryEndTime, contentHashEndTime).toSeconds();
+            long querySeconds = Duration.between(queryStartTime, queryEndTime).getSeconds();
+            long contentHashSeconds = Duration.between(queryEndTime, contentHashEndTime).getSeconds();
             System.out.printf("all source files queried in %d seconds%n", querySeconds);
             System.out.printf("content hash calculated in %d seconds%n", contentHashSeconds);
         }

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -69,7 +69,7 @@ class GenerateHashes implements Callable<Integer> {
             myWriter.close();
             Instant generateHashEndTime = Instant.now();
             if (displayElapsedTime) {
-                long generateHashSeconds = Duration.between(generateHashStartTime, generateHashEndTime).toSeconds();
+                long generateHashSeconds = Duration.between(generateHashStartTime, generateHashEndTime).getSeconds();
                 System.out.printf("generate-hashes command finishes in %d seconds%n", generateHashSeconds);
             }
             return ExitCode.OK;

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -35,7 +35,7 @@ class GenerateHashes implements Callable<Integer> {
     @Option(names = {"-s", "--seed-filepaths"}, description = "A text file containing a newline separated list of filepaths, each of these filepaths will be read and used as a seed for all targets.")
     File seedFilepaths;
 
-    @Option(names = {"--display-elapsed-time"}, description = "This flag controls whether to print out elapsed time for bazel query and content hashing")
+    @Option(names = {"--displayElapsedTime"}, description = "This flag controls whether to print out elapsed time for bazel query and content hashing")
     boolean displayElapsedTime;
 
     @Parameters(index = "0", description = "The filepath to write the resulting JSON of dictionary target => SHA-256 values")

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -70,7 +70,7 @@ class GenerateHashes implements Callable<Integer> {
             Instant generateHashEndTime = Instant.now();
             if (displayElapsedTime) {
                 long generateHashSeconds = Duration.between(generateHashStartTime, generateHashEndTime).getSeconds();
-                System.out.printf("generate-hashes command finishes in %d seconds%n", generateHashSeconds);
+                System.out.printf("BazelDiff: Generate-hashes command finishes in %d seconds%n", generateHashSeconds);
             }
             return ExitCode.OK;
         } catch (IOException | NoSuchAlgorithmException e) {


### PR DESCRIPTION
In `generate-hashes` command, it takes a while to run `bazel query` and generate content hash for all source files in a large repo. It would be helpful if we know how long these steps take.