### PR TITLE
fix: Handle canonical repo name for cquery

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
@@ -96,11 +96,12 @@ class BazelQueryService(
                             return ""
                         if "IncompatiblePlatformProvider" not in providers(target):
                             label = str(target.label)
+                            # normalize label to be consistent with content inside proto
                             if label.startswith("@//"):
-                                # normalize label to be consistent with content inside proto
                                 return label[1:]
-                            else:
-                                return label
+                            if label.startswith("@@//"):
+                                return label[2:]
+                            return label
                         return ""
                     """.trimIndent())
                     add(cqueryOutputFile.toString())


### PR DESCRIPTION
Not directly address #196 but this fix is required to work with bzlmod where canonical repo name is used.

This doc talks about canonical name: https://docs.google.com/document/d/1N81qfCa8oskCk5LqTW-LNthy6EBrDot7bdUsjz6JFC4/edit#heading=h.5mcn15i0e1ch