### PR TITLE
feat(bazel-diff): improve performance

### DIFF
--- a/artifacts.bzl
+++ b/artifacts.bzl
@@ -7,5 +7,6 @@ BAZEL_DIFF_MAVEN_ARTIFACTS = [
     maven.artifact("org.mockito", "mockito-core", "3.5.15", testonly = True),
     "info.picocli:picocli:jar:4.3.2",
     "com.google.code.gson:gson:jar:2.8.6",
-    "com.google.guava:guava:29.0-jre"
+    "com.google.guava:guava:29.0-jre",
+    "org.apache.commons:commons-pool2:2.11.1",
 ]

--- a/src/main/java/com/bazel_diff/BUILD
+++ b/src/main/java/com/bazel_diff/BUILD
@@ -27,7 +27,8 @@ java_library(
         "@com_google_protobuf//:protobuf_java",
         "@bazel_diff_maven//:info_picocli_picocli",
         "@bazel_diff_maven//:com_google_code_gson_gson",
-        "@bazel_diff_maven//:com_google_guava_guava"
+        "@bazel_diff_maven//:com_google_guava_guava",
+        "@bazel_diff_maven//:org_apache_commons_commons_pool2"
     ],
     javacopts = select({
         ":enable_verbose": ["-AVERBOSE=true"],

--- a/src/main/java/com/bazel_diff/BazelClient.java
+++ b/src/main/java/com/bazel_diff/BazelClient.java
@@ -1,5 +1,7 @@
 package com.bazel_diff;
 
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
 import com.google.devtools.build.lib.query2.proto.proto2api.Build;
 
 import java.io.*;
@@ -7,20 +9,19 @@ import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.Arrays;
 
 interface BazelClient {
     List<BazelTarget> queryAllTargets() throws IOException;
-    Map<String, BazelSourceFileTarget> queryAllSourcefileTargets() throws IOException, NoSuchAlgorithmException;
+
+    Map<String, BazelSourceFileTarget> queryAllSourcefileTargets() throws Exception;
 }
 
 class BazelClientImpl implements BazelClient {
@@ -41,8 +42,8 @@ class BazelClientImpl implements BazelClient {
     ) {
         this.workingDirectory = workingDirectory.normalize();
         this.bazelPath = bazelPath;
-        this.startupOptions = startupOptions != null ? Arrays.asList(startupOptions.split(" ")): new ArrayList<String>();
-        this.commandOptions = commandOptions != null ? Arrays.asList(commandOptions.split(" ")): new ArrayList<String>();
+        this.startupOptions = startupOptions != null ? Arrays.asList(startupOptions.split(" ")) : new ArrayList<String>();
+        this.commandOptions = commandOptions != null ? Arrays.asList(commandOptions.split(" ")) : new ArrayList<String>();
         this.verbose = verbose;
         this.keepGoing = keepGoing;
     }
@@ -56,11 +57,11 @@ class BazelClientImpl implements BazelClient {
             long querySeconds = Duration.between(queryStartTime, queryEndTime).getSeconds();
             System.out.printf("BazelDiff: All targets queried in %d seconds%n", querySeconds);
         }
-        return targets.stream().map( target -> new BazelTargetImpl(target)).collect(Collectors.toList());
+        return targets.stream().map(target -> new BazelTargetImpl(target)).collect(Collectors.toList());
     }
 
     @Override
-    public Map<String, BazelSourceFileTarget> queryAllSourcefileTargets() throws IOException, NoSuchAlgorithmException {
+    public Map<String, BazelSourceFileTarget> queryAllSourcefileTargets() throws Exception {
         Instant queryStartTime = Instant.now();
         List<Build.Target> targets = performBazelQuery("kind('source file', //...:all-targets)");
         Instant queryEndTime = Instant.now();
@@ -75,26 +76,59 @@ class BazelClientImpl implements BazelClient {
         return sourceFileTargets;
     }
 
-    private Map<String, BazelSourceFileTarget> processBazelSourcefileTargets(List<Build.Target> targets, Boolean readSourcefileTargets) throws IOException, NoSuchAlgorithmException {
-        Map<String, BazelSourceFileTarget> sourceTargets = new HashMap<>();
-        for (Build.Target target : targets) {
-            Build.SourceFile sourceFile = target.getSourceFile();
-            if (sourceFile != null) {
-                MessageDigest digest = MessageDigest.getInstance("SHA-256");
-                digest.update(sourceFile.getNameBytes().toByteArray());
-                for (String subinclude : sourceFile.getSubincludeList()) {
-                    digest.update(subinclude.getBytes());
-                }
-                BazelSourceFileTargetImpl sourceFileTarget = new BazelSourceFileTargetImpl(
-                        sourceFile.getName(),
-                        digest.digest().clone(),
-                        readSourcefileTargets ? workingDirectory : null,
-                        verbose
-                );
-                sourceTargets.put(sourceFileTarget.getName(), sourceFileTarget);
-            }
+    private Map<String, BazelSourceFileTarget> processBazelSourcefileTargets(List<Build.Target> targets, Boolean readSourcefileTargets) throws Exception {
+        AtomicReference<Exception> exception = new AtomicReference(null);
+        Map<String, BazelSourceFileTarget> result = targets.parallelStream().map((target -> {
+                    Build.SourceFile sourceFile = target.getSourceFile();
+                    if (sourceFile != null) {
+                        Hasher hasher = Hashing.sha256().newHasher();
+                        hasher.putBytes(sourceFile.getNameBytes().toByteArray());
+                        for (String subinclude : sourceFile.getSubincludeList()) {
+                            hasher.putBytes(subinclude.getBytes());
+                        }
+                        BazelSourceFileTargetImpl sourceFileTarget = null;
+                        try {
+                            sourceFileTarget = new BazelSourceFileTargetImpl(
+                                    sourceFile.getName(),
+                                    hasher.hash().asBytes().clone(),
+                                    readSourcefileTargets ? workingDirectory : null,
+                                    verbose
+                            );
+                        } catch (Exception e) {
+                            exception.set(e);
+                        }
+                        return new SourceTargetEntry(sourceFileTarget.getName(), sourceFileTarget);
+                    }
+                    return null;
+                }))
+                .filter(pair -> pair != null)
+                .collect(Collectors.toMap(SourceTargetEntry::getKey, SourceTargetEntry::getValue));
+
+        //Rethrowing nested parallel exception
+        Exception nestedException = exception.get();
+        if (nestedException != null) {
+            throw nestedException;
         }
-        return sourceTargets;
+
+        return result;
+    }
+
+    private static class SourceTargetEntry<K extends String, V extends BazelSourceFileTargetImpl> {
+        private K key;
+        private V value;
+
+        public SourceTargetEntry(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public K getKey() {
+            return key;
+        }
+
+        public V getValue() {
+            return value;
+        }
     }
 
     private List<Build.Target> performBazelQuery(String query) throws IOException {
@@ -129,6 +163,7 @@ class BazelClientImpl implements BazelClient {
         BufferedReader stdError = new BufferedReader(new InputStreamReader(process.getErrorStream()));
         Thread tStdError = new Thread(new Runnable() {
             String line = null;
+
             public void run() {
                 try {
                     while ((line = stdError.readLine()) != null) {
@@ -136,11 +171,12 @@ class BazelClientImpl implements BazelClient {
                             System.out.println(line);
                         }
 
-                        if(Thread.currentThread().isInterrupted()) {
+                        if (Thread.currentThread().isInterrupted()) {
                             return;
                         }
                     }
-                } catch(IOException e) {}
+                } catch (IOException e) {
+                }
             }
         });
         tStdError.start();

--- a/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
+++ b/src/main/java/com/bazel_diff/BazelSourceFileTarget.java
@@ -1,13 +1,12 @@
 package com.bazel_diff;
 
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+
 import java.io.*;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.io.IOException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 
 interface BazelSourceFileTarget {
     String getName();
@@ -17,51 +16,40 @@ interface BazelSourceFileTarget {
 class BazelSourceFileTargetImpl implements BazelSourceFileTarget {
     private String name;
     private byte[] digest;
+    static private ByteBufferPool pool = new ByteBufferPool(1024, 10240); //10kb
 
-    private void digestLargeFile(MessageDigest finalDigest, FileChannel inChannel) throws IOException {
-        int bufferSize = 10240; // 10kb
-        ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
-        while (inChannel.read(buffer) != -1) {
+    private void digest(Hasher finalDigest, InputStream stream) throws Exception {
+        ByteBuffer buffer = pool.borrow();
+        byte[] array = buffer.array(); //Available for non-direct buffers
+        Integer length = 0;
+        while (true) {
+            if (!((length = stream.read(array)) != -1)) break;
             buffer.flip();
-            finalDigest.update(buffer);
+            finalDigest.putBytes(array, 0, length);
             buffer.clear();
         }
+        pool.recycle(buffer);
     }
 
-    private void digestSmallFile(MessageDigest finalDigest, FileChannel inChannel) throws IOException {
-        long fileSize = inChannel.size();
-        ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
-        inChannel.read(buffer);
-        buffer.flip();
-        finalDigest.update(buffer);
-    }
-
-    BazelSourceFileTargetImpl(String name, byte[] digest, Path workingDirectory, Boolean verbose)
-        throws IOException, NoSuchAlgorithmException {
+    BazelSourceFileTargetImpl(String name, byte[] digest, Path workingDirectory, Boolean verbose) throws Exception {
         this.name = name;
-        MessageDigest finalDigest = MessageDigest.getInstance("SHA-256");
+        Hasher hasher = Hashing.sha256().newHasher();
         if (workingDirectory != null && name.startsWith("//")) {
             String filenameSubstring = name.substring(2);
             String filenamePath = filenameSubstring.replaceFirst(":", "/");
             Path absoluteFilePath = Paths.get(workingDirectory.toString(), filenamePath);
-            try (RandomAccessFile sourceFile = new RandomAccessFile(absoluteFilePath.toString(), "r")) {
-                FileChannel inChannel = sourceFile.getChannel();
-                if (inChannel.size() > 1048576) { // 1mb
-                    digestLargeFile(finalDigest, inChannel);
-                } else {
-                    digestSmallFile(finalDigest, inChannel);
-                }
-                sourceFile.close();
-                inChannel.close();
+
+            try (InputStream stream = new BufferedInputStream(new FileInputStream(absoluteFilePath.toString()))) {
+                digest(hasher, stream);
             } catch (FileNotFoundException e) {
                 if (verbose) {
                     System.out.printf("BazelDiff: [Warning] file %s not found%n", absoluteFilePath);
                 }
             }
         }
-        finalDigest.update(digest);
-        finalDigest.update(name.getBytes());
-        this.digest = finalDigest.digest();
+        hasher.putBytes(digest);
+        hasher.putBytes(name.getBytes());
+        this.digest = hasher.hash().asBytes();
     }
 
     @Override

--- a/src/main/java/com/bazel_diff/ByteBufferPool.java
+++ b/src/main/java/com/bazel_diff/ByteBufferPool.java
@@ -1,0 +1,67 @@
+package com.bazel_diff;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+import java.nio.ByteBuffer;
+
+public class ByteBufferPool {
+    private Integer poolSize;
+    private Integer bufferSize;
+    private Supplier<GenericObjectPool<ByteBuffer>> delegate = Suppliers.memoize(() -> {
+        GenericObjectPoolConfig<ByteBuffer> config = new GenericObjectPoolConfig<>();
+        config.setMaxTotal(poolSize);
+        return new GenericObjectPool(new ByteBufferObjectFactory(bufferSize), config);
+    });
+
+    public ByteBufferPool(Integer poolSize, Integer bufferSize) {
+        this.poolSize = poolSize;
+        this.bufferSize = bufferSize;
+    }
+
+    public ByteBuffer borrow() throws Exception {
+        return delegate.get().borrowObject();
+    }
+
+    public void recycle(ByteBuffer buffer) {
+        delegate.get().returnObject(buffer);
+    }
+}
+
+class ByteBufferObjectFactory implements PooledObjectFactory<ByteBuffer> {
+    private Integer bufferSize;
+
+    public ByteBufferObjectFactory(Integer bufferSize) {
+        this.bufferSize = bufferSize;
+    }
+
+    @Override
+    public void activateObject(PooledObject<ByteBuffer> p) throws Exception {
+        p.getObject().clear();
+    }
+
+    @Override
+    public void destroyObject(PooledObject<ByteBuffer> p) throws Exception {
+        p.getObject().clear();
+    }
+
+    @Override
+    public PooledObject<ByteBuffer> makeObject() throws Exception {
+        return new DefaultPooledObject(ByteBuffer.allocate(bufferSize));
+    }
+
+    @Override
+    public void passivateObject(PooledObject<ByteBuffer> p) throws Exception {
+        p.getObject().clear();
+    }
+
+    @Override
+    public boolean validateObject(PooledObject<ByteBuffer> p) {
+        return p.getObject().capacity() == bufferSize && !p.getObject().isDirect();
+    }
+}

--- a/src/main/java/com/bazel_diff/main.java
+++ b/src/main/java/com/bazel_diff/main.java
@@ -69,7 +69,7 @@ class GenerateHashes implements Callable<Integer> {
                 System.out.printf("BazelDiff: Generate-hashes command finishes in %d seconds%n", generateHashSeconds);
             }
             return ExitCode.OK;
-        } catch (IOException | NoSuchAlgorithmException e) {
+        } catch (Exception e) {
             e.printStackTrace();
             return ExitCode.SOFTWARE;
         }

--- a/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -42,10 +42,8 @@ public class TargetHashingClientImplTests {
         try {
             Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
             assertEquals(hash.size(), 0);
-        } catch (IOException e) {
-            assertTrue(false);
-        } catch (NoSuchAlgorithmException e) {
-            assertTrue(false);
+        } catch (Exception e) {
+            fail(e.getMessage());
         }
     }
 
@@ -58,7 +56,7 @@ public class TargetHashingClientImplTests {
             assertEquals(2, hash.size());
             assertEquals("2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775", hash.get("rule1"));
             assertEquals("bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9", hash.get("rule2"));
-        } catch (IOException | NoSuchAlgorithmException e) {
+        } catch (Exception e) {
             fail(e.getMessage());
         }
     }
@@ -75,7 +73,7 @@ public class TargetHashingClientImplTests {
             assertEquals(2, hash.size());
             assertEquals("0404d80eadcc2dbfe9f0d7935086e1115344a06bd76d4e16af0dfd7b4913ee60", hash.get("rule1"));
             assertEquals("6fe63fa16340d18176e6d6021972c65413441b72135247179362763508ebddfe", hash.get("rule2"));
-        } catch (IOException | NoSuchAlgorithmException e) {
+        } catch (Exception e) {
             fail(e.getMessage());
         }
     }
@@ -97,7 +95,7 @@ public class TargetHashingClientImplTests {
             assertEquals("bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9", hash.get("rule2"));
             assertEquals("87dd050f1ca0f684f37970092ff6a02677d995718b5a05461706c0f41ffd4915", hash.get("rule3"));
             assertEquals("a7bc5d23cd98c4942dc879c649eb9646e38eddd773f9c7996fa0d96048cf63dc", hash.get("rule4"));
-        } catch (IOException | NoSuchAlgorithmException e) {
+        } catch (Exception e) {
             fail(e.getMessage());
         }
     }
@@ -117,7 +115,7 @@ public class TargetHashingClientImplTests {
             Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
             assertEquals(4, hash.size());
             assertEquals("bf15e616e870aaacb02493ea0b8e90c6c750c266fa26375e22b30b78954ee523", hash.get("rule4"));
-        } catch (IOException | NoSuchAlgorithmException e) {
+        } catch (Exception e) {
             fail(e.getMessage());
         }
     }
@@ -140,7 +138,7 @@ public class TargetHashingClientImplTests {
             Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
             assertEquals(3, hash.size());
             oldHash = hash.get("rule3");
-        } catch (IOException | NoSuchAlgorithmException e) {
+        } catch (Exception e) {
             fail(e.getMessage());
         }
 
@@ -149,11 +147,30 @@ public class TargetHashingClientImplTests {
             Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
             assertEquals(3, hash.size());
             newHash = hash.get("rule3");
-        } catch (IOException | NoSuchAlgorithmException e) {
+        } catch (Exception e) {
             fail(e.getMessage());
         }
 
         assertNotEquals(oldHash, newHash);
+    }
+
+    @Test
+    public void TestImpactedTargets() {
+        TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
+        try {
+            Map<String, String> start = new HashMap<>();
+            start.put("1", "a");
+            start.put("2", "b");
+            Map<String, String> end = new HashMap<>();
+            end.put("1", "c");
+            end.put("2", "b");
+            end.put("3", "d");
+            Set<String> impacted = client.getImpactedTargets(start, end);
+            assertEquals(2, impacted.size());
+            assertArrayEquals(new String[] {"1", "3"}, impacted.toArray());
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
     }
 
     private BazelTarget createRuleTarget(String ruleName, List<String> ruleInputs, String ruleDigest) throws NoSuchAlgorithmException {


### PR DESCRIPTION
Changes:
* Use ByteBufferPool for effective pooling of memory for file hashing
* Use parallelStream() to speed up IO operations for file hashing
* Use Maps.difference from guava for getImpactedTargets instead of iterating over maps

Notes:
* The exceptions handling changed a bit since parallelStream hides exceptions
* I manually tested only generate-hashes but added a unit test to verify the behaviour of impacted targets since there are 0 tests for that functionality
* I tested on a large sample repo and the result is the same semantically, but since parallelisation changes the order of iterating over entries, the output JSON doesn't match byte-to-byte, but the entries are exactly the same just shuffled a bit