### PR TITLE
Bazel-diff takes into account external repository directory format introduced in Bazel 8

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/hash/ExternalRepoResolver.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/ExternalRepoResolver.kt
@@ -22,10 +22,18 @@ class ExternalRepoResolver(
       CacheBuilder.newBuilder()
           .build(
               CacheLoader.from { repoName: String ->
-                val externalRepoRoot = externalRoot.resolve(repoName)
-                if (Files.exists(externalRepoRoot)) {
-                  return@from externalRepoRoot
+                externalRoot.resolve(repoName).let {
+                  if (Files.exists(it)) {
+                    return@from it
+                  }
                 }
+
+                externalRoot.resolve("$repoName+").let {
+                  if (Files.exists(it)) {
+                    return@from it
+                  }
+                }
+
                 resolveBzlModPath(repoName)
               })
 


### PR DESCRIPTION
This PR adds support to [the updated external repository directory format, introduced in Bazel 7 and enabled in Bazel 8](https://github.com/bazelbuild/bazel/issues/23127). 

Fixes #288 