### PR TITLE
Allow the list of fine grained hashes to be defined by a file

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -82,7 +82,7 @@ class GenerateHashesCommand : Callable<Int> {
         names = ["--fineGrainedHashExternalReposFile"],
         description =
             [
-                "A text file containing a newline separated list of external repos. Similar to --fineGrainedHashExternalRepos but helps you avoid exceeding max arg length. Using this option supersedes the --fineGrainedHashExternalRepos flag."])
+                "A text file containing a newline separated list of external repos. Similar to --fineGrainedHashExternalRepos but helps you avoid exceeding max arg length. Mutually exclusive with --fineGrainedHashExternalRepos."])
   var fineGrainedHashExternalReposFile: File? = null
 
   @CommandLine.Option(

--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -79,6 +79,13 @@ class GenerateHashesCommand : Callable<Int> {
   var fineGrainedHashExternalRepos: Set<String> = emptySet()
 
   @CommandLine.Option(
+        names = ["--fineGrainedHashExternalReposFile"],
+        description =
+            [
+                "A text file containing a newline separated list of external repos. Similar to --fineGrainedHashExternalRepos but helps you avoid exceeding max arg length. Using this option supersedes the --fineGrainedHashExternalRepos flag."])
+  var fineGrainedHashExternalReposFile: File? = null
+
+  @CommandLine.Option(
       names = ["--useCquery"],
       negatable = true,
       description =
@@ -192,6 +199,7 @@ class GenerateHashesCommand : Callable<Int> {
               keepGoing,
               depsMappingJSONPath != null,
               fineGrainedHashExternalRepos,
+              fineGrainedHashExternalReposFile,
               excludeExternalTargets,
           ),
           loggingModule(parent.verbose),

--- a/cli/src/main/kotlin/com/bazel_diff/di/Modules.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/di/Modules.kt
@@ -30,8 +30,15 @@ fun hasherModule(
     keepGoing: Boolean,
     trackDeps: Boolean,
     fineGrainedHashExternalRepos: Set<String>,
+    fineGrainedHashExternalReposFile: File?,
     excludeExternalTargets: Boolean,
 ): Module = module {
+  val updatedFineGrainedHashExternalRepos = fineGrainedHashExternalReposFile?.let { file ->
+    file.readLines()
+        .filter { it.isNotBlank() }
+        .toSet()
+  } ?: fineGrainedHashExternalRepos
+
   val cmd: MutableList<String> =
       ArrayList<String>().apply {
         add(bazelPath.toString())
@@ -60,11 +67,11 @@ fun hasherModule(
         keepGoing,
         debug)
   }
-  single { BazelClient(useCquery, fineGrainedHashExternalRepos, excludeExternalTargets) }
+  single { BazelClient(useCquery, updatedFineGrainedHashExternalRepos, excludeExternalTargets) }
   single { BuildGraphHasher(get()) }
   single { TargetHasher() }
-  single { RuleHasher(useCquery, trackDeps, fineGrainedHashExternalRepos) }
-  single<SourceFileHasher> { SourceFileHasherImpl(fineGrainedHashExternalRepos) }
+  single { RuleHasher(useCquery, trackDeps, updatedFineGrainedHashExternalRepos) }
+  single<SourceFileHasher> { SourceFileHasherImpl(updatedFineGrainedHashExternalRepos) }
   single { ExternalRepoResolver(workingDirectory, bazelPath, outputPath) }
   single(named("working-directory")) { workingDirectory }
   single(named("output-base")) { outputPath }

--- a/cli/src/main/kotlin/com/bazel_diff/di/Modules.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/di/Modules.kt
@@ -33,6 +33,10 @@ fun hasherModule(
     fineGrainedHashExternalReposFile: File?,
     excludeExternalTargets: Boolean,
 ): Module = module {
+  if (fineGrainedHashExternalReposFile != null && fineGrainedHashExternalRepos.isNotEmpty()) {
+    System.err.println("Error: fineGrainedHashExternalReposFile and fineGrainedHashExternalRepos are mutually exclusive - please provide only one of them")
+    System.exit(1)
+  }
   val updatedFineGrainedHashExternalRepos = fineGrainedHashExternalReposFile?.let { file ->
     file.readLines()
         .filter { it.isNotBlank() }


### PR DESCRIPTION
I want to make sure all of the rules_go managed "external" Go libraries (eventually represented as Bazel "repos") are considered when hashing occurs.

Without this PR, it seems that I would need to list them all out in a comma separated string param using `--fineGrainedHashExternalRepos`, which risks exceeding the bash arg length. Because in rules_go, each go dependency becomes an individually addressable bazel repo, the argument length would explode because I have hundreds of Go libraries listed in my go.mod which are seen as hundreds of Bazel repos due to MODULE.bazel notation that ultimately looks like this:

```
use_repo(
    go_deps,
    "cc_mvdan_gofumpt",
    "com_github_adrg_strutil",
    ...
```
Right there, that's two separate Bazel repos.. but in reality, there will be hundreds of them.

For this reason, I'm proposing this PR in which the list of repos may be defined in a file, which avoids any glitches with the bash arg length limit.