### PR TITLE
Fix empty query when using --excludeExternalTargets with --useCquery

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -35,9 +35,13 @@ class BazelClient(
           // In addition, we must include all source dependencies in this query in order for them to
           // show up in
           // `configuredRuleInput`. Hence, one must not filter them out with `kind(rule, deps(..))`.
-          (queryService.query("deps(//...:all-targets)", useCquery = true) +
-                  queryService.query(repoTargetsQuery.joinToString(" + ") { "'$it'" }))
-              .distinctBy { it.name }
+          val mainTargets = queryService.query("deps(//...:all-targets)", useCquery = true)
+          val repoTargets = if (repoTargetsQuery.isNotEmpty()) {
+            queryService.query(repoTargetsQuery.joinToString(" + ") { "'$it'" })
+          } else {
+            emptyList()
+          }
+          (mainTargets + repoTargets).distinctBy { it.name }
         } else {
           val buildTargetsQuery =
               listOf("//...:all-targets") +

--- a/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
@@ -588,6 +588,33 @@ class E2ETest {
   }
 
   @Test
+  fun testUseCqueryWithExcludeExternalTargets() {
+    // This test verifies the fix for the issue where using --excludeExternalTargets with --useCquery
+    // would cause an empty query string to be passed to Bazel, resulting in exit code 2.
+    val workingDirectory = extractFixtureProject("/fixture/cquery-test-base.zip")
+
+    val bazelPath = "bazel"
+    val outputDir = temp.newFolder()
+    val hashesJson = File(outputDir, "hashes.json")
+
+    val cli = CommandLine(BazelDiff())
+
+    val exitCode = cli.execute(
+        "generate-hashes",
+        "-w",
+        workingDirectory.absolutePath,
+        "-b",
+        bazelPath,
+        "--useCquery",
+        // Platform is specified only to make the cquery succeed.
+        "--cqueryCommandOptions",
+        "--platforms=//:jre",
+        "--excludeExternalTargets",
+        hashesJson.absolutePath)
+    assertThat(exitCode).isEqualTo(0)
+  }
+
+  @Test
   fun testTargetDistanceMetrics() {
     val workspace = copyTestWorkspace("distance_metrics")
 


### PR DESCRIPTION
Fixes an issue where using `--excludeExternalTargets` with `--useCquery` would cause bazel-diff to pass an empty query string to `bazel query`, resulting in a failure with exit code 2.
The problem was that when external targets are excluded, the code was still trying to execute a query on an empty list, which produced an empty string. Now we check if there are actually any repo targets to query before executing the query, otherwise we just skip it and use an empty list.