### PR TITLE
Allow verbose flag to be passed as args

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ workspace.
   -V, --version           Print version information and exit.
   -w, --workspacePath=<workspacePath>
                           Path to Bazel workspace directory.
-  --displayElapsedTime    This flag controls whether to print out elapsed time
-                          for bazel query and content hashing
+  -v, --verbose           Display query string, missing files and elapsed time
 ```
 
 ## Installing

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -28,7 +28,6 @@ class BazelClientImpl implements BazelClient {
     private Path bazelPath;
     private Boolean verbose;
     private Boolean keepGoing;
-    private Boolean displayElapsedTime;
     private List<String> startupOptions;
     private List<String> commandOptions;
 
@@ -38,8 +37,7 @@ class BazelClientImpl implements BazelClient {
             String startupOptions,
             String commandOptions,
             Boolean verbose,
-            Boolean keepGoing,
-            Boolean displayElapsedTime
+            Boolean keepGoing
     ) {
         this.workingDirectory = workingDirectory.normalize();
         this.bazelPath = bazelPath;
@@ -47,7 +45,6 @@ class BazelClientImpl implements BazelClient {
         this.commandOptions = commandOptions != null ? Arrays.asList(commandOptions.split(" ")): new ArrayList<String>();
         this.verbose = verbose;
         this.keepGoing = keepGoing;
-        this.displayElapsedTime = displayElapsedTime;
     }
 
     @Override
@@ -55,7 +52,7 @@ class BazelClientImpl implements BazelClient {
         Instant queryStartTime = Instant.now();
         List<Build.Target> targets = performBazelQuery("'//external:all-targets' + '//...:all-targets'");
         Instant queryEndTime = Instant.now();
-        if (displayElapsedTime) {
+        if (verbose) {
             long querySeconds = Duration.between(queryStartTime, queryEndTime).getSeconds();
             System.out.printf("BazelDiff: All targets queried in %d seconds%n", querySeconds);
         }
@@ -69,7 +66,7 @@ class BazelClientImpl implements BazelClient {
         Instant queryEndTime = Instant.now();
         Map<String, BazelSourceFileTarget> sourceFileTargets = processBazelSourcefileTargets(targets, true);
         Instant contentHashEndTime = Instant.now();
-        if (displayElapsedTime) {
+        if (verbose) {
             long querySeconds = Duration.between(queryStartTime, queryEndTime).getSeconds();
             long contentHashSeconds = Duration.between(queryEndTime, contentHashEndTime).getSeconds();
             System.out.printf("BazelDiff: All source files queried in %d seconds%n", querySeconds);

--- a/src/main/java/com/bazel_diff/VersionProvider.java
+++ b/src/main/java/com/bazel_diff/VersionProvider.java
@@ -5,7 +5,7 @@ import picocli.CommandLine.IVersionProvider;
 class VersionProvider implements IVersionProvider {
     public String[] getVersion() throws Exception {
         return new String[] {
-            "3.2.2"
+            "3.4.0"
         };
     }
 }

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -110,7 +110,7 @@ class BazelDiff implements Callable<Integer> {
     Boolean keepGoing = true;
 
     @Option(names = {"-v", "--verbose"}, description = "Display query string, missing files and elapsed time", scope = ScopeType.INHERIT)
-    Boolean verbose;
+    Boolean verbose = false;
 
     @Override
     public Integer call() throws IOException {


### PR DESCRIPTION
https://github.com/Tinder/bazel-diff/pull/110#discussion_r845641370 reminds me that `verbose` can only be set at build time by setting `compilation_mode` to `dbg`. User should get verbose message printed by passing a flag at runtime.