### PR TITLE
Fix computing external repo fine-grained hashes

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -38,7 +38,8 @@ class BazelClient(private val fineGrainedHashExternalRepos: Set<String>) : KoinC
 
     suspend fun queryAllSourcefileTargets(): List<Build.Target> {
         val queryEpoch = Calendar.getInstance().getTimeInMillis()
-        val targets = queryService.query("kind('source file', //...:all-targets)")
+        val allReposToQuery = listOf("@") + fineGrainedHashExternalRepos.map { "@$it" }
+        val targets = queryService.query("kind('source file', ${allReposToQuery.joinToString(" + ") { "'$it//...:all-targets'" }})")
         val queryDuration = Calendar.getInstance().getTimeInMillis() - queryEpoch
         logger.i { "All source files queried in $queryDuration" }
 

--- a/cli/src/main/kotlin/com/bazel_diff/hash/SourceFileHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/SourceFileHasher.kt
@@ -13,49 +13,69 @@ class SourceFileHasher : KoinComponent {
     private val workingDirectory: Path
     private val logger: Logger
     private val relativeFilenameToContentHash: Map<String, String>?
+    private val outputBase: Path
+    private val fineGrainedHashExternalRepos: Set<String>
+
     init {
         val logger: Logger by inject()
         this.logger = logger
     }
 
-    constructor() {
+    constructor(fineGrainedHashExternalRepos: Set<String> = emptySet()) {
         val workingDirectory: Path by inject(qualifier = named("working-directory"))
         this.workingDirectory = workingDirectory
         val contentHashProvider: ContentHashProvider by inject()
         relativeFilenameToContentHash = contentHashProvider.filenameToHash
+        val outputBase: Path by inject(qualifier = named("output-base"))
+        this.outputBase = outputBase
+        this.fineGrainedHashExternalRepos = fineGrainedHashExternalRepos
     }
 
-    constructor(workingDirectory: Path, relativeFilenameToContentHash: Map<String, String>?) {
+    constructor(workingDirectory: Path, outputBase: Path, relativeFilenameToContentHash: Map<String, String>?, fineGrainedHashExternalRepos: Set<String> = emptySet()) {
         this.workingDirectory = workingDirectory
+        this.outputBase = outputBase
         this.relativeFilenameToContentHash = relativeFilenameToContentHash
+        this.fineGrainedHashExternalRepos = fineGrainedHashExternalRepos
     }
 
     fun digest(sourceFileTarget: BazelSourceFileTarget): ByteArray {
         return sha256 {
             val name = sourceFileTarget.name
-            if (name.startsWith("//")) {
+            val filenamePath = if (name.startsWith("//")) {
                 val filenameSubstring = name.substring(2)
-                val filenamePath = filenameSubstring.replaceFirst(
-                        ":".toRegex(),
-                        if (filenameSubstring.startsWith(":")) "" else "/"
-                )
-                if (relativeFilenameToContentHash?.contains(filenamePath) == true) {
-                    val contentHash = relativeFilenameToContentHash.getValue(filenamePath)
-                    safePutBytes(contentHash.toByteArray())
-                } else {
-                    val absoluteFilePath = Paths.get(workingDirectory.toString(), filenamePath)
-                    val file = absoluteFilePath.toFile()
-                    if (file.exists()) {
-                        if (file.isFile) {
-                            putFile(file)
-                        }
-                    } else {
-                        logger.w { "File $absoluteFilePath not found" }
-                    }
+                Paths.get(filenameSubstring.removePrefix(":").replace(':', '/'))
+            } else if (name.startsWith("@")) {
+                val parts = name.substring(1).split("//")
+                if (parts.size != 2) {
+                    logger.w { "Invalid source label $name" }
+                    return@sha256
                 }
-                safePutBytes(sourceFileTarget.seed)
-                safePutBytes(name.toByteArray())
+                val repoName = parts[0]
+                if (repoName !in fineGrainedHashExternalRepos) {
+                    return@sha256
+                }
+                val relativePath = Paths.get(parts[1].removePrefix(":").replace(':', '/'))
+                outputBase.resolve("external/$repoName").resolve(relativePath)
+            } else {
+                return@sha256
             }
+            val filenamePathString = filenamePath.toString()
+            if (relativeFilenameToContentHash?.contains(filenamePathString) == true) {
+                val contentHash = relativeFilenameToContentHash.getValue(filenamePathString)
+                safePutBytes(contentHash.toByteArray())
+            } else {
+                val absoluteFilePath = workingDirectory.resolve(filenamePath)
+                val file = absoluteFilePath.toFile()
+                if (file.exists()) {
+                    if (file.isFile) {
+                        putFile(file)
+                    }
+                } else {
+                    logger.w { "File $absoluteFilePath not found" }
+                }
+            }
+            safePutBytes(sourceFileTarget.seed)
+            safePutBytes(name.toByteArray())
         }
     }
 

--- a/cli/src/test/kotlin/com/bazel_diff/Modules.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/Modules.kt
@@ -1,6 +1,7 @@
 package com.bazel_diff
 
 import com.bazel_diff.bazel.BazelClient
+import com.bazel_diff.bazel.BazelQueryService
 import com.bazel_diff.hash.BuildGraphHasher
 import com.bazel_diff.hash.RuleHasher
 import com.bazel_diff.hash.SourceFileHasher
@@ -22,6 +23,7 @@ fun testModule(): Module = module {
     single { SourceFileHasher() }
     single { GsonBuilder().setPrettyPrinting().create() }
     single(named("working-directory")) { Paths.get("working-directory") }
+    single(named("output-base")) { Paths.get("output-base") }
     single { ContentHashProvider(null) }
 }
 

--- a/cli/src/test/resources/fixture/fine-grained-hash-external-repo-test-impacted-targets.txt
+++ b/cli/src/test/resources/fixture/fine-grained-hash-external-repo-test-impacted-targets.txt
@@ -2,9 +2,12 @@
 //src/main/java/com/integration:guava-user
 //src/main/java/com/integration:libguava-user-src.jar
 //src/main/java/com/integration:libguava-user.jar
+@bazel_diff_maven//:BUILD
 @bazel_diff_maven//:com_google_errorprone_error_prone_annotations
 @bazel_diff_maven//:com_google_errorprone_error_prone_annotations_2_11_0
 @bazel_diff_maven//:com_google_guava_guava
 @bazel_diff_maven//:com_google_guava_guava_31_1_jre
+@bazel_diff_maven//:pin
+@bazel_diff_maven//:pin.sh
 @bazel_diff_maven//:v1/https/jcenter.bintray.com/com/google/errorprone/error_prone_annotations/2.11.0/error_prone_annotations-2.11.0.jar
 @bazel_diff_maven//:v1/https/jcenter.bintray.com/com/google/guava/guava/31.1-jre/guava-31.1-jre.jar


### PR DESCRIPTION
The previous implementation ignores any change of source files in external repos. That implementation works for maven_install because maven_install does not download any jars into that particular repo. But it does not work for cases when the external repo comes with sources/jars in itself.

We have such use cases internally in Pinterest though I am not aware of any such use cases in common open source world. I have tested this implementation with our internal repo and it seems to work as expected. Interestingly, the difference of introduced in this PR is also sort of captured by the e2e test.