### PR TITLE
fix: Correctly handle repo name when apply fine grained filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,15 @@ workspace.
                             By default, external repos are treated as an opaque
                             blob. If an external repo is specified here,
                             bazel-diff instead computes the hash for individual
-                            targets. For example, one wants to specify `maven`
-                            here if they user rules_jvm_external so that
+                            targets. For example, one wants to specify `@maven`
+                            here if they use rules_jvm_external so that
                             individual third party dependency change won't
                             invalidate all targets in the mono repo. Note that
-                            when `--useCquery` is used, the canonical repo name
-                            must be provided but with single `@`, e.g.
-                            `@rules_jvm_external~~maven~maven`
+                            if `--useCquery` is true; or `--useCquery` is false but
+                            `--bazelCommandOptions=--consistent_labels` is provided,
+                            the canonical repo name must be provided,
+                            e.g. `@@maven` or `@@rules_jvm_external~~maven~maven` (bzlmod)
+                            instead of apparent name `@maven`
   -h, --help              Show this help message and exit.
       --ignoredRuleHashingAttributes=<ignoredRuleHashingAttributes>
                           Attributes that should be ignored when hashing rule

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -41,7 +41,7 @@ class BazelClient(
         } else {
           val buildTargetsQuery =
               listOf("//...:all-targets") +
-                  fineGrainedHashExternalRepos.map { "@$it//...:all-targets" }
+                  fineGrainedHashExternalRepos.map { "$it//...:all-targets" }
           queryService.query((repoTargetsQuery + buildTargetsQuery).joinToString(" + ") { "'$it'" })
         }
     val queryDuration = Calendar.getInstance().getTimeInMillis() - queryEpoch

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelRule.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelRule.kt
@@ -49,9 +49,7 @@ class BazelRule(private val rule: Build.Rule) {
   ): String {
     if (isNotMainRepo(ruleInput) &&
         ruleInput.startsWith("@") &&
-        fineGrainedHashExternalRepos.none {
-          ruleInput.startsWith("@$it") || ruleInput.startsWith("@@${it}")
-        }) {
+        fineGrainedHashExternalRepos.none { ruleInput.startsWith(it) }) {
       val splitRule = ruleInput.split("//".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
       if (splitRule.size == 2) {
         var externalRule = splitRule[0]

--- a/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
@@ -138,7 +138,7 @@ class E2ETest {
         "-b",
         bazelPath,
         "--fineGrainedHashExternalRepos",
-        "bazel_diff_maven",
+        "@bazel_diff_maven",
         from.absolutePath)
     // To
     cli.execute(
@@ -148,7 +148,7 @@ class E2ETest {
         "-b",
         bazelPath,
         "--fineGrainedHashExternalRepos",
-        "bazel_diff_maven",
+        "@bazel_diff_maven",
         to.absolutePath)
     // Impacted targets
     cli.execute(
@@ -254,7 +254,7 @@ class E2ETest {
   fun testFineGrainedHashBzlMod() {
     testFineGrainedHashBzlMod(
         emptyList(),
-        "bazel_diff_maven",
+        "@bazel_diff_maven",
         "/fixture/fine-grained-hash-bzlmod-test-impacted-targets.txt")
   }
 
@@ -262,7 +262,7 @@ class E2ETest {
   fun testFineGrainedHashBzlModCquery() {
     testFineGrainedHashBzlMod(
         listOf("--useCquery"),
-        "@rules_jvm_external~~maven~maven",
+        "@@rules_jvm_external~~maven~maven",
         "/fixture/fine-grained-hash-bzlmod-cquery-test-impacted-targets.txt")
   }
 
@@ -345,7 +345,7 @@ class E2ETest {
         "--cqueryCommandOptions",
         "--platforms=//:android",
         "--fineGrainedHashExternalRepos",
-        "bazel_diff_maven,bazel_diff_maven_android",
+        "@@bazel_diff_maven,@@bazel_diff_maven_android",
         from.absolutePath)
     // To
     cli.execute(
@@ -358,7 +358,7 @@ class E2ETest {
         "--cqueryCommandOptions",
         "--platforms=//:android",
         "--fineGrainedHashExternalRepos",
-        "bazel_diff_maven,bazel_diff_maven_android",
+        "@@bazel_diff_maven,@@bazel_diff_maven_android",
         to.absolutePath)
     // Impacted targets
     cli.execute(
@@ -391,7 +391,7 @@ class E2ETest {
         "--cqueryCommandOptions",
         "--platforms=//:jre",
         "--fineGrainedHashExternalRepos",
-        "bazel_diff_maven,bazel_diff_maven_android",
+        "@@bazel_diff_maven,@@bazel_diff_maven_android",
         from.absolutePath)
     // To
     cli.execute(
@@ -404,7 +404,7 @@ class E2ETest {
         "--cqueryCommandOptions",
         "--platforms=//:jre",
         "--fineGrainedHashExternalRepos",
-        "bazel_diff_maven,bazel_diff_maven_android",
+        "@@bazel_diff_maven,@@bazel_diff_maven_android",
         to.absolutePath)
     // Impacted targets
     cli.execute(
@@ -505,7 +505,7 @@ class E2ETest {
         "--cqueryCommandOptions",
         "--platforms=//:android",
         "--fineGrainedHashExternalRepos",
-        "bazel_diff_maven,bazel_diff_maven_android",
+        "@@bazel_diff_maven,@@bazel_diff_maven_android",
         from.absolutePath)
     // To
     cli.execute(
@@ -518,7 +518,7 @@ class E2ETest {
         "--cqueryCommandOptions",
         "--platforms=//:android",
         "--fineGrainedHashExternalRepos",
-        "bazel_diff_maven,bazel_diff_maven_android",
+        "@@bazel_diff_maven,@@bazel_diff_maven_android",
         to.absolutePath)
     // Impacted targets
     cli.execute(
@@ -552,7 +552,7 @@ class E2ETest {
         "--cqueryCommandOptions",
         "--platforms=//:jre",
         "--fineGrainedHashExternalRepos",
-        "bazel_diff_maven,bazel_diff_maven_android",
+        "@@bazel_diff_maven,@@bazel_diff_maven_android",
         from.absolutePath)
     // To
     cli.execute(
@@ -565,7 +565,7 @@ class E2ETest {
         "--cqueryCommandOptions",
         "--platforms=//:jre",
         "--fineGrainedHashExternalRepos",
-        "bazel_diff_maven,bazel_diff_maven_android",
+        "@@bazel_diff_maven,@@bazel_diff_maven_android",
         to.absolutePath)
     // Impacted targets
     cli.execute(


### PR DESCRIPTION
When using `--useCquery` or setting `--bazelCommandOptions=--consistent_labels` (while not using `--useCquery`), canonical repo name must be used for `--fineGrainedHashExternalRepos`, but with a leading `@`. In that case, we cannot remove all `@` from source target name, otherwise nothing will never match `--fineGrainedHashExternalRepos`.

This PR fixes that by asking users to always provide apparent or canonical repo name (with `@` or `@@`).

After this fix, it is not strictly necessary to use canonical name when `--useCquery` because we compare repo name without any `@`, but to keep it easier for users to follow, the readme says otherwise.

Note that this is a breaking change.