### PR TITLE
Read version from resource instead of hard-coding it

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,3 +2,6 @@ run -c opt --show_loading_progress=false --show_progress=false --ui_event_filter
 run:verbose -c dbg --show_loading_progress=true --show_progress=true --ui_event_filters=info,error,debug
 # https://github.com/mockito/mockito/issues/1879
 test --sandbox_tmpfs_path=/tmp
+
+# To allow stamping git tag for version.
+build --workspace_status_command=$(pwd)/workspace_status.sh

--- a/BUILD
+++ b/BUILD
@@ -2,3 +2,5 @@ alias(
     name = "bazel-diff",
     actual = "//cli:bazel-diff",
 )
+
+exports_files([".bazelversion"])

--- a/BUILD
+++ b/BUILD
@@ -2,5 +2,3 @@ alias(
     name = "bazel-diff",
     actual = "//cli:bazel-diff",
 )
-
-exports_files([".bazelversion"])

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -8,6 +8,17 @@ config_setting(
     },
 )
 
+genrule(
+    name = "version_file",
+    srcs = [],
+    outs = ["version"],
+    cmd_bash = """
+        version_tag=$$(grep ^STABLE_GIT_TAG bazel-out/stable-status.txt | cut -d' ' -f2); \
+        printf '%s' $$version_tag > $@;
+    """,
+    stamp = 1,
+)
+
 java_binary(
     name = "bazel-diff",
     jvm_flags = select({
@@ -22,7 +33,7 @@ java_binary(
 kt_jvm_library(
     name = "cli-lib",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
-    resources = ["//:.bazelversion"],
+    resources = [":version_file"],
     deps = [
         "@bazel_diff_maven//:com_google_code_gson_gson",
         "@bazel_diff_maven//:com_google_guava_guava",
@@ -32,7 +43,6 @@ kt_jvm_library(
         "@bazel_diff_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
         "@bazel_tools//src/main/protobuf:analysis_v2_java_proto",
         "@bazel_tools//src/main/protobuf:build_java_proto",
-        "@bazel_tools//tools/java/runfiles",
     ],
 )
 

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -22,6 +22,7 @@ java_binary(
 kt_jvm_library(
     name = "cli-lib",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
+    resources = ["//:.bazelversion"],
     deps = [
         "@bazel_diff_maven//:com_google_code_gson_gson",
         "@bazel_diff_maven//:com_google_guava_guava",
@@ -31,6 +32,7 @@ kt_jvm_library(
         "@bazel_diff_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
         "@bazel_tools//src/main/protobuf:analysis_v2_java_proto",
         "@bazel_tools//src/main/protobuf:build_java_proto",
+        "@bazel_tools//tools/java/runfiles",
     ],
 )
 

--- a/cli/src/main/kotlin/com/bazel_diff/cli/VersionProvider.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/VersionProvider.kt
@@ -7,8 +7,8 @@ import java.io.InputStreamReader
 class VersionProvider : IVersionProvider {
     override fun getVersion(): Array<String> {
         val classLoader = this::class.java.classLoader
-        val inputStream = classLoader.getResourceAsStream(".bazelversion")
-            ?: throw IllegalArgumentException("unknown version as .bazelversion file not found in resources")
+        val inputStream = classLoader.getResourceAsStream("cli/version")
+            ?: throw IllegalArgumentException("unknown version as version file not found in resources")
 
         val version = BufferedReader(InputStreamReader(inputStream)).use { it.readText().trim() }
         return arrayOf(version)

--- a/cli/src/main/kotlin/com/bazel_diff/cli/VersionProvider.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/VersionProvider.kt
@@ -1,9 +1,16 @@
 package com.bazel_diff.cli
 
 import picocli.CommandLine.IVersionProvider
+import java.io.BufferedReader
+import java.io.InputStreamReader
 
 class VersionProvider : IVersionProvider {
     override fun getVersion(): Array<String> {
-        return arrayOf("7.0.0")
+        val classLoader = this::class.java.classLoader
+        val inputStream = classLoader.getResourceAsStream(".bazelversion")
+            ?: throw IllegalArgumentException("unknown version as .bazelversion file not found in resources")
+
+        val version = BufferedReader(InputStreamReader(inputStream)).use { it.readText().trim() }
+        return arrayOf(version)
     }
 }

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set +e
+
+# Get the current Git tag
+echo "STABLE_GIT_TAG $(git describe --tags --abbrev=0 2>/dev/null || git rev-parse HEAD)"

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set +e
 
-# Get the current Git tag
+# Get the current Git tag or default to the commit hash
 echo "STABLE_GIT_TAG $(git describe --tags --abbrev=0 2>/dev/null || git rev-parse HEAD)"


### PR DESCRIPTION
* Seems like the hard-coded version keeps drifting everytime a new release is made (current release 7.1.0, but code still shows 7.0.0).
* This uses resource jar approach to embed the version into the binary and read it at runtime. This ensures that the version is always up to sync with release.

```
> git tag -a 7.1.1 -m "Version bump" 

> bazel-out/darwin_arm64-fastbuild/bin/cli/bazel-diff --version
7.1.1


# If built off master (no tags)
> bazel-out/darwin_arm64-fastbuild/bin/cli/bazel-diff --version                                                                                ✔
acd415a165d8515d9d94be18f14dcd62d0c1bf1c
```