### PR TITLE
Add e2e coverage for cquery streamed_proto path (#219)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "bazel-diff",
-    version = "19.0.0",
+    version = "19.0.1",
     compatibility_level = 0,
 )
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ First, add the following snippet to your project:
 #### Bzlmod snippet
 
 ```bazel
-bazel_dep(name = "bazel-diff", version = "19.0.0")
+bazel_dep(name = "bazel-diff", version = "19.0.1")
 ```
 
 You can now run the tool with:

--- a/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
@@ -184,6 +184,33 @@ class E2ETest {
   }
 
   @Test
+  fun testGenerateHashesWithCqueryStreamedProto() {
+    // Validates the --useCquery code path that consumes Bazel's `--output=streamed_proto`
+    // cquery output (https://github.com/Tinder/bazel-diff/issues/219). On Bazel 7.0.0+ this
+    // exercises the AnalysisProtosV2.CqueryResult.parseDelimitedFrom loop in
+    // BazelQueryService.query(); on older Bazel it falls back to single-message proto parsing.
+    // Uses the `distance_metrics` shell-only workspace so cquery analysis works without a
+    // sandboxed JDK / coursier fetch.
+    val workspace = copyTestWorkspace("distance_metrics")
+    val outputDir = temp.newFolder()
+    val output = File(outputDir, "hashes.json")
+
+    val cli = CommandLine(BazelDiff())
+    val exitCode = cli.execute(
+        "generate-hashes",
+        "-w", workspace.absolutePath,
+        "-b", "bazel",
+        "--useCquery",
+        output.absolutePath)
+
+    assertThat(exitCode).isEqualTo(0)
+
+    val hashes: Map<String, Any> =
+        Gson().fromJson(output.readText(), object : TypeToken<Map<String, Any>>() {}.type)
+    assertThat(hashes.isNotEmpty()).isEqualTo(true)
+  }
+
+  @Test
   fun testFineGrainedHashExternalRepo() {
     // The difference between these two snapshots is simply upgrading the Guava version.
     // Following is the diff.


### PR DESCRIPTION
## Summary

- Adds `testGenerateHashesWithCqueryStreamedProto` to `E2ETest.kt`, an explicit end-to-end test that exercises `generate-hashes --useCquery` against the lightweight `distance_metrics` workspace. This guards the `AnalysisProtosV2.CqueryResult.parseDelimitedFrom` streaming loop in `BazelQueryService.query()` (Bazel 7.0.0+).
- The underlying fix for [#219](https://github.com/Tinder/bazel-diff/issues/219) (streamed_proto support for cquery) already landed in #278; existing cquery e2e tests cover bzlmod / multi-platform fixtures but none isolate the simple `--useCquery` codepath.
- Bumps version 19.0.0 → 19.0.1 in `MODULE.bazel` and `README.md`.

## Test plan
- [x] `bazel test //cli:E2ETest --test_filter='com.bazel_diff.e2e.E2ETest#testGenerateHashesWithCqueryStreamedProto'` passes locally on Bazel 8.5.1
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)