### PR TITLE
Fixes ignoredRuleHashingAttributes space args

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -132,7 +132,7 @@ class GenerateHashesCommand : Callable<Int> {
         names = ["--ignoredRuleHashingAttributes"],
         description = ["Attributes that should be ignored when hashing rule targets."],
         scope = CommandLine.ScopeType.INHERIT,
-        converter = [OptionsConverter::class],
+        converter = [CommaSeparatedValueConverter::class],
     )
     var ignoredRuleHashingAttributes: Set<String> = emptySet()
 


### PR DESCRIPTION
This should use comma separated values

Related https://github.com/Tinder/bazel-diff/issues/198#issuecomment-1868968522