### PR TITLE
feat(devex): Initialize Trunk, the universal linter/formatter

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,8 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,0 +1,10 @@
+# Autoformatter friendly markdownlint config (all formatting rules disabled)
+default: true
+blank_lines: false
+bullet: false
+html: false
+indentation: false
+line_length: false
+spaces: false
+url: false
+whitespace: false

--- a/.trunk/configs/.shellcheckrc
+++ b/.trunk/configs/.shellcheckrc
@@ -1,0 +1,7 @@
+enable=all
+source-path=SCRIPTDIR
+disable=SC2154
+
+# If you're having issues with shellcheck following source, disable the errors via:
+# disable=SC1090
+# disable=SC1091

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,0 +1,10 @@
+rules:
+  quoted-strings:
+    required: only-when-needed
+    extra-allowed: ["{|}"]
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
+  key-duplicates: {}
+  octal-values:
+    forbid-implicit-octal: true

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,28 @@
+version: 0.1
+cli:
+  version: 1.14.2
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.2.2
+      uri: https://github.com/trunk-io/plugins
+runtimes:
+  enabled:
+    - go@1.21.0
+    - java@13.0.11
+    - node@18.12.1
+    - python@3.10.8
+lint:
+  enabled:
+    - actionlint@1.6.25
+    - buildifier@6.3.3
+    - checkov@2.4.9
+    - git-diff-check
+    - ktlint@0.50.0
+    - markdownlint@0.35.0
+    - prettier@3.0.3
+    - shellcheck@0.9.0
+    - shfmt@3.6.0
+    - trivy@0.44.1
+    - trufflehog@3.54.0
+    - yamllint@1.32.0


### PR DESCRIPTION
Hi! I'm an engineer over at [Trunk.io](https://trunk.io); thanks for building out this awesome tool! We're using it to help power some our products (e.g. our [merge-action repo](https://github.com/trunk-io/merge-action)), as well as our internal CI. 

This PR initializes the Trunk linter/formatter in this repository. It's entirely config as code: the core of this is the `trunk.yaml`, which specifies the linters / formatters to be enabled. Trunk also offers:
- git hooks integration, so all remote branches follow the same uniform set of rules,
- cross-language linting and formatting (invoked by `trunk fmt`),
- tool version management,
- VSCode integration,
- git awareness: trunk will only check incremental diffs to the history of the repo,
- and more!

This PR was generated by [downloading](https://trunk.io/products/check) and running `trunk init` on the repository. If you're curious to learn more, check out [our docs](https://docs.trunk.io/check), or stop by our [Slack](slack.trunk.io).

Throwing this out here to see what you think! Thanks again for creating bazel-diff!