### PR TITLE
fix(generate-hashes): fix infrequent NPE

### DIFF
--- a/src/main/java/com/bazel_diff/BazelTarget.java
+++ b/src/main/java/com/bazel_diff/BazelTarget.java
@@ -4,12 +4,20 @@ import com.google.devtools.build.lib.query2.proto.proto2api.Build;
 
 interface BazelTarget {
     boolean hasRule();
+
     BazelRule getRule();
+
     boolean hasSourceFile();
+
     String getSourceFileName();
+
     boolean hasGeneratedFile();
+
     String getGeneratedFileName();
+
     String getGeneratingRuleName();
+
+    TargetType getType();
 }
 
 class BazelTargetImpl implements BazelTarget {
@@ -22,6 +30,23 @@ class BazelTargetImpl implements BazelTarget {
     @Override
     public boolean hasRule() {
         return target.hasRule();
+    }
+
+    public TargetType getType() {
+        switch (target.getType()) {
+            case RULE:
+                return TargetType.RULE;
+            case SOURCE_FILE:
+                return TargetType.SOURCE_FILE;
+            case GENERATED_FILE:
+                return TargetType.GENERATED_FILE;
+            case PACKAGE_GROUP:
+                return TargetType.PACKAGE_GROUP;
+            case ENVIRONMENT_GROUP:
+                return TargetType.ENVIRONMENT_GROUP;
+            default:
+                return TargetType.UNKNOWN;
+        }
     }
 
     @Override
@@ -66,4 +91,3 @@ class BazelTargetImpl implements BazelTarget {
         return null;
     }
 }
-

--- a/src/main/java/com/bazel_diff/TargetType.java
+++ b/src/main/java/com/bazel_diff/TargetType.java
@@ -1,0 +1,10 @@
+package com.bazel_diff;
+
+public enum TargetType {
+    RULE,
+    SOURCE_FILE,
+    GENERATED_FILE,
+    PACKAGE_GROUP,
+    ENVIRONMENT_GROUP,
+    UNKNOWN,
+}

--- a/test/java/com/bazel_diff/TargetHashingClientImplTests.java
+++ b/test/java/com/bazel_diff/TargetHashingClientImplTests.java
@@ -121,7 +121,7 @@ public class TargetHashingClientImplTests {
     }
 
     @Test
-    public void HashAllBazelTargets_generatedTargets() throws IOException, NoSuchAlgorithmException {
+    public void HashAllBazelTargets_generatedTargets() throws Exception {
         BazelTarget generator = createRuleTarget("rule1", new ArrayList<String>(), "rule1Digest");
         BazelTarget target = createGeneratedTarget("rule0", "rule1");
 
@@ -134,22 +134,14 @@ public class TargetHashingClientImplTests {
 
         when(bazelClientMock.queryAllTargets()).thenReturn(Arrays.asList(rule3, target, generator));
         TargetHashingClientImpl client = new TargetHashingClientImpl(bazelClientMock, filesClientMock);
-        try {
-            Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
-            assertEquals(3, hash.size());
-            oldHash = hash.get("rule3");
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
+        Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
+        assertEquals(3, hash.size());
+        oldHash = hash.get("rule3");
 
         when(generator.getRule().getDigest()).thenReturn("newDigest".getBytes());
-        try {
-            Map<String, String> hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
-            assertEquals(3, hash.size());
-            newHash = hash.get("rule3");
-        } catch (Exception e) {
-            fail(e.getMessage());
-        }
+        hash = client.hashAllBazelTargetsAndSourcefiles(new HashSet<>());
+        assertEquals(3, hash.size());
+        newHash = hash.get("rule3");
 
         assertNotEquals(oldHash, newHash);
     }
@@ -167,7 +159,7 @@ public class TargetHashingClientImplTests {
             end.put("3", "d");
             Set<String> impacted = client.getImpactedTargets(start, end);
             assertEquals(2, impacted.size());
-            assertArrayEquals(new String[] {"1", "3"}, impacted.toArray());
+            assertArrayEquals(new String[]{"1", "3"}, impacted.toArray());
         } catch (Exception e) {
             fail(e.getMessage());
         }


### PR DESCRIPTION
There is an edge-case where the rules are depending on each other's digests, but they're hashed in parallel, so threads will not see the result of a previous hashing iteration. To overcome this we synchronise access using ConcurrentHashMap for the ruleHashes