### PR TITLE
Only log not found warning if not found

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/hash/SourceFileHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/SourceFileHasher.kt
@@ -45,8 +45,10 @@ class SourceFileHasher : KoinComponent {
                 } else {
                     val absoluteFilePath = Paths.get(workingDirectory.toString(), filenamePath)
                     val file = absoluteFilePath.toFile()
-                    if (file.exists() && file.isFile) {
-                        putFile(file)
+                    if (file.exists()) {
+                        if (file.isFile) {
+                            putFile(file)
+                        }
                     } else {
                         logger.w { "File $absoluteFilePath not found" }
                     }


### PR DESCRIPTION
We should only log if the file does not
actually exist