### PR TITLE
Mark some deps as dev dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,12 +1,12 @@
 module(
     name = "bazel-diff",
-    version = "12.0.0",
+    version = "12.1.0",
     compatibility_level = 0,
 )
 
-bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "aspect_rules_lint", version = "1.0.2")
-bazel_dep(name = "bazel_skylib", version = "1.6.1")
+bazel_dep(name = "rules_license", version = "1.0.0", dev_dependency = True)
+bazel_dep(name = "aspect_rules_lint", version = "1.0.2", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "rules_java", version = "8.11.0")
 bazel_dep(name = "rules_kotlin", version = "2.1.3")
@@ -34,5 +34,5 @@ use_repo(
     bazel_diff_maven = "bazel_diff_maven",
 )
 
-non_module_repositories = use_extension("//:extensions.bzl", "non_module_repositories")
+non_module_repositories = use_extension("//:extensions.bzl", "non_module_repositories", dev_dependency = True)
 use_repo(non_module_repositories, "ktfmt")


### PR DESCRIPTION
As per Review bzlmod dependencies and make use of `dev_dependency = True` #294

Signed-off-by: Maxwell Elliott <maxwell.elliott@gotinder.com>