### PR TITLE
question: Does quey need to transform rule input

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -1,9 +1,9 @@
 package com.bazel_diff.bazel
 
 import com.bazel_diff.log.Logger
+import java.util.Calendar
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import java.util.Calendar
 
 class BazelClient(
     private val useCquery: Boolean,

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelRule.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelRule.kt
@@ -37,9 +37,7 @@ class BazelRule(private val rule: Build.Rule) {
               .filter { it.startsWith("//external:") }
               .distinct()
     } else {
-      rule.ruleInputList.map { ruleInput: String ->
-        transformRuleInput(fineGrainedHashExternalRepos, ruleInput)
-      }
+      rule.ruleInputList
     }
   }
 


### PR DESCRIPTION
I'm not entirely I understand it correctly. It seems that there is no need to transform rule inputs when using `query` because it doesn't query any `external` targets.