### PR TITLE
Fix for Kotlin breaking time api changes

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -5,18 +5,18 @@ import com.google.devtools.build.lib.query2.proto.proto2api.Build
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.concurrent.ConcurrentMap
-import kotlin.time.ExperimentalTime
-import kotlin.time.measureTimedValue
+import kotlin.system.measureTimeMillis
+import java.util.Calendar;
 
 class BazelClient : KoinComponent {
     private val logger: Logger by inject()
     private val queryService: BazelQueryService by inject()
 
-    @OptIn(ExperimentalTime::class)
     suspend fun queryAllTargets(): List<BazelTarget> {
-        val (targets, queryDuration) = measureTimedValue {
-            queryService.query("'//external:all-targets' + '//...:all-targets'")
-        }
+        var calendar = Calendar.getInstance();
+        val queryEpoch = calendar.getTimeInMillis()
+        val targets = queryService.query("'//external:all-targets' + '//...:all-targets'")
+        val queryDuration = calendar.getTimeInMillis() - queryEpoch
         logger.i { "All targets queried in $queryDuration" }
         return targets.mapNotNull { target: Build.Target ->
             when (target.type) {
@@ -35,11 +35,11 @@ class BazelClient : KoinComponent {
         }
     }
 
-    @OptIn(ExperimentalTime::class)
     suspend fun queryAllSourcefileTargets(): List<Build.Target> {
-        val (targets, queryDuration) = measureTimedValue {
-            queryService.query("kind('source file', //...:all-targets)")
-        }
+        var calendar = Calendar.getInstance();
+        val queryEpoch = calendar.getTimeInMillis()
+        val targets = queryService.query("kind('source file', //...:all-targets)")
+        val queryDuration = calendar.getTimeInMillis() - queryEpoch
         logger.i { "All source files queried in $queryDuration" }
 
         return targets

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -5,15 +5,14 @@ import com.google.devtools.build.lib.query2.proto.proto2api.Build
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.concurrent.ConcurrentMap
-import kotlin.system.measureTimeMillis
-import java.util.Calendar;
+import java.util.Calendar
 
 class BazelClient : KoinComponent {
     private val logger: Logger by inject()
     private val queryService: BazelQueryService by inject()
 
     suspend fun queryAllTargets(): List<BazelTarget> {
-        var calendar = Calendar.getInstance();
+        var calendar = Calendar.getInstance()
         val queryEpoch = calendar.getTimeInMillis()
         val targets = queryService.query("'//external:all-targets' + '//...:all-targets'")
         val queryDuration = calendar.getTimeInMillis() - queryEpoch
@@ -36,7 +35,7 @@ class BazelClient : KoinComponent {
     }
 
     suspend fun queryAllSourcefileTargets(): List<Build.Target> {
-        var calendar = Calendar.getInstance();
+        var calendar = Calendar.getInstance()
         val queryEpoch = calendar.getTimeInMillis()
         val targets = queryService.query("kind('source file', //...:all-targets)")
         val queryDuration = calendar.getTimeInMillis() - queryEpoch

--- a/cli/src/main/kotlin/com/bazel_diff/hash/BuildGraphHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/BuildGraphHasher.kt
@@ -19,8 +19,7 @@ import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.atomic.AtomicReference
 import java.util.stream.Collectors
 import kotlin.io.path.readBytes
-import kotlin.system.measureTimeMillis
-import java.util.Calendar;
+import java.util.Calendar
 
 class BuildGraphHasher(private val bazelClient: BazelClient) : KoinComponent {
     private val targetHasher: TargetHasher by inject()
@@ -44,7 +43,7 @@ class BuildGraphHasher(private val bazelClient: BazelClient) : KoinComponent {
              * Querying targets and source hashing is done in parallel
              */
             val sourceDigestsFuture = async(Dispatchers.IO) {
-                var calendar = Calendar.getInstance();
+                var calendar = Calendar.getInstance()
                 val sourceHashDurationEpoch = calendar.getTimeInMillis()
                 val sourceFileTargets = hashSourcefiles(sourceTargets)
                 val sourceHashDuration = calendar.getTimeInMillis() - sourceHashDurationEpoch

--- a/cli/src/main/kotlin/com/bazel_diff/hash/BuildGraphHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/BuildGraphHasher.kt
@@ -19,15 +19,14 @@ import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.atomic.AtomicReference
 import java.util.stream.Collectors
 import kotlin.io.path.readBytes
-import kotlin.time.ExperimentalTime
-import kotlin.time.measureTimedValue
+import kotlin.system.measureTimeMillis
+import java.util.Calendar;
 
 class BuildGraphHasher(private val bazelClient: BazelClient) : KoinComponent {
     private val targetHasher: TargetHasher by inject()
     private val sourceFileHasher: SourceFileHasher by inject()
     private val logger: Logger by inject()
 
-    @OptIn(ExperimentalTime::class)
     fun hashAllBazelTargetsAndSourcefiles(seedFilepaths: Set<Path> = emptySet()): Map<String, String> {
         /**
          * Bazel will lock parallel queries but this is still allowing us to hash source files while executing a parallel query
@@ -45,9 +44,10 @@ class BuildGraphHasher(private val bazelClient: BazelClient) : KoinComponent {
              * Querying targets and source hashing is done in parallel
              */
             val sourceDigestsFuture = async(Dispatchers.IO) {
-                val (sourceFileTargets, sourceHashDuration) = measureTimedValue {
-                    hashSourcefiles(sourceTargets)
-                }
+                var calendar = Calendar.getInstance();
+                val sourceHashDurationEpoch = calendar.getTimeInMillis()
+                val sourceFileTargets = hashSourcefiles(sourceTargets)
+                val sourceHashDuration = calendar.getTimeInMillis() - sourceHashDurationEpoch
                 logger.i { "Source file hashes calculated in $sourceHashDuration" }
                 sourceFileTargets
             }

--- a/cli/src/main/kotlin/com/bazel_diff/interactor/GenerateHashesInteractor.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/interactor/GenerateHashesInteractor.kt
@@ -11,18 +11,16 @@ import java.io.FileDescriptor
 import java.io.FileReader
 import java.io.FileWriter
 import java.nio.file.Path
-import kotlin.time.ExperimentalTime
-import kotlin.time.measureTime
+import kotlin.system.measureTimeMillis
 
 class GenerateHashesInteractor : KoinComponent {
     private val buildGraphHasher: BuildGraphHasher by inject()
     private val logger: Logger by inject()
     private val gson: Gson by inject()
 
-    @OptIn(ExperimentalTime::class)
     fun execute(seedFilepaths: File?, outputPath: File?): Boolean {
         return try {
-            val duration = measureTime {
+            val duration = measureTimeMillis {
                 var seedFilepathsSet: Set<Path> = when {
                     seedFilepaths != null -> {
                         BufferedReader(FileReader(seedFilepaths)).use {


### PR DESCRIPTION
Fixes issues that Kotlin upgrade
forced by breaking their own
timing functions (who knows why)

Fixes 4.2.0 release seems to be broken #159