### PR TITLE
keep bazelrc in verbose mode

### DIFF
--- a/src/main/java/com/bazel_diff/BUILD
+++ b/src/main/java/com/bazel_diff/BUILD
@@ -2,7 +2,7 @@ load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_proto_li
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 config_setting(
-    name = "enable_verbose",
+    name = "enable_debug",
     values = {
         "compilation_mode": "dbg",
     },
@@ -14,7 +14,7 @@ java_binary(
     runtime_deps = [":java-bazel-diff-lib"],
     visibility = ["//visibility:public"],
     jvm_flags = select({
-        ":enable_verbose": ["-DVERBOSE=true"],
+        ":enable_debug": ["-DDEBUG=true"],
         "//conditions:default": [],
     }),
 )
@@ -30,7 +30,7 @@ java_library(
         "@bazel_diff_maven//:com_google_guava_guava"
     ],
     javacopts = select({
-        ":enable_verbose": ["-AVERBOSE=true"],
+        ":enable_debug": ["-ADEBUG=true"],
         "//conditions:default": [],
     }),
     visibility = ["//test/java/com/bazel_diff:__pkg__"]

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -28,6 +28,7 @@ class BazelClientImpl implements BazelClient {
     private Path bazelPath;
     private Boolean verbose;
     private Boolean keepGoing;
+    private Boolean debug;
     private List<String> startupOptions;
     private List<String> commandOptions;
 
@@ -36,8 +37,9 @@ class BazelClientImpl implements BazelClient {
             Path bazelPath,
             String startupOptions,
             String commandOptions,
+            Boolean keepGoing,
             Boolean verbose,
-            Boolean keepGoing
+            Boolean debug
     ) {
         this.workingDirectory = workingDirectory.normalize();
         this.bazelPath = bazelPath;
@@ -45,6 +47,7 @@ class BazelClientImpl implements BazelClient {
         this.commandOptions = commandOptions != null ? Arrays.asList(commandOptions.split(" ")): new ArrayList<String>();
         this.verbose = verbose;
         this.keepGoing = keepGoing;
+        this.debug = debug;
     }
 
     @Override
@@ -105,6 +108,8 @@ class BazelClientImpl implements BazelClient {
         cmd.add((bazelPath.toString()));
         if (verbose) {
             System.out.println(String.format("Executing Query: %s", query));
+        }
+        if (debug) {
             cmd.add("--bazelrc=/dev/null");
         }
         cmd.addAll(this.startupOptions);

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -45,8 +45,9 @@ class GenerateHashes implements Callable<Integer> {
                 parent.bazelPath,
                 parent.bazelStartupOptions,
                 parent.bazelCommandOptions,
+                parent.keepGoing,
                 parent.isVerbose(),
-                parent.keepGoing);
+                parent.isDebug());
         TargetHashingClient hashingClient = new TargetHashingClientImpl(bazelClient, new FilesClientImp());
         try {
             Instant generateHashStartTime = Instant.now();
@@ -131,8 +132,9 @@ class BazelDiff implements Callable<Integer> {
                 bazelPath,
                 bazelStartupOptions,
                 bazelCommandOptions,
+                keepGoing,
                 isVerbose(),
-                keepGoing
+                isDebug()
         );
         TargetHashingClient hashingClient = new TargetHashingClientImpl(bazelClient, new FilesClientImp());
         Gson gson = new Gson();
@@ -150,7 +152,7 @@ class BazelDiff implements Callable<Integer> {
             System.out.println("Final Hashes JSON filepath does not exist! Exiting");
             return ExitCode.USAGE;
         }
-        Map<String, String > gsonHash = new HashMap<>();
+        Map<String, String> gsonHash = new HashMap<>();
         Map<String, String> startingHashes = gson.fromJson(startingFileReader, gsonHash.getClass());
         Map<String, String> finalHashes = gson.fromJson(finalFileReader, gsonHash.getClass());
         Set<String> impactedTargets = hashingClient.getImpactedTargets(startingHashes, finalHashes);
@@ -166,8 +168,12 @@ class BazelDiff implements Callable<Integer> {
     }
 
     Boolean isVerbose() {
-        String verboseFlag = System.getProperty("VERBOSE", "false");
-        return verboseFlag.equals("true") || verbose;
+        return verbose || this.isDebug();
+    }
+
+    Boolean isDebug() {
+        String debugFlag = System.getProperty("DEBUG", "false");
+        return debugFlag.equals("true");
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
It's a bit unintuitive to append `--bazelrc=/dev/null` in verbose mode. It may be more appropriate to be used under a `debug` flag?