### PR TITLE
Handle JDK9 Buffer breaking migration

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,35 @@
+name: CD
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  BuildJAR:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ '8' ]
+    steps:
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+        id: java
+      - name: Setup Go environment
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.17
+        id: go
+      - name: Setup Bazelisk
+        run: go install github.com/bazelbuild/bazelisk@latest && export PATH=$PATH:$(go env GOPATH)/bin
+      - uses: actions/checkout@v2
+      - name: Build deployable JAR
+        run: USE_BAZEL_VERSION=last_downstream_green ~/go/bin/bazelisk bazelisk build //src/main/java/com/bazel_diff:bazel-diff_deploy.jar
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bazel-diff_deploy.jar
+          path: bazel-bin/src/main/java/com/bazel_diff/bazel-diff_deploy.jar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  Tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -9,7 +9,7 @@ on:
     - cron: "0 */12 * * *"
 
 jobs:
-  build:
+  Integration:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/integration_external_target.yml
+++ b/.github/workflows/integration_external_target.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 */12 * * *"
 
 jobs:
-  build:
+  IntegrationExternalTarget:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
+++ b/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
@@ -1,6 +1,7 @@
 package com.bazel_diff;
 
 import java.io.*;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
@@ -22,7 +23,7 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
         int bufferSize = 10240; // 10kb
         ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
         while (inChannel.read(buffer) != -1) {
-            buffer.flip();
+            ((Buffer)buffer).flip();
             finalDigest.update(buffer);
             buffer.clear();
         }
@@ -32,7 +33,7 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
         long fileSize = inChannel.size();
         ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
         inChannel.read(buffer);
-        buffer.flip();
+        ((Buffer)buffer).flip();
         finalDigest.update(buffer);
     }
 

--- a/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
+++ b/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
@@ -1,7 +1,6 @@
 package com.bazel_diff;
 
 import java.io.*;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
@@ -23,7 +22,7 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
         int bufferSize = 10240; // 10kb
         ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
         while (inChannel.read(buffer) != -1) {
-            ((Buffer)buffer).flip();
+            buffer.flip();
             finalDigest.update(buffer);
             buffer.clear();
         }
@@ -33,7 +32,7 @@ class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
         long fileSize = inChannel.size();
         ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
         inChannel.read(buffer);
-        ((Buffer)buffer).flip();
+        buffer.flip();
         finalDigest.update(buffer);
     }
 


### PR DESCRIPTION
Flip does not return a ByteBuffer
on certain versions of java