### PR TITLE
Fix junit version when using bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ maven.install(
         "info.picocli:picocli:jar:4.6.3",
         "io.insert-koin:koin-core-jvm:3.1.6",
         "io.insert-koin:koin-test-junit4:4.0.0",
-        "junit:junit:5.11.2",
+        "junit:junit:4.13.2",
         "org.apache.commons:commons-pool2:2.11.1",
         "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2",
         "org.mockito.kotlin:mockito-kotlin:5.4.0",


### PR DESCRIPTION
Keep the junit version the same as the [BAZEL_DIFF_MAVEN_ARTIFACTS](https://github.com/Tinder/bazel-diff/blob/6a491b19cfb60cbe8c625bfd62fd4bdcf939ad65/artifacts.bzl).

I believe junit v5 does not exist on maven2 registry, they refactored the packages completely.