### PR TITLE
throw a BazelQueryException on a failed bazel query

### DIFF
--- a/src/main/java/com/bazel_diff/BazelQueryException.java
+++ b/src/main/java/com/bazel_diff/BazelQueryException.java
@@ -1,0 +1,9 @@
+package com.bazel_diff;
+
+public class BazelQueryException extends Exception {
+
+  public BazelQueryException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/com/bazel_diff/TargetHashingClient.java
+++ b/src/main/java/com/bazel_diff/TargetHashingClient.java
@@ -170,7 +170,7 @@ class TargetHashingClientImpl implements TargetHashingClient {
         return null;
     }
 
-    private Map<String, String> hashAllTargets(byte[] seedHash, Map<String, BazelSourceFileTarget> bazelSourcefileTargets) throws IOException {
+    private Map<String, String> hashAllTargets(byte[] seedHash, Map<String, BazelSourceFileTarget> bazelSourcefileTargets) throws IOException, BazelQueryException {
         List<BazelTarget> allTargets = bazelClient.queryAllTargets();
         Map<String, byte[]> ruleHashes = new HashMap<>();
         Map<String, BazelRule> allRulesMap = new HashMap<>();


### PR DESCRIPTION
currently, a failed `bazel query` doesn't stop `bazel-diff`
the query runs and `bazel-diff` exits with code 0 when complete
this occurs with or without `--keep_going="false"`

to reproduce: make a syntax error in `BUILD.bazel` file and generate-hashes on the workspace

this adds a new exception which is thrown if `bazel query` exits with non-zero exit code