### PR TITLE
Tolerate bad query result with bzlmod support

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/hash/ExternalRepoResolver.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/ExternalRepoResolver.kt
@@ -1,17 +1,21 @@
 package com.bazel_diff.hash
 
+import com.bazel_diff.log.Logger
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
 import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
 class ExternalRepoResolver(
-        private val workingDirectory: Path,
-        private val bazelPath: Path,
-        private val outputBase: Path,
+    private val workingDirectory: Path,
+    private val bazelPath: Path,
+    private val outputBase: Path,
 ) : KoinComponent {
+    private val logger: Logger by inject()
+
     private val externalRoot: Path by lazy {
         outputBase.resolve("external")
     }
@@ -30,13 +34,32 @@ class ExternalRepoResolver(
 
     private fun resolveBzlModPath(repoName: String): Path {
         // Query result line should look something like "<exec root>/external/<canonical repo name>/some/bazel/target: <kind> <label>"
-        val queryResultLine = runProcessAndCaptureFirstLine(bazelPath.toString(), "query", "@$repoName//...", "--output", "location")
+        val queryResultLine = runProcessAndCaptureFirstLine(
+            bazelPath.toString(),
+            "query",
+            "@$repoName//...",
+            "--keep_going",
+            "--output",
+            "location"
+        )
+        if (queryResultLine == null) {
+            // Fallback to the default external repo root if nothing was found via bazel query.
+            // Normally this should not happen since any external repo should have at least one
+            // target to be consumed. But if it does, we just return the default external repo root
+            // and caller would handle the non-existent path.
+            logger.w {
+                "External repo $repoName has no target under it. You probably want to remove " +
+                        "this repo from `fineGrainedHashExternalRepos` since bazel-diff is not " +
+                        "able to correctly generate fine-grained hash for it."
+            }
+            return externalRoot.resolve(repoName);
+        }
         val path = Paths.get(queryResultLine.split(": ", limit = 2)[0])
         val bzlModRelativePath = path.relativize(externalRoot).first()
         return externalRoot.resolve(bzlModRelativePath)
     }
 
-    private fun runProcessAndCaptureFirstLine(vararg command: String): String {
+    private fun runProcessAndCaptureFirstLine(vararg command: String): String? {
         val process = ProcessBuilder(*command).directory(workingDirectory.toFile()).start()
         process.inputStream.bufferedReader().use {
             // read the first line and close the stream so that Bazel doesn't need to continue


### PR DESCRIPTION
We are seeing the following errors with my previous change 😅 . Apparently bazel query can sometimes fail and as a result bazel-diff crashes due to NPE in such cases. Unfortunately I can't figured out another way to reliably get the path under `<bazel-cache/external/` without bazel query so this PR will just fallback to the old bazel external module path if bazel query failed. 

```
09:01:24 GMT-07:00  com.google.common.util.concurrent.UncheckedExecutionException: java.lang.NullPointerException: readLine(...) must not be null
09:01:24 GMT-07:00  	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2055)
09:01:24 GMT-07:00  	at com.google.common.cache.LocalCache.get(LocalCache.java:3966)
09:01:24 GMT-07:00  	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3989)
09:01:24 GMT-07:00  	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4950)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.ExternalRepoResolver.resolveExternalRepoRoot(ExternalRepoResolver.kt:28)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.SourceFileHasher$digest$1.invoke(SourceFileHasher.kt:58)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.SourceFileHasher$digest$1.invoke(SourceFileHasher.kt:42)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.HashingExtensionsKt.sha256(HashingExtensions.kt:14)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.SourceFileHasher.digest(SourceFileHasher.kt:42)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.BuildGraphHasher$hashSourcefiles$result$1.apply(BuildGraphHasher.kt:71)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.BuildGraphHasher$hashSourcefiles$result$1.apply(BuildGraphHasher.kt:62)
09:01:24 GMT-07:00  	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
09:01:24 GMT-07:00  	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
09:01:24 GMT-07:00  	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
09:01:24 GMT-07:00  	at java.base/java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290)
09:01:24 GMT-07:00  	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:754)
09:01:24 GMT-07:00  	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
09:01:24 GMT-07:00  	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
09:01:24 GMT-07:00  	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
09:01:24 GMT-07:00  	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
09:01:24 GMT-07:00  	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
09:01:24 GMT-07:00  Caused by: java.lang.NullPointerException: readLine(...) must not be null
09:01:24 GMT-07:00  	at com.bazel_diff.hash.ExternalRepoResolver.runProcessAndCaptureFirstLine(ExternalRepoResolver.kt:44)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.ExternalRepoResolver.resolveBzlModPath(ExternalRepoResolver.kt:33)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.ExternalRepoResolver.access$resolveBzlModPath(ExternalRepoResolver.kt:10)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.ExternalRepoResolver$cache$1.apply(ExternalRepoResolver.kt:24)
09:01:24 GMT-07:00  	at com.bazel_diff.hash.ExternalRepoResolver$cache$1.apply(ExternalRepoResolver.kt:19)
09:01:24 GMT-07:00  	at com.google.common.cache.CacheLoader$FunctionToCacheLoader.load(CacheLoader.java:169)
09:01:24 GMT-07:00  	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3533)
09:01:24 GMT-07:00  	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2282)
09:01:24 GMT-07:00  	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2159)
09:01:24 GMT-07:00  	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2049)
09:01:24 GMT-07:00  	... 20 more

```