### PR TITLE
Add `--includTargetType` and `--targetType` options 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Commands:
 
 ```terminal
 Usage: bazel-diff generate-hashes [-hkvV] [--[no-]useCquery] [-b=<bazelPath>]
+                                  [--[no-]includeTargetType]
                                   [--contentHashPath=<contentHashPath>]
                                   [-s=<seedFilepaths>] -w=<workspacePath>
                                   [-co=<bazelCommandOptions>]...
@@ -92,10 +93,33 @@ Usage: bazel-diff generate-hashes [-hkvV] [--[no-]useCquery] [-b=<bazelPath>]
                                   [-so=<bazelStartupOptions>]... <outputPath>
 Writes to a file the SHA256 hashes for each Bazel Target in the provided
 workspace.
-      <outputPath>        The filepath to write the resulting JSON of
-                            dictionary target => SHA-256 values. If not
-                            specified, the JSON will be written to STDOUT.
-  -b, --bazelPath=<bazelPath>
+      <outputPath>        The filepath to write the resulting JSON to. 
+                            If not specified, the JSON will be written to STDOUT.
+                            
+                            By default the JSON schema is a dictionary of target => SHA-256 values. 
+                            Example:
+                                 {
+                                    "//cli:bazel-diff_deploy.jar":  "4ae310f8ad2bc728934e3509b6102ca658e828b9cd668f79990e95c6663f9633"
+                                    ...
+                                 }
+                            
+                            If --includeTargetType is specified, the JSON schema will include the target type (SourceFile/Rule/GeneratedFile)
+                            Example:
+                                {
+                                  "//cli:src/test/resources/fixture/integration-test-1.zip": "SourceFile#c259eba8539f4c14e4536c61975457c2990e090067893f4a2981e7bb5f4ef4cf",
+                                  "//external:android_gmaven_r8": "Rule#795f583449a40814c05e1cc5d833002afed8d12bce5b835579c7f139c2462d61",
+                                  "//cli:bazel-diff_deploy.jar": "GeneratedFile#4ae310f8ad2bc728934e3509b6102ca658e828b9cd668f79990e95c6663f9633",
+                                  ...
+                                }
+      ----[no-]includeTargetType
+                          Whether include target type in the generated JSON or not.
+                            If false, the generate JSON schema is: {"<target>": "<sha256>"}
+                            If true, the generate JSON schema is: {"<target>": "<type>#<sha256>" 
+      -tt, --targetType=<targetType>
+                          The type of targets to filter, available options are SourceFile/Rule/GeneratedFile
+                          Only works if the JSON was generated with `--includeTargetType` enabled.
+                          If not specified, all types of impacted targets will be returned.
+      -b, --bazelPath=<bazelPath>
                           Path to Bazel binary. If not specified, the Bazel
                             binary available in PATH will be used.
       -co, --bazelCommandOptions=<bazelCommandOptions>
@@ -157,7 +181,7 @@ See https://github.com/bazelbuild/bazel/issues/17743 for more details.
 ### What does the SHA256 value of `generate-hashes` represent?
 
 `generate-hashes` is a canonical SHA256 value representing all attributes and inputs into a target. These inputs
-are the summation of the of the rule implementation hash, the SHA256 value
+are the summation of the rule implementation hash, the SHA256 value
 for every attribute of the rule and then the summation of the SHA256 value for
 all `rule_inputs` using the same exact algorithm. For source_file inputs the
 content of the file are converted into a SHA256 value.
@@ -167,18 +191,24 @@ content of the file are converted into a SHA256 value.
 ```terminal
 Usage: bazel-diff get-impacted-targets [-v] -fh=<finalHashesJSONPath>
                                        -o=<outputPath>
+                                       -tt=<targetType>
                                        -sh=<startingHashesJSONPath>
 Command-line utility to analyze the state of the bazel build graph
       -fh, --finalHashes=<finalHashesJSONPath>
                   The path to the JSON file of target hashes for the final
                     revision. Run 'generate-hashes' to get this value.
-  -o, --output=<outputPath>
+      -o, --output=<outputPath>
                   Filepath to write the impacted Bazel targets to, newline
                     separated
       -sh, --startingHashes=<startingHashesJSONPath>
                   The path to the JSON file of target hashes for the initial
                     revision. Run 'generate-hashes' to get this value.
-  -v, --verbose   Display query string, missing files and elapsed time
+      -tt, --targetType=<targetType>
+                  The type of targets to filter, available options are SourceFile/Rule/GeneratedFile
+                  Only works if the JSON was generated with `--includeTargetType` enabled.
+                  If not specified, all types of impacted targets will be returned.
+      -v, --verbose   
+                  Display query string, missing files and elapsed time
 ```
 
 ## Installing

--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -82,6 +82,24 @@ class GenerateHashesCommand : Callable<Int> {
     var useCquery = false
 
     @CommandLine.Option(
+        names = ["--includeTargetType"],
+        negatable = true,
+        description = ["Whether include target type in the generated JSON or not.\n"
+            + "If false, the generate JSON schema is: {\"<target>\": \"<sha256>\"}\n"
+            + "If true, the generate JSON schema is: {\"<target>\": \"<type>#<sha256>\" }"],
+        scope = CommandLine.ScopeType.INHERIT
+    )
+    var includeTargetType = false
+
+    @CommandLine.Option(
+        names = ["-tt", "--targetType"],
+        split = ",",
+        scope = CommandLine.ScopeType.LOCAL,
+        description = ["The types of targets to filter. Use comma (,) to separate multiple values, e.g. '--targetType=SourceFile,Rule,GeneratedFile'."]
+    )
+    var targetType: Set<String>? = null
+
+    @CommandLine.Option(
         names = ["--cqueryCommandOptions"],
         description = ["Additional space separated Bazel command options used when invoking `bazel cquery`. This flag is has no effect if `--useCquery`is false."],
         scope = CommandLine.ScopeType.INHERIT,
@@ -142,7 +160,7 @@ class GenerateHashesCommand : Callable<Int> {
             )
         }
 
-        return when (GenerateHashesInteractor().execute(seedFilepaths, outputPath, ignoredRuleHashingAttributes)) {
+        return when (GenerateHashesInteractor().execute(seedFilepaths, outputPath, ignoredRuleHashingAttributes, targetType, includeTargetType)) {
             true -> CommandLine.ExitCode.OK
             false -> CommandLine.ExitCode.SOFTWARE
         }.also { stopKoin() }

--- a/cli/src/main/kotlin/com/bazel_diff/cli/GetImpactedTargetsCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GetImpactedTargetsCommand.kt
@@ -39,6 +39,14 @@ class GetImpactedTargetsCommand : Callable<Int> {
     lateinit var finalHashesJSONPath: File
 
     @CommandLine.Option(
+            names = ["-tt", "--targetType"],
+            split = ",",
+            scope = CommandLine.ScopeType.LOCAL,
+            description = ["The types of targets to filter. Use comma (,) to separate multiple values, e.g. '--targetType=SourceFile,Rule,GeneratedFile'."]
+    )
+    var targetType: Set<String>? = null
+
+    @CommandLine.Option(
         names = ["-o", "--output"],
         scope = CommandLine.ScopeType.LOCAL,
         description = ["Filepath to write the impacted Bazel targets to, newline separated. If not specified, the targets will be written to STDOUT."],
@@ -58,8 +66,8 @@ class GetImpactedTargetsCommand : Callable<Int> {
 
         validate()
         val deserialiser = DeserialiseHashesInteractor()
-        val from = deserialiser.execute(startingHashesJSONPath)
-        val to = deserialiser.execute(finalHashesJSONPath)
+        val from = deserialiser.execute(startingHashesJSONPath, targetType)
+        val to = deserialiser.execute(finalHashesJSONPath, targetType)
 
         val impactedTargets = CalculateImpactedTargetsInteractor().execute(from, to)
 
@@ -70,7 +78,7 @@ class GetImpactedTargetsCommand : Callable<Int> {
             }).use { writer ->
                 impactedTargets.forEach {
                     writer.write(it)
-                    //Should not be depend on OS
+                    //Should not depend on OS
                     writer.write("\n")
                 }
             }

--- a/cli/src/main/kotlin/com/bazel_diff/hash/BuildGraphHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/BuildGraphHasher.kt
@@ -21,11 +21,6 @@ import java.util.stream.Collectors
 import kotlin.io.path.readBytes
 import java.util.Calendar
 
-data class TargetHash(
-    val type: String,
-    val hash: String
-)
-
 class BuildGraphHasher(private val bazelClient: BazelClient) : KoinComponent {
     private val targetHasher: TargetHasher by inject()
     private val sourceFileHasher: SourceFileHasher by inject()

--- a/cli/src/main/kotlin/com/bazel_diff/hash/TargetHash.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/TargetHash.kt
@@ -1,0 +1,18 @@
+package com.bazel_diff.hash
+
+data class TargetHash(
+    val type: String, // Rule/GeneratedFile/SourceFile/...
+    val hash: String
+) {
+    val hashWithType by lazy {
+        "${type}#${hash}"
+    }
+
+    fun toJson(includeTargetType: Boolean): String {
+        return if (includeTargetType) {
+            hashWithType
+        } else {
+            hash
+        }
+    }
+}

--- a/cli/src/test/kotlin/com/bazel_diff/hash/BuildGraphHasherTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/hash/BuildGraphHasherTest.kt
@@ -73,8 +73,8 @@ class BuildGraphHasherTest : KoinTest {
 
         val hash = hasher.hashAllBazelTargetsAndSourcefiles()
         assertThat(hash).containsOnly(
-            "rule1" to "2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775",
-            "rule2" to "bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9",
+            "rule1" to TargetHash("Rule", "2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775"),
+            "rule2" to TargetHash("Rule", "bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9"),
         )
     }
 
@@ -86,8 +86,8 @@ class BuildGraphHasherTest : KoinTest {
         whenever(bazelClientMock.queryAllSourcefileTargets()).thenReturn(emptyList())
         val hash = hasher.hashAllBazelTargetsAndSourcefiles(seedFilepaths)
         assertThat(hash).containsOnly(
-            "rule1" to "0404d80eadcc2dbfe9f0d7935086e1115344a06bd76d4e16af0dfd7b4913ee60",
-            "rule2" to "6fe63fa16340d18176e6d6021972c65413441b72135247179362763508ebddfe",
+            "rule1" to TargetHash("Rule", "0404d80eadcc2dbfe9f0d7935086e1115344a06bd76d4e16af0dfd7b4913ee60"),
+            "rule2" to TargetHash("Rule", "6fe63fa16340d18176e6d6021972c65413441b72135247179362763508ebddfe"),
         )
     }
 
@@ -103,10 +103,10 @@ class BuildGraphHasherTest : KoinTest {
         whenever(bazelClientMock.queryAllSourcefileTargets()).thenReturn(emptyList())
         val hash = hasher.hashAllBazelTargetsAndSourcefiles()
         assertThat(hash).containsOnly(
-            "rule1" to "2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775",
-            "rule2" to "bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9",
-            "rule3" to "87dd050f1ca0f684f37970092ff6a02677d995718b5a05461706c0f41ffd4915",
-            "rule4" to "a7bc5d23cd98c4942dc879c649eb9646e38eddd773f9c7996fa0d96048cf63dc",
+            "rule1" to TargetHash("Rule", "2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775"),
+            "rule2" to TargetHash("Rule", "bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9"),
+            "rule3" to TargetHash("Rule", "87dd050f1ca0f684f37970092ff6a02677d995718b5a05461706c0f41ffd4915"),
+            "rule4" to TargetHash("Rule", "a7bc5d23cd98c4942dc879c649eb9646e38eddd773f9c7996fa0d96048cf63dc"),
         )
     }
 
@@ -122,10 +122,10 @@ class BuildGraphHasherTest : KoinTest {
         whenever(bazelClientMock.queryAllSourcefileTargets()).thenReturn(emptyList())
         val hash = hasher.hashAllBazelTargetsAndSourcefiles()
         assertThat(hash).containsOnly(
-            "rule1" to "2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775",
-            "rule2" to "bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9",
-            "rule3" to "ca2f970a5a5a18730d7633cc32b48b1d94679f4ccaea56c4924e1f9913bd9cb5",
-            "rule4" to "bf15e616e870aaacb02493ea0b8e90c6c750c266fa26375e22b30b78954ee523",
+            "rule1" to TargetHash("Rule", "2c963f7c06bc1cead7e3b4759e1472383d4469fc3238dc42f8848190887b4775"),
+            "rule2" to TargetHash("Rule", "bdc1abd0a07103cea34199a9c0d1020619136ff90fb88dcc3a8f873c811c1fe9"),
+            "rule3" to TargetHash("Rule", "ca2f970a5a5a18730d7633cc32b48b1d94679f4ccaea56c4924e1f9913bd9cb5"),
+            "rule4" to TargetHash("Rule", "bf15e616e870aaacb02493ea0b8e90c6c750c266fa26375e22b30b78954ee523"),
         )
     }
 

--- a/cli/src/test/kotlin/com/bazel_diff/interactor/DeserialiseHashesInteractorTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/interactor/DeserialiseHashesInteractorTest.kt
@@ -1,7 +1,10 @@
 package com.bazel_diff.interactor
 
 import assertk.assertThat
+import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.messageContains
 import com.bazel_diff.testModule
 import org.junit.Rule
 import org.junit.Test
@@ -22,15 +25,56 @@ class DeserialiseHashesInteractorTest : KoinTest {
     @get:Rule
     val temp: TemporaryFolder = TemporaryFolder()
 
+    val interactor = DeserialiseHashesInteractor()
+
     @Test
     fun testDeserialisation() {
         val file = temp.newFile().apply {
-            writeText("{\"target-name\":\"hash\"}")
+            writeText("""{"target-name":"hash"}""")
         }
 
-        val actual = DeserialiseHashesInteractor().execute(file)
+        val actual = interactor.execute(file)
         assertThat(actual).isEqualTo(mapOf(
             "target-name" to "hash"
+        ))
+    }
+
+    @Test
+    fun testDeserialisatingFileWithoutType() {
+        val file = temp.newFile().apply {
+            writeText("""{"target-name":"hash"}""")
+        }
+
+        assertThat { interactor.execute(file, setOf("Whatever"))}
+            .isFailure().apply {
+                messageContains("please re-generate the JSON with --includeTypeTarget!")
+                hasClass(IllegalStateException::class)
+            }
+    }
+
+    @Test
+    fun testDeserialisationWithType() {
+        val file = temp.newFile().apply {
+            writeText("""{
+                |  "target-1":"GeneratedFile#hash1", 
+                |  "target-2":"Rule#hash2",
+                |  "target-3":"SourceFile#hash3"
+                |}""".trimMargin())
+        }
+
+        assertThat(interactor.execute(file, null)).isEqualTo(mapOf(
+            "target-1" to "hash1",
+            "target-2" to "hash2",
+            "target-3" to "hash3"
+        ))
+        assertThat(interactor.execute(file, setOf("GeneratedFile"))).isEqualTo(mapOf(
+            "target-1" to "hash1"
+        ))
+        assertThat(interactor.execute(file, setOf("Rule"))).isEqualTo(mapOf(
+            "target-2" to "hash2"
+        ))
+        assertThat(interactor.execute(file, setOf("SourceFile"))).isEqualTo(mapOf(
+            "target-3" to "hash3"
         ))
     }
 }

--- a/cli/src/test/resources/fixture/impacted_targets-1-2-rule-sourcefile.txt
+++ b/cli/src/test/resources/fixture/impacted_targets-1-2-rule-sourcefile.txt
@@ -1,0 +1,3 @@
+//test/java/com/integration:bazel-diff-integration-test-lib
+//test/java/com/integration:bazel-diff-integration-tests
+//test/java/com/integration:TestStringGenerator.java


### PR DESCRIPTION
I'm aware that it's recommended to consume the generated impacted target list with `bazel query`, as suggested in https://github.com/Tinder/bazel-diff/issues/173 and https://github.com/Tinder/bazel-diff/issues/151. However, our use case is that we do want to avoid the extra 30-60s spent on `bazel query` (we have a huge workspace).

This PR adds a `--includeTargetType` option to `generate-hashes` command, which will add "target type" to the generated JSON like this:

```
{
  "//cli:src/test/resources/fixture/integration-test-1.zip": "SourceFile#c259eba8539f4c14e4536c61975457c2990e090067893f4a2981e7bb5f4ef4cf",
  "//external:android_gmaven_r8": "Rule#795f583449a40814c05e1cc5d833002afed8d12bce5b835579c7f139c2462d61",
  "//cli:bazel-diff_deploy.jar": "GeneratedFile#4ae310f8ad2bc728934e3509b6102ca658e828b9cd668f79990e95c6663f9633",
  ...
}
```

Later, an extra `--targetType=Rule` can be used in `get-impacted-targets` command to filter out the targets with specific type.

This may be not what you like, but it does help us a lot so I'm contributing this from our fork.

The tests are updated accordingly.