### PR TITLE
Fixes for external repo resolver and sorting in impacted set

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "bazel-diff",
-    version = "18.1.0",
+    version = "19.0.0",
     compatibility_level = 0,
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -498,7 +498,7 @@
     "//:extensions.bzl%non_module_repositories": {
       "general": {
         "bzlTransitiveDigest": "ks6ZQP7BhZgybSu5miBVjOep566JGWK7Lf4pDkWwq4M=",
-        "usagesDigest": "ob2ul2ayBkYes0CNMIGYCh+oR8nUJNfvTkBQNVtTfIM=",
+        "usagesDigest": "PvpLvGYAOD+J/zRMx9PkfCWczcz+hzAAmbPJSCFIBxQ=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/cli/src/main/kotlin/com/bazel_diff/hash/ExternalRepoResolver.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/ExternalRepoResolver.kt
@@ -66,7 +66,7 @@ class ExternalRepoResolver(
       return externalRoot.resolve(repoName)
     }
     val path = Paths.get(queryResultLine.split(": ", limit = 2)[0])
-    val bzlModRelativePath = path.relativize(externalRoot).first()
+    val bzlModRelativePath = externalRoot.relativize(path).first()
     return externalRoot.resolve(bzlModRelativePath)
   }
 

--- a/cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt
@@ -59,6 +59,7 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
 
     impactedTargets
         .filter { typeFilter.accepts(it) }
+        .sortedWith(impactedTargetOrdering(to, from))
         .let { filtered ->
           outputWriter.use { writer -> filtered.forEach { writer.write("$it\n") } }
         }
@@ -110,8 +111,10 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
       computeAllDistances(from, to, depEdges)
     }
 
+    val ordering = impactedTargetOrdering(to, from)
     impactedTargets
         .filterKeys { typeFilter.accepts(it) }
+        .toSortedMap(ordering)
         .let { filtered ->
           outputWriter.use { writer ->
             writer.write(
@@ -124,6 +127,24 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
                     }))
           }
         }
+  }
+
+  private fun impactedTargetOrdering(
+      to: Map<String, TargetHash>,
+      from: Map<String, TargetHash>
+  ): Comparator<String> {
+    fun kindRank(label: String): Int {
+      val type = to[label]?.type?.takeIf { it.isNotEmpty() }
+          ?: from[label]?.type?.takeIf { it.isNotEmpty() }
+      return when (type) {
+        "SourceFile" -> 0
+        "GeneratedFile" -> 1
+        "Rule" -> 2
+        null -> 4
+        else -> 3
+      }
+    }
+    return compareBy<String>({ kindRank(it) }, { it })
   }
 
   fun computeAllDistances(

--- a/cli/src/test/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractorTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractorTest.kt
@@ -35,6 +35,40 @@ class CalculateImpactedTargetsInteractorTest : KoinTest {
   }
 
   @Test
+  fun testExecuteSortsByKindThenLabel() {
+    val startHashes =
+        mapOf(
+            "//pkg:rule_a" to TargetHash("Rule", "r_a", "r_a"),
+            "//pkg:rule_b" to TargetHash("Rule", "r_b", "r_b"),
+            "//pkg:gen_a" to TargetHash("GeneratedFile", "g_a", "g_a"),
+            "//pkg:gen_b" to TargetHash("GeneratedFile", "g_b", "g_b"),
+            "//pkg:src_a" to TargetHash("SourceFile", "s_a", "s_a"),
+            "//pkg:src_b" to TargetHash("SourceFile", "s_b", "s_b"),
+        )
+    val endHashes = startHashes.mapValues { (_, v) -> v.copy(hash = v.hash + "-changed") }
+
+    val outputWriter = StringWriter()
+    CalculateImpactedTargetsInteractor()
+        .execute(
+            from = startHashes,
+            to = endHashes,
+            outputWriter = outputWriter,
+            targetTypes = null,
+        )
+
+    val lines = outputWriter.toString().trimEnd('\n').split("\n")
+    assertThat(lines)
+        .containsExactly(
+            "//pkg:src_a",
+            "//pkg:src_b",
+            "//pkg:gen_a",
+            "//pkg:gen_b",
+            "//pkg:rule_a",
+            "//pkg:rule_b",
+        )
+  }
+
+  @Test
   fun testOmitsUnchangedTargets() {
     val (depEdges, startHashes) =
         createTargetHashes(


### PR DESCRIPTION
These changes make sure we solve for bzlModRelativePath correctly and also improves output of the tool by sorting outputs