### PR TITLE
fix: patch the build to match with the release

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/cli/VersionProvider.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/VersionProvider.kt
@@ -4,6 +4,6 @@ import picocli.CommandLine.IVersionProvider
 
 class VersionProvider : IVersionProvider {
     override fun getVersion(): Array<String> {
-        return arrayOf("4.1.0")
+        return arrayOf("4.8.0")
     }
 }


### PR DESCRIPTION
looks like the version report is way off.

```
$ bazel-diff --version
4.1.0
```