### PR TITLE
Fix .jar download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ bazel run //:bazel-diff
 ### Run Via JAR Release
 
 ```terminal
-curl -LO bazel-diff.jar GITHUB_RELEASE_JAR_URL
+curl -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar
 java -jar bazel-diff.jar -h
 ```
 


### PR DESCRIPTION
https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar will always point to the latest release.

Also, the `-O/--remote-name` option means "Write output to a local file named like the remote file we get.".
I think what was intended here is actually `-o/--output <file>` ("Write  output  to <file> instead of stdout")