### PR TITLE
fix: omit stderr from metadata when generating hashes

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelModService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelModService.kt
@@ -52,7 +52,7 @@ class BazelModService(
         process(
             *cmd.toTypedArray(),
             stdout = Redirect.CAPTURE,
-            stderr = Redirect.CAPTURE,
+            stderr = Redirect.SILENT,
             workingDirectory = workingDirectory.toFile(),
             destroyForcibly = true,
         )
@@ -93,7 +93,7 @@ class BazelModService(
         process(
             *cmd.toTypedArray(),
             stdout = Redirect.CAPTURE,
-            stderr = Redirect.CAPTURE,
+            stderr = Redirect.SILENT,
             workingDirectory = workingDirectory.toFile(),
             destroyForcibly = true,
         )


### PR DESCRIPTION
Occasionally I see `INFO: Checking for file changes...\n` in the metadata when generating hashes, which is extra useless info that causes bazel-diff to think the whole graph has changed. This silences the stderr so that it never gets added to the metadata.

I can't reproduce the issue exactly, but I've been running this patch internally for a little bit and it seems to be working.

Fixes #329