### PR TITLE
fix: Duration Reporting

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -12,10 +12,9 @@ class BazelClient : KoinComponent {
     private val queryService: BazelQueryService by inject()
 
     suspend fun queryAllTargets(): List<BazelTarget> {
-        var calendar = Calendar.getInstance()
-        val queryEpoch = calendar.getTimeInMillis()
+        val queryEpoch = Calendar.getInstance().getTimeInMillis()
         val targets = queryService.query("'//external:all-targets' + '//...:all-targets'")
-        val queryDuration = calendar.getTimeInMillis() - queryEpoch
+        val queryDuration = Calendar.getInstance().getTimeInMillis() - queryEpoch
         logger.i { "All targets queried in $queryDuration" }
         return targets.mapNotNull { target: Build.Target ->
             when (target.type) {
@@ -35,10 +34,9 @@ class BazelClient : KoinComponent {
     }
 
     suspend fun queryAllSourcefileTargets(): List<Build.Target> {
-        var calendar = Calendar.getInstance()
-        val queryEpoch = calendar.getTimeInMillis()
+        val queryEpoch = Calendar.getInstance().getTimeInMillis()
         val targets = queryService.query("kind('source file', //...:all-targets)")
-        val queryDuration = calendar.getTimeInMillis() - queryEpoch
+        val queryDuration = Calendar.getInstance().getTimeInMillis() - queryEpoch
         logger.i { "All source files queried in $queryDuration" }
 
         return targets

--- a/cli/src/main/kotlin/com/bazel_diff/hash/BuildGraphHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/BuildGraphHasher.kt
@@ -43,10 +43,9 @@ class BuildGraphHasher(private val bazelClient: BazelClient) : KoinComponent {
              * Querying targets and source hashing is done in parallel
              */
             val sourceDigestsFuture = async(Dispatchers.IO) {
-                var calendar = Calendar.getInstance()
-                val sourceHashDurationEpoch = calendar.getTimeInMillis()
+                val sourceHashDurationEpoch = Calendar.getInstance().getTimeInMillis()
                 val sourceFileTargets = hashSourcefiles(sourceTargets)
-                val sourceHashDuration = calendar.getTimeInMillis() - sourceHashDurationEpoch
+                val sourceHashDuration = Calendar.getInstance().getTimeInMillis() - sourceHashDurationEpoch
                 logger.i { "Source file hashes calculated in $sourceHashDuration" }
                 sourceFileTargets
             }

--- a/cli/src/main/kotlin/com/bazel_diff/interactor/GenerateHashesInteractor.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/interactor/GenerateHashesInteractor.kt
@@ -20,8 +20,7 @@ class GenerateHashesInteractor : KoinComponent {
 
     fun execute(seedFilepaths: File?, outputPath: File?): Boolean {
         return try {
-            var calendar = Calendar.getInstance()
-            val epoch = calendar.getTimeInMillis()
+            val epoch = Calendar.getInstance().getTimeInMillis()
             var seedFilepathsSet: Set<Path> = when {
                 seedFilepaths != null -> {
                     BufferedReader(FileReader(seedFilepaths)).use {
@@ -39,7 +38,7 @@ class GenerateHashesInteractor : KoinComponent {
             }.use {
                 it.write(gson.toJson(hashes))
             }
-            val duration = calendar.getTimeInMillis() - epoch;
+            val duration = Calendar.getInstance().getTimeInMillis() - epoch;
             logger.i { "generate-hashes finished in $duration" }
             true
         } catch (e: Exception) {


### PR DESCRIPTION
Reusing the same `Calendar` instance would report all durations as 0 milliseconds. Create a new Calendar instance for the start and end timestamps.