### PR TITLE
chore: Fix instructions about building deploy jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ bazel run :bazel-diff --config=verbose -- bazel-diff -h
 ### Build your own deployable JAR
 
 ```terminal
-bazel build //src/main/java/com/bazel_diff:bazel-diff_deploy.jar
-java -jar bazel-bin/src/main/java/com/bazel_diff/bazel-diff_deploy.jar # This JAR can be run anywhere
+bazel build //cli:bazel-diff_deploy.jar
+java -jar bazel-bin/cli/bazel-diff_deploy.jar # This JAR can be run anywhere
 ```
 
 ### Build from source in your Bazel Project


### PR DESCRIPTION
This part is outdated. I tried the commands locally and they worked.