### PR TITLE
Make some command line parameters and options optional

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -34,9 +34,9 @@ class GenerateHashesCommand : Callable<Int> {
 
     @CommandLine.Option(
         names = ["-b", "--bazelPath"],
-        description = ["Path to Bazel binary"],
+        description = ["Path to Bazel binary. If not specified, the Bazel binary available in PATH will be used."],
         scope = CommandLine.ScopeType.INHERIT,
-        required = true,
+        defaultValue = "bazel",
     )
     lateinit var bazelPath: Path
 

--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -80,7 +80,8 @@ class GenerateHashesCommand : Callable<Int> {
 
     @CommandLine.Parameters(
         index = "0",
-        description = ["The filepath to write the resulting JSON of dictionary target => SHA-256 values"]
+        description = ["The filepath to write the resulting JSON of dictionary target => SHA-256 values. If not specified, the JSON will be written to STDOUT."],
+        defaultValue = CommandLine.Parameters.NULL_VALUE
     )
     var outputPath: File? = null
 
@@ -88,7 +89,6 @@ class GenerateHashesCommand : Callable<Int> {
     lateinit var spec: CommandLine.Model.CommandSpec
 
     override fun call(): Int {
-        val output = validateOutput(outputPath)
         validate(contentHashPath=contentHashPath)
 
         startKoin {
@@ -106,17 +106,10 @@ class GenerateHashesCommand : Callable<Int> {
             )
         }
 
-        return when (GenerateHashesInteractor().execute(seedFilepaths, output)) {
+        return when (GenerateHashesInteractor().execute(seedFilepaths, outputPath)) {
             true -> CommandLine.ExitCode.OK
             false -> CommandLine.ExitCode.SOFTWARE
         }.also { stopKoin() }
-    }
-
-    private fun validateOutput(output: File?): File {
-        return output ?: throw CommandLine.ParameterException(
-            spec.commandLine(),
-            "No output path specified."
-        )
     }
 
     private fun validate(contentHashPath: File?) {

--- a/cli/src/main/kotlin/com/bazel_diff/interactor/GenerateHashesInteractor.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/interactor/GenerateHashesInteractor.kt
@@ -7,6 +7,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.BufferedReader
 import java.io.File
+import java.io.FileDescriptor
 import java.io.FileReader
 import java.io.FileWriter
 import java.nio.file.Path
@@ -19,7 +20,7 @@ class GenerateHashesInteractor : KoinComponent {
     private val gson: Gson by inject()
 
     @OptIn(ExperimentalTime::class)
-    fun execute(seedFilepaths: File?, outputPath: File): Boolean {
+    fun execute(seedFilepaths: File?, outputPath: File?): Boolean {
         return try {
             val duration = measureTime {
                 var seedFilepathsSet: Set<Path> = when {
@@ -33,7 +34,10 @@ class GenerateHashesInteractor : KoinComponent {
                     else -> emptySet()
                 }
                 val hashes = buildGraphHasher.hashAllBazelTargetsAndSourcefiles(seedFilepathsSet)
-                FileWriter(outputPath).use {
+                when (outputPath) {
+                    null -> FileWriter(FileDescriptor.out)
+                    else -> FileWriter(outputPath)
+                }.use {
                     it.write(gson.toJson(hashes))
                 }
             }


### PR DESCRIPTION
1. Make the `outputPath` parameter of the `generate-hashes` command optional. If it's not specified, the JSON will be written to STDOUT.
2. Make the `-o|--output` option of the `get-impacted-targets` command optional. If it's not specified, the targets will be written to STDOUT.
3. Make the `-b|--bazelPath` option optional. If it's not specified, the Bazel binary available in `PATH` will be used.

Why this may be useful:
1. Being able to output to STDOUT makes piped processing of the generated results easier. See https://github.com/Tinder/bazel-diff/issues/154 for reference.
2. The `bazel` binary available in `PATH` looks like a sensible default. It will simplify/shorten the resulting `bazel-diff` commands in some/most cases.