### PR TITLE
Properly handle bazel rc versions

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
@@ -53,9 +53,9 @@ class BazelQueryService(
     if (result.output.size != 1 || !result.output.first().startsWith("bazel ")) {
       throw RuntimeException("Bazel version command returned unexpected output: ${result.output}")
     }
-    // Trim off any prerelease suffixes.
+    // Trim off any prerelease suffixes (e.g., 8.6.0-rc1 or 8.6.0rc1).
     val versionString = result.output.first().removePrefix("bazel ").trim().split('-')[0]
-    val version = versionString.split('.').map { it.toInt() }.toTypedArray()
+    val version = versionString.split('.').map { it.takeWhile { c -> c.isDigit() }.toInt() }.toTypedArray()
     return Triple(version[0], version[1], version[2])
   }
 


### PR DESCRIPTION
I've encountered following error when testing bazel-diff with Bazel 8.6.0rc1:

```
[Error] Unexpected error during generation of hashes
java.lang.NumberFormatException: For input string: "0rc1"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Integer.parseInt(Integer.java:652)
	at java.base/java.lang.Integer.parseInt(Integer.java:770)
	at com.bazel_diff.bazel.BazelQueryService.determineBazelVersion(BazelQueryService.kt:58)
	at com.bazel_diff.bazel.BazelQueryService.access$determineBazelVersion(BazelQueryService.kt:19)
	at com.bazel_diff.bazel.BazelQueryService$determineBazelVersion$1.invokeSuspend(BazelQueryService.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at com.bazel_diff.bazel.BazelQueryService$version$2.invoke(BazelQueryService.kt:29)
	at com.bazel_diff.bazel.BazelQueryService$version$2.invoke(BazelQueryService.kt:29)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.bazel_diff.bazel.BazelQueryService.getVersion(BazelQueryService.kt:29)
	at com.bazel_diff.bazel.BazelQueryService.getCanUseOutputFile(BazelQueryService.kt:72)
	at com.bazel_diff.bazel.BazelQueryService.runQuery(BazelQueryService.kt:199)
	at com.bazel_diff.bazel.BazelQueryService.runQuery$default(BazelQueryService.kt:126)
	at com.bazel_diff.bazel.BazelQueryService.query(BazelQueryService.kt:89)
	at com.bazel_diff.bazel.BazelQueryService.query$default(BazelQueryService.kt:74)
	at com.bazel_diff.bazel.BazelClient.queryAllTargets(BazelClient.kt:56)
	at com.bazel_diff.hash.BuildGraphHasher$hashAllBazelTargetsAndSourcefiles$1$targetsTask$1.invokeSuspend(BuildGraphHasher.kt:35)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```