### PR TITLE
feat: Add flag to exclude external targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Commands:
 
 ```terminal
 Usage: bazel-diff generate-hashes [-hkvV] [--[no-]useCquery] [-b=<bazelPath>]
+                                  [--[no-]excludeExternalTargets]
                                   [--[no-]includeTargetType]
                                   [--contentHashPath=<contentHashPath>]
                                   [-s=<seedFilepaths>] -w=<workspacePath>
@@ -151,7 +152,11 @@ workspace.
                                   "//cli:bazel-diff_deploy.jar": "GeneratedFile#4ae310f8ad2bc728934e3509b6102ca658e828b9cd668f79990e95c6663f9633",
                                   ...
                                 }
-      ----[no-]includeTargetType
+      --[no-]excludeExternalTargets
+                          If true, exclude external targets. This must be
+                            switched on when using `--noenable_workspace` Bazel
+                            command line option. Defaults to `false`.
+      --[no-]includeTargetType
                           Whether include target type in the generated JSON or not.
                             If false, the generate JSON schema is: {"<target>": "<sha256>"}
                             If true, the generate JSON schema is: {"<target>": "<type>#<sha256>"

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -6,14 +6,18 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.Calendar
 
-class BazelClient(private val useCquery: Boolean, private val fineGrainedHashExternalRepos: Set<String>) : KoinComponent {
+class BazelClient(
+        private val useCquery: Boolean,
+        private val fineGrainedHashExternalRepos: Set<String>,
+        private val excludeExternalTargets: Boolean
+) : KoinComponent {
     private val logger: Logger by inject()
     private val queryService: BazelQueryService by inject()
 
     suspend fun queryAllTargets(): List<BazelTarget> {
         val queryEpoch = Calendar.getInstance().getTimeInMillis()
 
-        val repoTargetsQuery = listOf("//external:all-targets")
+        val repoTargetsQuery = if (excludeExternalTargets) emptyList() else listOf("//external:all-targets")
         val targets = if (useCquery) {
             // Explicitly listing external repos here sometimes causes issues mentioned at
             // https://bazel.build/query/cquery#recursive-target-patterns. Hence, we query all dependencies with `deps`

--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -150,6 +150,14 @@ class GenerateHashesCommand : Callable<Int> {
     )
     var modifiedFilepaths: File? = null
 
+    @CommandLine.Option(
+        names = ["--excludeExternalTargets"],
+        negatable = true,
+        description = ["If true, exclude external targets. This must be switched on when using `--noenable_workspace` Bazel command line option. Defaults to `false`."],
+        scope = CommandLine.ScopeType.INHERIT
+    )
+    var excludeExternalTargets = false
+
     @CommandLine.Spec
     lateinit var spec: CommandLine.Model.CommandSpec
 
@@ -169,6 +177,7 @@ class GenerateHashesCommand : Callable<Int> {
                     keepGoing,
                     depsMappingJSONPath != null,
                     fineGrainedHashExternalRepos,
+                    excludeExternalTargets,
                 ),
                 loggingModule(parent.verbose),
                 serialisationModule(),

--- a/cli/src/main/kotlin/com/bazel_diff/di/Modules.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/di/Modules.kt
@@ -30,6 +30,7 @@ fun hasherModule(
         keepGoing: Boolean,
         trackDeps: Boolean,
         fineGrainedHashExternalRepos: Set<String>,
+        excludeExternalTargets: Boolean,
 ): Module = module {
     val cmd: MutableList<String> = ArrayList<String>().apply {
             add(bazelPath.toString())
@@ -59,7 +60,7 @@ fun hasherModule(
                 debug
         )
     }
-    single { BazelClient(useCquery, fineGrainedHashExternalRepos) }
+    single { BazelClient(useCquery, fineGrainedHashExternalRepos, excludeExternalTargets) }
     single { BuildGraphHasher(get()) }
     single { TargetHasher() }
     single { RuleHasher(useCquery, trackDeps, fineGrainedHashExternalRepos) }

--- a/cli/src/test/kotlin/com/bazel_diff/Modules.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/Modules.kt
@@ -14,7 +14,7 @@ fun testModule(): Module = module {
     val outputBase = Paths.get("output-base")
     val workingDirectory = Paths.get("working-directory")
     single<Logger> { SilentLogger }
-    single { BazelClient(false, emptySet()) }
+    single { BazelClient(false, emptySet(), false) }
     single { BuildGraphHasher(get()) }
     single { TargetHasher() }
     single { RuleHasher(false, true, emptySet()) }


### PR DESCRIPTION
Closes #236 

This PR adds a new flag `--[no--]excludeExternalTargets` that aims to support `--noenable_workspace` Bazel flag. This flag defaults to `false` so should be backward compatible.