### PR TITLE
Minor performance improvement with `--useCquery`

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
@@ -75,7 +75,10 @@ class BazelQueryService(
             addAll(startupOptions)
             if (useCquery) {
                 add("cquery")
-                add("--transitions=lite")
+                if (!outputCompatibleTargets) {
+                    // There is no need to query the transitions when querying for compatible targets.
+                    add("--transitions=lite")
+                }
             } else {
                 add("query")
             }


### PR DESCRIPTION
Computing transitions is slow and it's not necessary when trying to figure out list of compatible targets.