### PR TITLE
fix: stackoverflow on circular dependencies

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/hash/RuleHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/RuleHasher.kt
@@ -3,6 +3,7 @@ package com.bazel_diff.hash
 import com.bazel_diff.bazel.BazelRule
 import com.bazel_diff.bazel.BazelSourceFileTarget
 import com.bazel_diff.log.Logger
+import com.google.common.annotations.VisibleForTesting
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.concurrent.ConcurrentMap
@@ -10,6 +11,7 @@ import java.util.concurrent.ConcurrentMap
 class RuleHasher : KoinComponent {
     private val logger: Logger by inject()
     private val sourceFileHasher: SourceFileHasher by inject()
+    @VisibleForTesting
     class CircularDependencyException(message: String) : Exception(message)
 
 

--- a/cli/src/main/kotlin/com/bazel_diff/hash/RuleHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/RuleHasher.kt
@@ -10,14 +10,30 @@ import java.util.concurrent.ConcurrentMap
 class RuleHasher : KoinComponent {
     private val logger: Logger by inject()
     private val sourceFileHasher: SourceFileHasher by inject()
+    private class CircularDependencyException(message: String) : Exception(message)
+
+
+    private fun raiseCircularDependency(depPath: LinkedHashSet<String>, begin: String): CircularDependencyException {
+        val sb = StringBuilder().appendLine("Circular dependency detected: ").append(begin).append(" -> ")
+        val circularPath = depPath.toList().takeLastWhile { it != begin }
+        circularPath.forEach { sb.append(it).append(" -> ") }
+        sb.append(begin)
+        return CircularDependencyException(sb.toString())
+    }
 
     fun digest(
         rule: BazelRule,
         allRulesMap: Map<String, BazelRule>,
         ruleHashes: ConcurrentMap<String, ByteArray>,
         sourceDigests: ConcurrentMap<String, ByteArray>,
-        seedHash: ByteArray?
+        seedHash: ByteArray?,
+        depPath: LinkedHashSet<String>?
     ): ByteArray {
+        val depPathClone = if (depPath != null) LinkedHashSet(depPath) else LinkedHashSet()
+        if (depPathClone.contains(rule.name)) {
+            throw raiseCircularDependency(depPathClone, rule.name)
+        }
+        depPathClone.add(rule.name)
         ruleHashes[rule.name]?.let { return it }
 
         val finalHashValue = sha256 {
@@ -38,7 +54,8 @@ class RuleHasher : KoinComponent {
                             allRulesMap,
                             ruleHashes,
                             sourceDigests,
-                            seedHash
+                            seedHash,
+                            depPathClone,
                         )
                         safePutBytes(ruleInputHash)
                     }

--- a/cli/src/main/kotlin/com/bazel_diff/hash/RuleHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/RuleHasher.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentMap
 class RuleHasher : KoinComponent {
     private val logger: Logger by inject()
     private val sourceFileHasher: SourceFileHasher by inject()
-    private class CircularDependencyException(message: String) : Exception(message)
+    class CircularDependencyException(message: String) : Exception(message)
 
 
     private fun raiseCircularDependency(depPath: LinkedHashSet<String>, begin: String): CircularDependencyException {

--- a/cli/src/main/kotlin/com/bazel_diff/hash/TargetHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/TargetHasher.kt
@@ -29,12 +29,13 @@ class TargetHasher : KoinComponent {
                         allRulesMap,
                         ruleHashes,
                         sourceDigests,
-                        seedHash
+                        seedHash,
+                        depPath = null
                     )
                 }
             }
             is BazelTarget.Rule -> {
-                ruleHasher.digest(target.rule, allRulesMap, ruleHashes, sourceDigests, seedHash)
+                ruleHasher.digest(target.rule, allRulesMap, ruleHashes, sourceDigests, seedHash, depPath = null)
             }
             is BazelTarget.SourceFile -> sha256 {
                 safePutBytes(sourceDigests[target.sourceFileName])


### PR DESCRIPTION
Exception will be thrown when circular exception is detected