### PR TITLE
use file channel to improve content hash efficiency

### DIFF
--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -2,8 +2,6 @@ package com.bazel_diff;
 
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
 
-import com.google.common.collect.Iterables;
-
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.io.IOException;

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -69,7 +69,8 @@ class BazelClientImpl implements BazelClient {
                 BazelSourceFileTargetImpl sourceFileTarget = new BazelSourceFileTargetImpl(
                         sourceFile.getName(),
                         digest.digest().clone(),
-                        readSourcefileTargets ? workingDirectory : null
+                        readSourcefileTargets ? workingDirectory : null,
+                        verbose
                 );
                 sourceTargets.put(sourceFileTarget.getName(), sourceFileTarget);
             }

--- a/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
+++ b/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -23,8 +24,8 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
         if (workingDirectory != null && name.startsWith("//")) {
             String filenameSubstring = name.substring(2);
             String filenamePath = filenameSubstring.replaceFirst(":", "/");
-            String absoluteFilePath = workingDirectory.toString() + filenamePath;
-            try (RandomAccessFile sourceFile = new RandomAccessFile(absoluteFilePath, "r")) {
+            Path absoluteFilePath = Paths.get(workingDirectory.toString(), filenamePath);
+            try (RandomAccessFile sourceFile = new RandomAccessFile(absoluteFilePath.toString(), "r")) {
                 FileChannel inChannel = sourceFile.getChannel();
                 long fileSize = inChannel.size();
                 ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
@@ -35,7 +36,7 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
                 finalDigest.update(buffer);
                 finalDigest.update(digest);
             } catch (FileNotFoundException e) {}
-        } else if (digest != null ){
+        } else if (digest != null ) {
             finalDigest.update(digest);
         }
         finalDigest.update(name.getBytes());

--- a/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
+++ b/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
@@ -36,7 +36,7 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
         finalDigest.update(buffer);
     }
 
-    BazelSourceFileTargetImpl(String name, byte[] digest, Path workingDirectory)
+    BazelSourceFileTargetImpl(String name, byte[] digest, Path workingDirectory, Boolean verbose)
         throws IOException, NoSuchAlgorithmException {
         this.name = name;
         MessageDigest finalDigest = MessageDigest.getInstance("SHA-256");
@@ -53,7 +53,11 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
                 }
                 sourceFile.close();
                 inChannel.close();
-            } catch (FileNotFoundException e) {}
+            } catch (FileNotFoundException e) {
+                if (verbose) {
+                    System.out.printf("BazelDiff: [Warning] file %s not found%n", absoluteFilePath);
+                }
+            }
         }
         finalDigest.update(digest);
         finalDigest.update(name.getBytes());

--- a/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
+++ b/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
@@ -27,7 +27,7 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
             try (RandomAccessFile sourceFile = new RandomAccessFile(absoluteFilePath, "r")) {
                 FileChannel inChannel = sourceFile.getChannel();
                 long fileSize = inChannel.size();
-                ByteBuffer buffer = ByteBuffer.allocate((int) fileSize + digest.length + 1);
+                ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
                 inChannel.read(buffer);
                 buffer.flip();
                 inChannel.close();


### PR DESCRIPTION
Content hash is a bit faster now using non-blocking IO api.

before:
> content hash done in 157 seconds

after:
> content hash done in 120 seconds