### PR TITLE
fix: Handle alias for compatible targets query

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -1,9 +1,9 @@
 package com.bazel_diff.bazel
 
 import com.bazel_diff.log.Logger
+import java.util.Calendar
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import java.util.Calendar
 
 class BazelClient(
     private val useCquery: Boolean,

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
@@ -106,6 +106,9 @@ class BazelQueryService(
                         if providers(target) == None:
                             return ""
                         if "IncompatiblePlatformProvider" not in providers(target):
+                            target_repr = repr(target)
+                            if "<alias target" in target_repr:
+                                return target_repr.split(" ")[2]
                             return str(target.label)
                         return ""
                     """


### PR DESCRIPTION
Inspired by https://github.com/bazel-contrib/target-determinator/pull/64 to handle alias correctly when querying compatible targets.