### PR TITLE
Avoid warning logs when verbose is disabled

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/log/StdoutLogger.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/log/StdoutLogger.kt
@@ -18,7 +18,9 @@ class StdoutLogger(private val verbose: Boolean) : Logger {
     }
 
     override fun w(block: () -> String) {
-        println("[Warning] ${block.invoke()}")
+        if (verbose) {
+            println("[Warning] ${block.invoke()}")
+        }
     }
 
     override fun i(block: () -> String) {


### PR DESCRIPTION
Warning logs should only be emitted when
`verbose` mode is set

Fixes Add ability to disable warnings #139