### PR TITLE
Bump version reported by CLI to current version (7.0.0).

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/cli/VersionProvider.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/VersionProvider.kt
@@ -4,6 +4,6 @@ import picocli.CommandLine.IVersionProvider
 
 class VersionProvider : IVersionProvider {
     override fun getVersion(): Array<String> {
-        return arrayOf("5.0.0")
+        return arrayOf("7.0.0")
     }
 }


### PR DESCRIPTION
Currently, version `7.0.0` of `bazel-diff` is still reporting it's on version `5.0.0` when using `-V` from the command line. Bump the version so that CLI reports the current version. 