### PR TITLE
Update README to point to the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 http_jar(
     name = "bazel_diff",
     urls = [
-        "https://github.com/Tinder/bazel-diff/releases/download/4.0.5/bazel-diff_deploy.jar",
+        "https://github.com/Tinder/bazel-diff/releases/download/4.3.0/bazel-diff_deploy.jar",
     ],
-    sha256 = "59f2a614f90b4c2a6c83f1e6146d8722dfaac3a1d8f42734dcbb6ccf373a1cbd",
+    sha256 = "9c4546623a8b9444c06370165ea79a897fcb9881573b18fa5c9ee5c8ba0867e2",
 )
 ```
 


### PR DESCRIPTION
ReadMe on the repository was still pointing to the old release.  
This MR attempts to update readMe to point to the latest release with the corresponding SHA256 so that developers don't have to worry about figuring out the latest SHA and makes integration of this tool easy. 