### PR TITLE
Tighten canonical-repo match in queryTargetsDependingOnModules

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -73,6 +73,12 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "CalculateImpactedTargetsInteractorModuleQueryTest",
+    test_class = "com.bazel_diff.interactor.CalculateImpactedTargetsInteractorModuleQueryTest",
+    runtime_deps = [":cli-test-lib"],
+)
+
+kt_jvm_test(
     name = "NormalisingPathConverterTest",
     test_class = "com.bazel_diff.cli.converter.NormalisingPathConverterTest",
     runtime_deps = [":cli-test-lib"],

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -79,6 +79,12 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "CalculateImpactedTargetsInteractorModuleQueryTest",
+    test_class = "com.bazel_diff.interactor.CalculateImpactedTargetsInteractorModuleQueryTest",
+    runtime_deps = [":cli-test-lib"],
+)
+
+kt_jvm_test(
     name = "NormalisingPathConverterTest",
     test_class = "com.bazel_diff.cli.converter.NormalisingPathConverterTest",
     runtime_deps = [":cli-test-lib"],

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
@@ -349,9 +349,13 @@ class BazelQueryService(
    * `bazel mod dump_repo_mapping ""`. Returns a map of apparent name → canonical name.
    * Filters out internal repos (bazel_tools, _builtins, local_config_*) that aren't
    * relevant for dependency hashing.
+   *
+   * Used by both `queryBzlmodRepos` (for synthetic //external:* target generation) and
+   * `CalculateImpactedTargetsInteractor.queryTargetsDependingOnModules` (to resolve a
+   * changed module's canonical repo prefix without substring matching `allTargets.keys`).
    */
   @OptIn(ExperimentalCoroutinesApi::class)
-  private suspend fun discoverRepoMapping(): Map<String, String> {
+  suspend fun discoverRepoMapping(): Map<String, String> {
     val cmd: MutableList<String> =
         ArrayList<String>().apply {
           add(bazelPath.toString())

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/ModuleGraphParser.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/ModuleGraphParser.kt
@@ -57,7 +57,10 @@ class ModuleGraphParser {
     val version = obj.get("version")?.asString
     val apparentName = obj.get("apparentName")?.asString
 
-    if (key != null && name != null && version != null && apparentName != null) {
+    // Bazel's MODULE.bazel spec requires module names to be non-empty; reject
+    // empty `name` so the synthetic `<root>` entry of an unnamed MODULE.bazel
+    // doesn't reach downstream canonical-repo matching.
+    if (key != null && !name.isNullOrEmpty() && version != null && apparentName != null) {
       modules[key] = Module(key, name, version, apparentName)
     }
 

--- a/cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt
@@ -1,6 +1,7 @@
 package com.bazel_diff.interactor
 
 import com.bazel_diff.bazel.BazelQueryService
+import com.bazel_diff.bazel.Module
 import com.bazel_diff.bazel.ModuleGraphParser
 import com.bazel_diff.hash.TargetHash
 import com.bazel_diff.log.Logger
@@ -53,7 +54,7 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
 
     val impactedTargets = if (changedModules.isNotEmpty()) {
       logger.i { "Module changes detected - querying for targets that depend on changed modules" }
-      queryTargetsDependingOnModules(changedModules, to)
+      queryTargetsDependingOnModules(changedModules, from, to)
     } else {
       computeSimpleImpactedTargets(from, to)
     }
@@ -106,7 +107,7 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
 
     val impactedTargets = if (changedModules.isNotEmpty()) {
       logger.i { "Module changes detected - querying for targets that depend on changed modules" }
-      val moduleImpactedTargets = queryTargetsDependingOnModules(changedModules, to)
+      val moduleImpactedTargets = queryTargetsDependingOnModules(changedModules, from, to)
       // Mark module-impacted targets with distance 0, then compute distances from there
       val moduleImpactedHashes = from.filterKeys { !moduleImpactedTargets.contains(it) }
       computeAllDistances(moduleImpactedHashes, to, depEdges)
@@ -239,61 +240,76 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
   }
 
   /**
-   * Detects module changes by comparing module graphs and returns changed module keys.
+   * Detects module changes by comparing module graphs and returns the changed Modules.
    *
-   * This method:
-   * 1. Parses the from and to module graphs
-   * 2. Identifies which modules changed (added, removed, or version changed)
-   * 3. Logs the changes for visibility
-   * 4. Returns the set of changed module keys
+   * Resolves each changed key against the "to" graph first (the state we will query
+   * against), falling back to the "from" graph for modules that were removed.
    *
-   * @param fromModuleGraphJson JSON from `bazel mod graph --output=json` for starting revision
-   * @param toModuleGraphJson JSON from `bazel mod graph --output=json` for final revision
-   * @return Set of changed module keys, empty if no changes
+   * @param fromModuleGraphJson JSON from `bazel mod graph --output=json` for the starting revision
+   * @param toModuleGraphJson JSON from `bazel mod graph --output=json` for the final revision
+   * @return Set of changed Modules, empty if no changes
    */
   private fun detectChangedModules(
       fromModuleGraphJson: String?,
       toModuleGraphJson: String?
-  ): Set<String> {
-    // If either module graph is missing, assume no changes
+  ): Set<Module> {
     if (fromModuleGraphJson == null || toModuleGraphJson == null) {
       return emptySet()
     }
 
-    // Parse module graphs
     val fromGraph = moduleGraphParser.parseModuleGraph(fromModuleGraphJson)
     val toGraph = moduleGraphParser.parseModuleGraph(toModuleGraphJson)
+    val changedKeys = moduleGraphParser.findChangedModules(fromGraph, toGraph)
 
-    // Find changed modules
-    val changedModules = moduleGraphParser.findChangedModules(fromGraph, toGraph)
-
-    if (changedModules.isEmpty()) {
+    if (changedKeys.isEmpty()) {
       logger.i { "No module changes detected" }
-    } else {
-      logger.i { "Detected ${changedModules.size} module changes: ${changedModules.joinToString(", ")}" }
+      return emptySet()
     }
 
+    val changedModules = changedKeys.mapNotNull { key -> toGraph[key] ?: fromGraph[key] }.toSet()
+    logger.i { "Detected ${changedModules.size} module changes: ${changedModules.joinToString(", ") { it.key }}" }
     return changedModules
   }
 
   /**
    * Queries Bazel to find all targets that depend on the changed modules.
    *
-   * This uses an efficient module-level query approach:
-   * 1. Identifies which external repository each changed module corresponds to
-   * 2. Uses `rdeps(//..., @@module~version//...)` to find workspace targets depending on each module
-   * 3. Returns the union of all impacted targets
+   * For each changed module M we compute the set of canonical repos in `allTargets`
+   * that belong to M, then run `rdeps(//..., @@<repo>//...)` once per canonical repo.
    *
-   * @param changedModuleKeys Set of changed module keys (e.g., "abseil-cpp@20240722.0")
-   * @param allTargets Map of all targets from the final revision
+   * Repo ownership is decided by two ordered predicates:
+   *
+   * 1. Tier A — root repo mapping. If `bazel mod dump_repo_mapping ""` maps
+   *    `M.apparentName` to canonical C, any repo R with R == C or R starts with
+   *    "C+" / "C~" belongs to M. Covers extension-created children (`C++ext+repo`,
+   *    `C~~ext~repo`) whose parent canonical lives in M.
+   * 2. Tier B — name-prefix fallback. R belongs to M if R starts with
+   *    "{M.name}+" or "{M.name}~". Extension-created forms (`name++ext+repo`,
+   *    `name~~ext~repo`) are already covered by these prefixes. Handles
+   *    transitive modules absent from root's mapping and the case where
+   *    `discoverRepoMapping` failed.
+   *
+   * Modules that match nothing (Tier C) are logged and skipped — a module with no
+   * materialised repos in `allTargets.keys` cannot impact any hashed target, and
+   * `computeSimpleImpactedTargets` still runs below to catch direct source changes.
+   *
+   * The key invariant vs. the previous implementation: we match on the parsed
+   * canonical repo name (`label.substring(2).substringBefore("//")`), not on a
+   * `contains` substring of the full label, so a module named "cpp" no longer
+   * matches canonical `abseil-cpp+`.
+   *
+   * @param changedModules Modules identified as changed between the two graphs
+   * @param from Starting-revision target hashes; used only to pick up labels whose
+   *     content changed independently of any module bump
+   * @param allTargets Final-revision target hashes (the set we can query against)
    * @return Set of target labels that are impacted by module changes
    */
   private fun queryTargetsDependingOnModules(
-      changedModuleKeys: Set<String>,
+      changedModules: Set<Module>,
+      from: Map<String, TargetHash>,
       allTargets: Map<String, TargetHash>
   ): Set<String> {
     return try {
-      // Inject BazelQueryService if available
       val queryService: BazelQueryService? = try {
         inject<BazelQueryService>().value
       } catch (e: Exception) {
@@ -305,59 +321,113 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
         return allTargets.keys
       }
 
-      val impactedTargets = mutableSetOf<String>()
+      val repoMapping: Map<String, String> =
+          try {
+            runBlocking { queryService.discoverRepoMapping() }
+          } catch (e: Exception) {
+            logger.w { "discoverRepoMapping failed, falling back to module-name matching: ${e.message}" }
+            emptyMap()
+          }
+      // Log size so operators can distinguish "Tier A had nothing to match
+      // against" from "Tier A matched but the module wasn't in root mapping".
+      // `discoverRepoMapping` returns an empty map on subprocess exit != 0
+      // without throwing, so we cannot rely on the catch block above to
+      // surface that case.
+      logger.i { "Discovered ${repoMapping.size} root repo mapping entries" }
 
-      for (moduleKey in changedModuleKeys) {
-        // Extract module name from key (e.g., "abseil-cpp" from "abseil-cpp@20240722.0")
-        val moduleName = moduleKey.substringBefore("@")
-        logger.i { "Querying targets depending on module: $moduleName (key: $moduleKey)" }
+      // Parse `allTargets` into the set of canonical repo names once, instead of
+      // rescanning every label per changed module.
+      val canonicalRepos: Set<String> = allTargets.keys.asSequence()
+          .filter { it.startsWith("@@") }
+          .map { it.substring(2).substringBefore("//") }
+          .filter { it.isNotEmpty() }
+          .toSet()
 
-        // Find the canonical repository name for this module from allTargets
-        // Bzlmod repos look like: @@abseil-cpp~20240116.2//... or @@rules_jvm_external~~maven~maven//...
-        val moduleRepos = allTargets.keys
-            .filter { it.startsWith("@@") && it.contains(moduleName) }
-            .map { it.substring(2).substringBefore("//") } // Extract repo name
-            .toSet()
-
+      // Collect the canonical repos to query once — multiple "changed modules"
+      // often collapse to the same canonical name (e.g. `findChangedModules`
+      // reports both `foo@1.0` removed and `foo@2.0` added, or two modules have
+      // overlapping extension-created children). Running `rdeps` per distinct
+      // canonical name — not per module iteration — avoids the redundant work.
+      val reposToQuery = mutableSetOf<String>()
+      for (module in changedModules) {
+        logger.i { "Resolving repos for changed module: ${module.name} (key: ${module.key})" }
+        val moduleRepos = reposOwnedBy(module, canonicalRepos, repoMapping)
         if (moduleRepos.isEmpty()) {
-          logger.w { "No external repository found for module $moduleName" }
+          logger.w { "No external repository found for module ${module.name}" }
           continue
         }
+        logger.i { "Found ${moduleRepos.size} repositories for module ${module.name}: ${moduleRepos.joinToString(", ")}" }
+        reposToQuery.addAll(moduleRepos)
+      }
 
-        logger.i { "Found ${moduleRepos.size} repositories for module $moduleName: ${moduleRepos.joinToString(", ")}" }
+      val impactedTargets = mutableSetOf<String>()
+      for (repoName in reposToQuery) {
+        try {
+          val queryExpression = "rdeps(//..., @@$repoName//...)"
+          logger.i { "Executing query: $queryExpression" }
 
-        // Query workspace targets that depend on any target in the changed module repo
-        for (repoName in moduleRepos) {
-          try {
-            // Use rdeps to find all workspace targets depending on this module
-            // rdeps(universe, target_set) finds all targets in universe that depend on target_set
-            val queryExpression = "rdeps(//..., @@$repoName//...)"
-            logger.i { "Executing query: $queryExpression" }
+          val rdeps = runBlocking { queryService.query(queryExpression, useCquery = false) }
+          val rdepLabels = rdeps.map { it.name }.filter { !it.startsWith("@@") }
 
-            val rdeps = runBlocking { queryService.query(queryExpression, useCquery = false) }
-            val rdepLabels = rdeps.map { it.name }.filter { !it.startsWith("@@") } // Filter to workspace targets only
-
-            logger.i { "Found ${rdepLabels.size} workspace targets depending on @@$repoName" }
-            impactedTargets.addAll(rdepLabels)
-          } catch (e: Exception) {
-            logger.w { "Failed to query rdeps for @@$repoName: ${e.message}" }
-            logger.w { "Conservatively marking all targets as impacted for this module" }
-            // On error for this module, add all workspace targets
-            impactedTargets.addAll(allTargets.keys.filter { !it.startsWith("@@") })
-          }
+          logger.i { "Found ${rdepLabels.size} workspace targets depending on @@$repoName" }
+          impactedTargets.addAll(rdepLabels)
+        } catch (e: Exception) {
+          logger.w { "Failed to query rdeps for @@$repoName: ${e.message}" }
+          logger.w { "Conservatively marking all targets as impacted for this module" }
+          impactedTargets.addAll(allTargets.keys.filter { !it.startsWith("@@") })
         }
       }
 
-      // Add directly changed targets from hash comparison (e.g., code changes)
-      val directlyChanged = computeSimpleImpactedTargets(emptyMap(), allTargets)
+      // Union with hash-diff results so we still surface labels whose content changed
+      // independently of any module version bump (e.g. a source file in `//app:app`
+      // edited in the same commit as a MODULE.bazel update). The earlier
+      // `computeSimpleImpactedTargets(emptyMap(), allTargets)` form returned every
+      // key in `allTargets`, which silently defeated the rdeps filtering above.
+      val directlyChanged = computeSimpleImpactedTargets(from, allTargets)
       impactedTargets.addAll(directlyChanged)
 
       logger.i { "Total targets impacted by module changes: ${impactedTargets.size}" }
       impactedTargets
     } catch (e: Exception) {
       logger.e(e) { "Error querying targets depending on modules" }
-      // On error, conservatively mark all targets as impacted
       allTargets.keys
     }
+  }
+
+  /**
+   * Canonical repos in `canonicalRepos` that belong to `module`, using Tier A
+   * (root repo mapping) plus Tier B (name-prefix fallback). See
+   * [queryTargetsDependingOnModules] for the full contract.
+   *
+   * @param module Changed module whose owned repos we want to resolve
+   * @param canonicalRepos Set of canonical repo names parsed from `allTargets.keys`
+   * @param repoMapping Root module's apparent→canonical repo mapping (may be empty)
+   * @return Canonical repos belonging to `module`, or empty if none matched (Tier C)
+   */
+  private fun reposOwnedBy(
+      module: Module,
+      canonicalRepos: Set<String>,
+      repoMapping: Map<String, String>
+  ): Set<String> {
+    val prefixes = mutableListOf<String>()
+    val exactMatches = mutableSetOf<String>()
+
+    val mappedCanonical = repoMapping[module.apparentName]
+    if (!mappedCanonical.isNullOrEmpty()) {
+      exactMatches.add(mappedCanonical)
+      prefixes.add("$mappedCanonical+")
+      prefixes.add("$mappedCanonical~")
+    }
+
+    // Tier B prefixes always apply — they cover transitive modules that root's
+    // `dump_repo_mapping` does not include, and also act as the sole source when
+    // `discoverRepoMapping` returned empty. `++`/`~~` are subsumed by `+`/`~`
+    // (extension-created repos start with `name+` or `name~` by definition).
+    prefixes.add("${module.name}+")
+    prefixes.add("${module.name}~")
+
+    return canonicalRepos.filter { repo ->
+      repo in exactMatches || prefixes.any { repo.startsWith(it) }
+    }.toSet()
   }
 }

--- a/cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt
@@ -374,7 +374,17 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
         } catch (e: Exception) {
           logger.w { "Failed to query rdeps for @@$repoName: ${e.message}" }
           logger.w { "Conservatively marking all targets as impacted for this module" }
-          impactedTargets.addAll(allTargets.keys.filter { !it.startsWith("@@") })
+          // Emit the buildable workspace subset when it exists; otherwise
+          // (bzlmod-only shape) fall through to every hashed label so the
+          // downstream `excludeExternalTargets` strip does not reduce the
+          // fallback to empty.
+          val buildableWorkspaceTargets = allTargets.keys.filter {
+            !it.startsWith("@@") && !it.startsWith("//external:")
+          }
+          impactedTargets.addAll(
+              if (buildableWorkspaceTargets.isEmpty()) allTargets.keys
+              else buildableWorkspaceTargets
+          )
         }
       }
 

--- a/cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt
@@ -1,6 +1,7 @@
 package com.bazel_diff.interactor
 
 import com.bazel_diff.bazel.BazelQueryService
+import com.bazel_diff.bazel.Module
 import com.bazel_diff.bazel.ModuleGraphParser
 import com.bazel_diff.hash.TargetHash
 import com.bazel_diff.log.Logger
@@ -50,7 +51,7 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
 
     val impactedTargets = if (changedModules.isNotEmpty()) {
       logger.i { "Module changes detected - querying for targets that depend on changed modules" }
-      queryTargetsDependingOnModules(changedModules, to)
+      queryTargetsDependingOnModules(changedModules, from, to)
     } else {
       computeSimpleImpactedTargets(from, to)
     }
@@ -103,7 +104,7 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
 
     val impactedTargets = if (changedModules.isNotEmpty()) {
       logger.i { "Module changes detected - querying for targets that depend on changed modules" }
-      val moduleImpactedTargets = queryTargetsDependingOnModules(changedModules, to)
+      val moduleImpactedTargets = queryTargetsDependingOnModules(changedModules, from, to)
       // Mark module-impacted targets with distance 0, then compute distances from there
       val moduleImpactedHashes = from.filterKeys { !moduleImpactedTargets.contains(it) }
       computeAllDistances(moduleImpactedHashes, to, depEdges)
@@ -259,40 +260,27 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
   }
 
   /**
-   * Detects module changes by comparing module graphs and returns changed module keys.
+   * Detects module changes by comparing module graphs and returns the changed Modules.
    *
-   * This method:
-   * 1. Parses the from and to module graphs
-   * 2. Identifies which modules changed (added, removed, or version changed)
-   * 3. Logs the changes for visibility
-   * 4. Returns the set of changed module keys
+   * Resolves each changed key against the "to" graph first (the state we will query
+   * against), falling back to the "from" graph for modules that were removed.
    *
-   * @param fromModuleGraphJson JSON from `bazel mod graph --output=json` for starting revision
-   * @param toModuleGraphJson JSON from `bazel mod graph --output=json` for final revision
-   * @return Set of changed module keys, empty if no changes
+   * @param fromModuleGraphJson JSON from `bazel mod graph --output=json` for the starting revision
+   * @param toModuleGraphJson JSON from `bazel mod graph --output=json` for the final revision
+   * @return Set of changed Modules, empty if no changes
    */
   private fun detectChangedModules(
       fromModuleGraphJson: String?,
       toModuleGraphJson: String?
-  ): Set<String> {
-    // If either module graph is missing, assume no changes
+  ): Set<Module> {
     if (fromModuleGraphJson == null || toModuleGraphJson == null) {
       return emptySet()
     }
 
-    // Parse module graphs
     val fromGraph = moduleGraphParser.parseModuleGraph(fromModuleGraphJson)
     val toGraph = moduleGraphParser.parseModuleGraph(toModuleGraphJson)
 
-    // Parse-asymmetry guard for https://github.com/Tinder/bazel-diff/issues/335.
-    // The JSON strings differ (otherwise we wouldn't be here), but exactly one side parsed
-    // to a non-empty graph. `bazel mod graph --output=json` always emits at least the root
-    // module, so an empty parse means the JSON was unparseable -- truncated, corrupted, a
-    // future serialisation change, or an older stderr-polluted capture from before #336.
-    // Treating every module on the parseable side as "added" would explode the impacted
-    // set: ~5k serial rdeps subprocesses with a real BazelQueryService, or `allTargets.keys`
-    // with none bound. Return empty so callers fall back to the per-target hash diff, which
-    // is bounded and correct for this case.
+    // Parse-asymmetry guard for https://github.com/Tinder/bazel-diff/issues/335 fix #2.
     if (fromGraph.isEmpty() != toGraph.isEmpty()) {
       logger.w {
         "Module graph parse asymmetry detected (one side parsed to ${fromGraph.size} modules, " +
@@ -302,31 +290,30 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
       return emptySet()
     }
 
-    // Find changed modules
-    val changedModules = moduleGraphParser.findChangedModules(fromGraph, toGraph)
+    val changedKeys = moduleGraphParser.findChangedModules(fromGraph, toGraph)
 
-    if (changedModules.isEmpty()) {
+    if (changedKeys.isEmpty()) {
       logger.i { "No module changes detected" }
-    } else {
-      logger.i { "Detected ${changedModules.size} module changes: ${changedModules.joinToString(", ")}" }
+      return emptySet()
     }
 
+    val changedModules = changedKeys.mapNotNull { key -> toGraph[key] ?: fromGraph[key] }.toSet()
+    logger.i { "Detected ${changedModules.size} module changes: ${changedModules.joinToString(", ") { it.key }}" }
     return changedModules
   }
 
   /**
    * Queries Bazel to find all workspace targets that depend on any changed module.
    *
-   * Maps every changed module to its matching bzlmod canonical repos, then issues a
-   * single `rdeps(//..., @@a//... + @@b//... + ...)` query. Bazel executes the union
-   * in one analysis pass, avoiding per-repo subprocess fan-out.
-   *
-   * @param changedModuleKeys Set of changed module keys (e.g., "abseil-cpp@20240722.0")
-   * @param allTargets Map of all targets from the final revision
-   * @return Set of target labels that are impacted by module changes
+   * Resolves each changed module to its base canonical repo (see
+   * [canonicalRepoIsBaseForModule]) and issues a single unioned `rdeps(//..., …)`
+   * query. The hash-diff over `from`/`allTargets` is unioned in below to surface
+   * labels whose content changed alongside a MODULE.bazel update; this is also how
+   * extension-repo content changes propagate to main-repo consumers.
    */
   private fun queryTargetsDependingOnModules(
-      changedModuleKeys: Set<String>,
+      changedModules: Set<Module>,
+      from: Map<String, TargetHash>,
       allTargets: Map<String, TargetHash>
   ): Set<String> {
     val queryService: BazelQueryService? = try {
@@ -340,65 +327,55 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
       return allTargets.keys
     }
 
-    // Map every changed module to its bzlmod canonical *base* repo. We deliberately do
-    // NOT pull in module-extension repos here (e.g. `aspect_bazel_lib++toolchains+bats_toolchains`):
-    // a loose `it.contains(moduleName)` substring scan matched all of them and produced
-    // ~5,000 serial rdeps subprocesses on the workspace in
-    // https://github.com/Tinder/bazel-diff/issues/335. Extension-repo target hashes
-    // propagate to main-repo consumers via the normal dep-hash chain, so the simple
-    // hash diff already catches consumers when an extension repo's contents actually
-    // change. The rdeps query only needs to find main-repo targets whose dependency on
-    // the module's *base* repo isn't reflected in a hash flip (MODULE.bazel-only bumps,
-    // dep additions/removals against an otherwise-unchanged repo, etc.).
-    //
-    // Canonical-name forms we recognise as the base repo for module X:
-    //   * Bazel 7+ default form:        `X+`                 (no version embedded)
-    //   * Bazel <7 form / multi-version: `X~<version>`       (e.g. abseil-cpp~20240722.0)
-    //   * Bazel 7+ with explicit version: `X+<version>`      (no further `+` segments)
-    //
-    // Extension-repo forms we reject:
-    //   * `X++<ext>+<repo>`             (Bazel 7+, empty version)
-    //   * `X+<version>+<ext>+<repo>`    (Bazel 7+, embedded version)
-    //   * `X~<version>~<ext>~<repo>`    (Bazel <7)
+    val canonicalRepos: Set<String> = allTargets.keys.asSequence()
+        .filter { it.startsWith("@@") }
+        .map { it.substring(2).substringBefore("//") }
+        .filter { it.isNotEmpty() }
+        .toSet()
+
     val moduleRepos = mutableSetOf<String>()
-    for (moduleKey in changedModuleKeys) {
-      val moduleName = moduleKey.substringBefore("@")
-      val matched = allTargets.keys
-          .filter { it.startsWith("@@") }
-          .mapNotNull { target ->
-            val canonical = target.substring(2).substringBefore("//")
-            if (canonicalRepoIsBaseForModule(canonical, moduleName)) canonical else null
-          }
-          .distinct()
-      if (matched.isEmpty()) {
-        logger.w { "No external repository matched module $moduleKey" }
-      } else {
-        logger.i { "Module $moduleKey matched ${matched.size} repos: ${matched.joinToString(", ")}" }
-        moduleRepos.addAll(matched)
+    var skippedNoMatch = 0
+    for (module in changedModules) {
+      logger.i { "Resolving repos for changed module: ${module.name} (key: ${module.key})" }
+      val resolved = canonicalRepos.filter { canonicalRepoIsBaseForModule(it, module.name) }.toSet()
+      if (resolved.isEmpty()) {
+        logger.i { "No external repository found for module ${module.name} (skipped)" }
+        skippedNoMatch++
+        continue
       }
+      logger.i { "Found ${resolved.size} repositories for module ${module.name}: ${resolved.joinToString(", ")}" }
+      moduleRepos.addAll(resolved)
+    }
+    if (skippedNoMatch > 0) {
+      logger.i { "Skipped $skippedNoMatch of ${changedModules.size} changed modules with no materialised repos in allTargets" }
     }
 
     if (moduleRepos.isEmpty()) {
       logger.i { "No external repositories matched any changed module" }
-      return computeSimpleImpactedTargets(emptyMap(), allTargets)
+      return computeSimpleImpactedTargets(from, allTargets)
     }
 
-    logger.i { "Querying rdeps for ${moduleRepos.size} repositories across ${changedModuleKeys.size} changed modules" }
+    logger.i { "Querying rdeps for ${moduleRepos.size} repositories across ${changedModules.size} changed modules" }
 
     val impactedTargets = mutableSetOf<String>()
     try {
-      // Single unioned rdeps query: bazel executes the union in one analysis pass.
       val queryExpression = "rdeps(//..., ${moduleRepos.joinToString(" + ") { "@@$it//..." }})"
       val rdeps = runBlocking { queryService.query(queryExpression, useCquery = false) }
       val rdepLabels = rdeps.map { it.name }.filter { !it.startsWith("@@") }
       logger.i { "Found ${rdepLabels.size} workspace targets depending on changed modules" }
       impactedTargets.addAll(rdepLabels)
     } catch (e: Exception) {
-      logger.e(e) { "Unioned rdeps query failed - conservatively marking all workspace targets impacted" }
-      impactedTargets.addAll(allTargets.keys.filter { !it.startsWith("@@") })
+      logger.e(e) { "Unioned rdeps query failed - falling back to buildable workspace targets (or every hashed label on bzlmod-only shapes)" }
+      val buildableWorkspaceTargets = allTargets.keys.filter(::isBuildableWorkspaceTarget)
+      impactedTargets.addAll(
+          if (buildableWorkspaceTargets.isEmpty()) allTargets.keys
+          else buildableWorkspaceTargets
+      )
     }
 
-    impactedTargets.addAll(computeSimpleImpactedTargets(emptyMap(), allTargets))
+    // Union with hash-diff results to surface labels whose content changed alongside
+    // the MODULE.bazel update.
+    impactedTargets.addAll(computeSimpleImpactedTargets(from, allTargets))
 
     logger.i { "Total targets impacted by module changes: ${impactedTargets.size}" }
     return impactedTargets
@@ -426,4 +403,10 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
     val versionSegment = rest.substring(1)
     return !versionSegment.contains('+') && !versionSegment.contains('~')
   }
+
+  // Distinct from the `excludeExternalTargets` filter at the output sites: this
+  // also strips `@@` so the rdeps-failure fallback can detect a bzlmod-only
+  // workspace shape.
+  private fun isBuildableWorkspaceTarget(label: String): Boolean =
+      !label.startsWith("@@") && !label.startsWith("//external:")
 }

--- a/cli/src/test/kotlin/com/bazel_diff/bazel/ModuleGraphParserTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/bazel/ModuleGraphParserTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import org.junit.Test
 
 class ModuleGraphParserTest {
@@ -130,6 +131,31 @@ class ModuleGraphParserTest {
     val result = parser.parseModuleGraph(json)
 
     assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun parseModuleGraph_withEmptyName_skipsModule() {
+    // Reproduces the JSON shape `bazel mod graph --output=json` emits for an
+    // unnamed root MODULE.bazel.
+    val json =
+        """
+      {
+        "key": "<root>",
+        "name": "",
+        "version": "",
+        "apparentName": "",
+        "dependencies": [
+          {"key": "platforms@1.0.0", "name": "platforms", "version": "1.0.0", "apparentName": "platforms"}
+        ]
+      }
+    """
+            .trimIndent()
+
+    val result = parser.parseModuleGraph(json)
+
+    assertThat(result).hasSize(1)
+    assertThat(result["platforms@1.0.0"]).isNotNull()
+    assertThat(result["<root>"]).isNull()
   }
 
   @Test

--- a/cli/src/test/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractorModuleQueryTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractorModuleQueryTest.kt
@@ -1,0 +1,362 @@
+package com.bazel_diff.interactor
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.doesNotContain
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import com.bazel_diff.SilentLogger
+import com.bazel_diff.bazel.BazelQueryService
+import com.bazel_diff.bazel.BazelTarget
+import com.bazel_diff.hash.TargetHash
+import com.bazel_diff.log.Logger
+import com.google.gson.GsonBuilder
+import java.io.StringWriter
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests for the module-change query path in [CalculateImpactedTargetsInteractor] that
+ * exercise the predicate matching changed modules to canonical external repos in
+ * `allTargets`. Lives in its own test class (instead of extending
+ * `CalculateImpactedTargetsInteractorTest`) so we can register a mocked
+ * [BazelQueryService] in Koin without disturbing the existing global `KoinTestRule`.
+ */
+class CalculateImpactedTargetsInteractorModuleQueryTest : KoinTest {
+
+  private val queryService: BazelQueryService = mock()
+
+  @Before
+  fun setUp() {
+    startKoin {
+      modules(
+          module {
+            single<Logger> { SilentLogger }
+            single { queryService }
+            single { GsonBuilder().disableHtmlEscaping().create() }
+          })
+    }
+  }
+
+  @After
+  fun tearDown() {
+    stopKoin()
+  }
+
+  @Test
+  fun matchesCanonicalPlusFormRepo() { runBlocking {
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@aspect_bazel_lib+//lib:foo" to TargetHash("Rule", "x", "x"),
+        "@@other+//x:y" to TargetHash("Rule", "o", "o"))
+
+    whenever(queryService.discoverRepoMapping())
+        .thenReturn(mapOf("aspect_bazel_lib" to "aspect_bazel_lib+"))
+    whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("aspect_bazel_lib", "2.10.0"),
+        toModuleGraphJson = graph("aspect_bazel_lib", "2.11.0"))
+
+    verify(queryService).query(eq("rdeps(//..., @@aspect_bazel_lib+//...)"), eq(false))
+    verify(queryService, never()).query(eq("rdeps(//..., @@other+//...)"), eq(false))
+    // rdeps returned empty and there are no hash-diff changes (from == to), so
+    // the impacted set must be empty. Guards against regression to the prior
+    // `computeSimpleImpactedTargets(emptyMap(), allTargets)` form, which unioned
+    // the full workspace back into the output.
+    assertThat(outputLines(writer)).isEmpty()
+  } }
+
+  @Test
+  fun matchesCanonicalTildeFormRepo() { runBlocking {
+    val start = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@abseil-cpp~20240116.2//absl:strings" to TargetHash("Rule", "x", "x"))
+    val end = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@abseil-cpp~20240722.0//absl:strings" to TargetHash("Rule", "y", "y"))
+
+    whenever(queryService.discoverRepoMapping()).thenReturn(emptyMap())
+    whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+    CalculateImpactedTargetsInteractor().execute(
+        from = start,
+        to = end,
+        outputWriter = StringWriter(),
+        targetTypes = null,
+        fromModuleGraphJson = graph("abseil-cpp", "20240116.2"),
+        toModuleGraphJson = graph("abseil-cpp", "20240722.0"))
+
+    verify(queryService).query(eq("rdeps(//..., @@abseil-cpp~20240722.0//...)"), eq(false))
+  } }
+
+  @Test
+  fun matchesExtensionCreatedRepoViaMapping() { runBlocking {
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@rules_jvm_external+//lib:foo" to TargetHash("Rule", "x", "x"),
+        "@@rules_jvm_external++maven+maven//:guava" to TargetHash("Rule", "y", "y"))
+
+    whenever(queryService.discoverRepoMapping())
+        .thenReturn(mapOf("rules_jvm_external" to "rules_jvm_external+"))
+    whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = StringWriter(),
+        targetTypes = null,
+        fromModuleGraphJson = graph("rules_jvm_external", "5.0"),
+        toModuleGraphJson = graph("rules_jvm_external", "6.0"))
+
+    verify(queryService).query(eq("rdeps(//..., @@rules_jvm_external+//...)"), eq(false))
+    verify(queryService).query(
+        eq("rdeps(//..., @@rules_jvm_external++maven+maven//...)"), eq(false))
+  } }
+
+  @Test
+  fun matchesExtensionCreatedRepoViaNameFallback() { runBlocking {
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@rules_jvm_external+//lib:foo" to TargetHash("Rule", "x", "x"),
+        "@@rules_jvm_external++maven+maven//:guava" to TargetHash("Rule", "y", "y"))
+
+    whenever(queryService.discoverRepoMapping()).thenReturn(emptyMap())
+    whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = StringWriter(),
+        targetTypes = null,
+        fromModuleGraphJson = graph("rules_jvm_external", "5.0"),
+        toModuleGraphJson = graph("rules_jvm_external", "6.0"))
+
+    verify(queryService).query(eq("rdeps(//..., @@rules_jvm_external+//...)"), eq(false))
+    verify(queryService).query(
+        eq("rdeps(//..., @@rules_jvm_external++maven+maven//...)"), eq(false))
+  } }
+
+  @Test
+  fun doesNotMatchUnrelatedRepoBySubstring() { runBlocking {
+    // Headline regression guard: module "cpp" must not match canonical "abseil-cpp+".
+    // Also asserts on output: stub `rdeps(@@cpp+//...)` to return `//foo:bar` and add
+    // a hash-diff change in `//app:app`. The impacted set must be exactly
+    // {//foo:bar, //app:app} — never {@@abseil-cpp+//absl:strings}.
+    val from = mapOf(
+        "//app:app" to TargetHash("Rule", "a1", "a1"),
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "b", "b"),
+        "@@cpp+//pkg:lib" to TargetHash("Rule", "c", "c"))
+    val to = mapOf(
+        "//app:app" to TargetHash("Rule", "a2", "a2"), // hash change
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "b", "b"),
+        "@@cpp+//pkg:lib" to TargetHash("Rule", "c", "c"))
+
+    whenever(queryService.discoverRepoMapping()).thenReturn(emptyMap())
+    whenever(queryService.query(any(), any())).thenAnswer { inv ->
+      if (inv.getArgument<String>(0) == "rdeps(//..., @@cpp+//...)") {
+        listOf(mockRuleTarget("//foo:bar"))
+      } else emptyList<BazelTarget>()
+    }
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().execute(
+        from = from,
+        to = to,
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("cpp", "1.0"),
+        toModuleGraphJson = graph("cpp", "2.0"))
+
+    val queryCaptor = argumentCaptor<String>()
+    verify(queryService).query(queryCaptor.capture(), any())
+    assertThat(queryCaptor.allValues).hasSize(1)
+    assertThat(queryCaptor.allValues).contains("rdeps(//..., @@cpp+//...)")
+    assertThat(queryCaptor.allValues).doesNotContain("rdeps(//..., @@abseil-cpp+//...)")
+    // Regression guard on the F2 fix: `@@abseil-cpp+//absl:strings` must NOT
+    // leak into the impacted set just because it shares a canonical-repo
+    // substring with the changed module.
+    assertThat(outputLines(writer)).containsExactlyInAnyOrder("//foo:bar", "//app:app")
+  } }
+
+  @Test
+  fun transitiveModuleNotInRootMappingUsesNameFallback() { runBlocking {
+    // Root mapping does not include deep_transitive_dep; Tier B matches by name prefix.
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@deep_transitive_dep~3.2.1//:lib" to TargetHash("Rule", "b", "b"))
+
+    whenever(queryService.discoverRepoMapping())
+        .thenReturn(mapOf("some_other_module" to "some_other_module+"))
+    whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = StringWriter(),
+        targetTypes = null,
+        fromModuleGraphJson = graph("deep_transitive_dep", "3.2.0"),
+        toModuleGraphJson = graph("deep_transitive_dep", "3.2.1"))
+
+    verify(queryService).query(
+        eq("rdeps(//..., @@deep_transitive_dep~3.2.1//...)"), eq(false))
+  } }
+
+  @Test
+  fun transitiveModuleWithNoMaterialisedReposIsNotQueried() { runBlocking {
+    // `ghost_module` has no canonical prefix anywhere in allTargets. The key
+    // behaviour under test is "no rdeps subprocess spawns for this module";
+    // the overall impacted set is determined by the existing conservative
+    // union (out of scope for this PR).
+    val hashes = mapOf("//app:app" to TargetHash("Rule", "a", "a"))
+
+    whenever(queryService.discoverRepoMapping()).thenReturn(emptyMap())
+
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = StringWriter(),
+        targetTypes = null,
+        fromModuleGraphJson = graph("ghost_module", "1.0"),
+        toModuleGraphJson = graph("ghost_module", "2.0"))
+
+    verify(queryService, never()).query(any(), any())
+  } }
+
+  @Test
+  fun multipleChangedModulesProduceDisjointMatchSets() { runBlocking {
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@abseil-cpp+//a:1" to TargetHash("Rule", "b", "b"),
+        "@@aspect_bazel_lib+//b:2" to TargetHash("Rule", "c", "c"))
+
+    whenever(queryService.discoverRepoMapping()).thenReturn(
+        mapOf(
+            "abseil-cpp" to "abseil-cpp+",
+            "aspect_bazel_lib" to "aspect_bazel_lib+"))
+    whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+    val fromGraph = """
+      {
+        "key": "root", "name": "root", "version": "", "apparentName": "root",
+        "dependencies": [
+          {"key": "abseil-cpp@1.0", "name": "abseil-cpp", "version": "1.0", "apparentName": "abseil-cpp"},
+          {"key": "aspect_bazel_lib@2.0", "name": "aspect_bazel_lib", "version": "2.0", "apparentName": "aspect_bazel_lib"}
+        ]
+      }
+    """.trimIndent()
+    val toGraph = """
+      {
+        "key": "root", "name": "root", "version": "", "apparentName": "root",
+        "dependencies": [
+          {"key": "abseil-cpp@2.0", "name": "abseil-cpp", "version": "2.0", "apparentName": "abseil-cpp"},
+          {"key": "aspect_bazel_lib@3.0", "name": "aspect_bazel_lib", "version": "3.0", "apparentName": "aspect_bazel_lib"}
+        ]
+      }
+    """.trimIndent()
+
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = StringWriter(),
+        targetTypes = null,
+        fromModuleGraphJson = fromGraph,
+        toModuleGraphJson = toGraph)
+
+    val queryCaptor = argumentCaptor<String>()
+    verify(queryService, times(2)).query(queryCaptor.capture(), any())
+    assertThat(queryCaptor.allValues).hasSize(2)
+    assertThat(queryCaptor.allValues).contains("rdeps(//..., @@abseil-cpp+//...)")
+    assertThat(queryCaptor.allValues).contains("rdeps(//..., @@aspect_bazel_lib+//...)")
+  } }
+
+  @Test
+  fun discoverRepoMappingFailureFallsBackToNameTier() { runBlocking {
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "b", "b"))
+
+    whenever(queryService.discoverRepoMapping())
+        .thenThrow(RuntimeException("simulated mapping failure"))
+    whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = StringWriter(),
+        targetTypes = null,
+        fromModuleGraphJson = graph("abseil-cpp", "20240116.2"),
+        toModuleGraphJson = graph("abseil-cpp", "20240722.0"))
+
+    verify(queryService).query(eq("rdeps(//..., @@abseil-cpp+//...)"), eq(false))
+  } }
+
+  @Test
+  fun executeWithDistancesRunsModuleQueryPath() { runBlocking {
+    // Covers the parallel module-query call site in `executeWithDistances`.
+    // Also confirms the F2 fix holds for the distances-output path: when `from == to`
+    // and rdeps returns empty, the JSON output is the empty-array `[]`, not every label.
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@aspect_bazel_lib+//lib:foo" to TargetHash("Rule", "x", "x"))
+
+    whenever(queryService.discoverRepoMapping())
+        .thenReturn(mapOf("aspect_bazel_lib" to "aspect_bazel_lib+"))
+    whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().executeWithDistances(
+        from = hashes,
+        to = hashes,
+        depEdges = emptyMap(),
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("aspect_bazel_lib", "2.10.0"),
+        toModuleGraphJson = graph("aspect_bazel_lib", "2.11.0"))
+
+    verify(queryService).query(eq("rdeps(//..., @@aspect_bazel_lib+//...)"), eq(false))
+    assertThat(writer.toString()).isEqualTo("[]")
+  } }
+
+  private fun outputLines(writer: StringWriter): List<String> =
+      writer.toString().lineSequence().filter { it.isNotBlank() }.toList()
+
+  private fun mockRuleTarget(name: String): BazelTarget.Rule {
+    val target = mock<BazelTarget.Rule>()
+    whenever(target.name).thenReturn(name)
+    return target
+  }
+
+  private fun graph(name: String, version: String): String = """
+    {
+      "key": "root",
+      "name": "root",
+      "version": "",
+      "apparentName": "root",
+      "dependencies": [
+        {"key": "$name@$version", "name": "$name", "version": "$version", "apparentName": "$name"}
+      ]
+    }
+  """.trimIndent()
+}

--- a/cli/src/test/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractorModuleQueryTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractorModuleQueryTest.kt
@@ -313,6 +313,66 @@ class CalculateImpactedTargetsInteractorModuleQueryTest : KoinTest {
   } }
 
   @Test
+  fun queryFailureOnBzlmodOnlyShapeEmitsAllHashedLabels() { runBlocking {
+    // No workspace-local `//...` labels, so the fallback must surface the
+    // full hash set. Otherwise the downstream `excludeExternalTargets`
+    // strip reduces it to empty.
+    val hashes = mapOf(
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "a", "a"),
+        "@@abseil-cpp+//absl:base" to TargetHash("Rule", "b", "b"),
+        "//external:com_google_absl" to TargetHash("Rule", "c", "c"))
+
+    whenever(queryService.discoverRepoMapping())
+        .thenReturn(mapOf("abseil-cpp" to "abseil-cpp+"))
+    whenever(queryService.query(any(), any()))
+        .thenThrow(RuntimeException("simulated bazel query failure"))
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("abseil-cpp", "20240116.2"),
+        toModuleGraphJson = graph("abseil-cpp", "20240722.0"))
+
+    verify(queryService).query(eq("rdeps(//..., @@abseil-cpp+//...)"), eq(false))
+    assertThat(outputLines(writer)).containsExactlyInAnyOrder(
+        "@@abseil-cpp+//absl:strings",
+        "@@abseil-cpp+//absl:base",
+        "//external:com_google_absl")
+  } }
+
+  @Test
+  fun queryFailureOnMixedWorkspacePreservesGranularity() { runBlocking {
+    // Fallback must return only the buildable `//...` subset when one
+    // exists, not every hashed label.
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "//lib:util" to TargetHash("Rule", "b", "b"),
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "c", "c"),
+        "@@other+//x:y" to TargetHash("Rule", "d", "d"),
+        "//external:abseil-cpp" to TargetHash("Rule", "e", "e"))
+
+    whenever(queryService.discoverRepoMapping())
+        .thenReturn(mapOf("abseil-cpp" to "abseil-cpp+"))
+    whenever(queryService.query(any(), any()))
+        .thenThrow(RuntimeException("simulated bazel query failure"))
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("abseil-cpp", "20240116.2"),
+        toModuleGraphJson = graph("abseil-cpp", "20240722.0"))
+
+    assertThat(outputLines(writer)).containsExactlyInAnyOrder(
+        "//app:app", "//lib:util")
+  } }
+
+  @Test
   fun executeWithDistancesRunsModuleQueryPath() { runBlocking {
     // Covers the parallel module-query call site in `executeWithDistances`.
     // Also confirms the F2 fix holds for the distances-output path: when `from == to`

--- a/cli/src/test/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractorModuleQueryTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractorModuleQueryTest.kt
@@ -1,0 +1,338 @@
+package com.bazel_diff.interactor
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.doesNotContain
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import com.bazel_diff.SilentLogger
+import com.bazel_diff.bazel.BazelQueryService
+import com.bazel_diff.bazel.BazelTarget
+import com.bazel_diff.hash.TargetHash
+import com.bazel_diff.log.Logger
+import com.google.gson.GsonBuilder
+import java.io.StringWriter
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests for the module-change query path in [CalculateImpactedTargetsInteractor] that
+ * exercise the predicate matching changed modules to canonical external repos in
+ * `allTargets`. Lives in its own test class (instead of extending
+ * `CalculateImpactedTargetsInteractorTest`) so we can register a mocked
+ * [BazelQueryService] in Koin without disturbing the existing global `KoinTestRule`.
+ */
+class CalculateImpactedTargetsInteractorModuleQueryTest : KoinTest {
+
+  private val queryService: BazelQueryService = mock()
+
+  @Before
+  fun setUp() {
+    startKoin {
+      modules(
+          module {
+            single<Logger> { SilentLogger }
+            single { queryService }
+            single { GsonBuilder().disableHtmlEscaping().create() }
+          })
+    }
+  }
+
+  @After
+  fun tearDown() {
+    stopKoin()
+  }
+
+  @Test
+  fun rdepsEmptyAndIdenticalHashesProducesEmptyImpactedSet() {
+    runBlocking {
+      // F2 sentinel for the execute() path: when rdeps returns no workspace targets
+      // and from == to, the impacted set must be empty. Catches a regression where
+      // the hash-diff union below the rdeps catch widens to allTargets.keys (the
+      // pre-fix `computeSimpleImpactedTargets(emptyMap(), allTargets)` form).
+      // Predicate shape, fan-out, and over-match cases are pinned by
+      // CalculateImpactedTargetsInteractorIssue335Test and
+      // CalculateImpactedTargetsInteractorTest.testUnionsRdepsAcrossChangedModules.
+      val hashes = mapOf(
+          "//app:app" to TargetHash("Rule", "a", "a"),
+          "@@aspect_bazel_lib+//lib:foo" to TargetHash("Rule", "x", "x"))
+
+      whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+      val writer = StringWriter()
+      CalculateImpactedTargetsInteractor().execute(
+          from = hashes,
+          to = hashes,
+          outputWriter = writer,
+          targetTypes = null,
+          fromModuleGraphJson = graph("aspect_bazel_lib", "2.10.0"),
+          toModuleGraphJson = graph("aspect_bazel_lib", "2.11.0"))
+
+      assertThat(outputLines(writer)).isEmpty()
+    }
+  }
+
+  @Test
+  fun doesNotMatchUnrelatedRepoBySubstring() { runBlocking {
+    // Module "cpp" must not match canonical "abseil-cpp+".
+    val from = mapOf(
+        "//app:app" to TargetHash("Rule", "a1", "a1"),
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "b", "b"),
+        "@@cpp+//pkg:lib" to TargetHash("Rule", "c", "c"))
+    val to = mapOf(
+        "//app:app" to TargetHash("Rule", "a2", "a2"), // hash change
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "b", "b"),
+        "@@cpp+//pkg:lib" to TargetHash("Rule", "c", "c"))
+
+    whenever(queryService.query(any(), any())).thenAnswer { inv ->
+      if (inv.getArgument<String>(0) == "rdeps(//..., @@cpp+//...)") {
+        listOf(mockRuleTarget("//foo:bar"))
+      } else emptyList<BazelTarget>()
+    }
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().execute(
+        from = from,
+        to = to,
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("cpp", "1.0"),
+        toModuleGraphJson = graph("cpp", "2.0"))
+
+    val queryCaptor = argumentCaptor<String>()
+    verify(queryService).query(queryCaptor.capture(), any())
+    assertThat(queryCaptor.allValues).hasSize(1)
+    assertThat(queryCaptor.allValues).contains("rdeps(//..., @@cpp+//...)")
+    assertThat(queryCaptor.allValues).doesNotContain("rdeps(//..., @@abseil-cpp+//...)")
+    assertThat(outputLines(writer)).containsExactlyInAnyOrder("//foo:bar", "//app:app")
+  } }
+
+  @Test
+  fun moduleWithNoMaterialisedReposIsNotQueried() { runBlocking {
+    // `ghost_module` has no canonical prefix anywhere in allTargets — no
+    // rdeps subprocess should spawn for this module. The early-return in
+    // queryTargetsDependingOnModules' "no module repos matched" branch must
+    // delegate to computeSimpleImpactedTargets(from, allTargets) so a real
+    // hash diff still surfaces, not collapse to empty or to allTargets.keys.
+    // The fixture has both a hash-changed and an unchanged target so the
+    // assertion distinguishes "delegates correctly" from "leaks all keys".
+    val from = mapOf(
+        "//app:changed" to TargetHash("Rule", "a", "a"),
+        "//app:unchanged" to TargetHash("Rule", "b", "b"))
+    val to = mapOf(
+        "//app:changed" to TargetHash("Rule", "a-new", "a-new"),
+        "//app:unchanged" to TargetHash("Rule", "b", "b"))
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().execute(
+        from = from,
+        to = to,
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("ghost_module", "1.0"),
+        toModuleGraphJson = graph("ghost_module", "2.0"))
+
+    verify(queryService, never()).query(any(), any())
+    assertThat(outputLines(writer)).containsExactlyInAnyOrder("//app:changed")
+  } }
+
+  @Test
+  fun versionBumpReportedAsAddPlusRemoveDedupesCanonical() { runBlocking {
+    // findChangedModules reports a version bump as {old removed, new added}.
+    // Both Modules share the canonical prefix; the union must contain it once.
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@foo+//pkg:lib" to TargetHash("Rule", "x", "x"))
+
+    whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = StringWriter(),
+        targetTypes = null,
+        fromModuleGraphJson = graph("foo", "1.0"),
+        toModuleGraphJson = graph("foo", "2.0"))
+
+    val queryCaptor = argumentCaptor<String>()
+    verify(queryService).query(queryCaptor.capture(), eq(false))
+    val unioned = queryCaptor.firstValue
+    assertThat(unioned.split("@@foo+//...")).hasSize(2)  // exactly one occurrence
+  } }
+
+  @Test
+  fun queryFailureOnBzlmodOnlyShapeEmitsAllHashedLabels() { runBlocking {
+    // No workspace-local `//...` labels, so the fallback must surface the
+    // full hash set. Otherwise the downstream `excludeExternalTargets`
+    // strip reduces it to empty.
+    val hashes = mapOf(
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "a", "a"),
+        "@@abseil-cpp+//absl:base" to TargetHash("Rule", "b", "b"),
+        "//external:com_google_absl" to TargetHash("Rule", "c", "c"))
+
+    whenever(queryService.query(any(), any()))
+        .thenThrow(RuntimeException("simulated bazel query failure"))
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("abseil-cpp", "20240116.2"),
+        toModuleGraphJson = graph("abseil-cpp", "20240722.0"))
+
+    verify(queryService).query(eq("rdeps(//..., @@abseil-cpp+//...)"), eq(false))
+    assertThat(outputLines(writer)).containsExactlyInAnyOrder(
+        "@@abseil-cpp+//absl:strings",
+        "@@abseil-cpp+//absl:base",
+        "//external:com_google_absl")
+  } }
+
+  @Test
+  fun queryFailureOnMixedWorkspacePreservesGranularity() { runBlocking {
+    // Fallback must return only the buildable `//...` subset when one
+    // exists, not every hashed label.
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "//lib:util" to TargetHash("Rule", "b", "b"),
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "c", "c"),
+        "@@other+//x:y" to TargetHash("Rule", "d", "d"),
+        "//external:abseil-cpp" to TargetHash("Rule", "e", "e"))
+
+    whenever(queryService.query(any(), any()))
+        .thenThrow(RuntimeException("simulated bazel query failure"))
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("abseil-cpp", "20240116.2"),
+        toModuleGraphJson = graph("abseil-cpp", "20240722.0"))
+
+    assertThat(outputLines(writer)).containsExactlyInAnyOrder(
+        "//app:app", "//lib:util")
+  } }
+
+  @Test
+  fun catchFallbackOnMixedWorkspaceStripsExternalUnderExcludeFlag() { runBlocking {
+    // Catch-fallback's buildable subset is `!@@ && !//external:`. Under
+    // excludeExternalTargets=true the downstream filter further strips
+    // `//external:*`. The externally-visible contract here is that
+    // //external:* never reaches the user when the flag is set, regardless
+    // of which layer did the strip — so a future regression that widens
+    // isBuildableWorkspaceTarget to include //external:* would still be
+    // caught at the output.
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "c", "c"),
+        "//external:abseil-cpp" to TargetHash("Rule", "e", "e"))
+
+    whenever(queryService.query(any(), any()))
+        .thenThrow(RuntimeException("simulated bazel query failure"))
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("abseil-cpp", "20240116.2"),
+        toModuleGraphJson = graph("abseil-cpp", "20240722.0"),
+        excludeExternalTargets = true)
+
+    assertThat(outputLines(writer)).containsExactlyInAnyOrder("//app:app")
+  } }
+
+  @Test
+  fun catchFallbackOnBzlmodOnlyKeepsCanonicalsUnderExcludeFlag() { runBlocking {
+    // Catch-fallback on a bzlmod-only workspace emits every hashed label
+    // (the buildable subset is empty). Under excludeExternalTargets=true the
+    // //external:* bridges are stripped but @@canonical labels survive — the
+    // headline "rebuild everything" signal still reaches the user. Catches a
+    // future regression that widens excludeExternalTargets to also strip @@,
+    // which would silently empty the output on bzlmod-only catch-fallbacks.
+    val hashes = mapOf(
+        "@@abseil-cpp+//absl:strings" to TargetHash("Rule", "a", "a"),
+        "@@abseil-cpp+//absl:base" to TargetHash("Rule", "b", "b"),
+        "//external:com_google_absl" to TargetHash("Rule", "c", "c"))
+
+    whenever(queryService.query(any(), any()))
+        .thenThrow(RuntimeException("simulated bazel query failure"))
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().execute(
+        from = hashes,
+        to = hashes,
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("abseil-cpp", "20240116.2"),
+        toModuleGraphJson = graph("abseil-cpp", "20240722.0"),
+        excludeExternalTargets = true)
+
+    assertThat(outputLines(writer)).containsExactlyInAnyOrder(
+        "@@abseil-cpp+//absl:strings",
+        "@@abseil-cpp+//absl:base")
+  } }
+
+  @Test
+  fun executeWithDistancesRunsModuleQueryPath() { runBlocking {
+    // Covers the module-query call site in `executeWithDistances`.
+    val hashes = mapOf(
+        "//app:app" to TargetHash("Rule", "a", "a"),
+        "@@aspect_bazel_lib+//lib:foo" to TargetHash("Rule", "x", "x"))
+
+    whenever(queryService.query(any(), any())).thenReturn(emptyList())
+
+    val writer = StringWriter()
+    CalculateImpactedTargetsInteractor().executeWithDistances(
+        from = hashes,
+        to = hashes,
+        depEdges = emptyMap(),
+        outputWriter = writer,
+        targetTypes = null,
+        fromModuleGraphJson = graph("aspect_bazel_lib", "2.10.0"),
+        toModuleGraphJson = graph("aspect_bazel_lib", "2.11.0"))
+
+    verify(queryService).query(eq("rdeps(//..., @@aspect_bazel_lib+//...)"), eq(false))
+    assertThat(writer.toString()).isEqualTo("[]")
+  } }
+
+  private fun outputLines(writer: StringWriter): List<String> =
+      writer.toString().lineSequence().filter { it.isNotBlank() }.toList()
+
+  private fun mockRuleTarget(name: String): BazelTarget.Rule {
+    val target = mock<BazelTarget.Rule>()
+    whenever(target.name).thenReturn(name)
+    return target
+  }
+
+  private fun graph(name: String, version: String): String = """
+    {
+      "key": "root",
+      "name": "root",
+      "version": "",
+      "apparentName": "root",
+      "dependencies": [
+        {"key": "$name@$version", "name": "$name", "version": "$version", "apparentName": "$name"}
+      ]
+    }
+  """.trimIndent()
+}


### PR DESCRIPTION
Partial fix for #335.

Layered on top #353 (parse-asymmetry guard), #354 (base-canonical-repo predicate). Hardens several edge cases in the surrounding code:

- **`Set<Module>` restructuring.** `detectChangedModules` now returns typed `Module`s instead of module-key strings, wiring `module.name` up to the canonical-match predicate.

- **Real hash diff in the rdeps union.** Fix `computeSimpleImpactedTargets(emptyMap(), allTargets)` returning `allTargets.keys` and silently unioning every target back into the rdeps result. Wire up `from` so the union uses the real hash diff.

- **reject empty `module.name` at the parser.** The unnamed-root `MODULE.bazel` case (where `bazel mod graph --output=json` emits `name=""`) would otherwise reach `canonicalRepoIsBaseForModule` and over-match every canonical.

- **Shape-aware rdeps-failure fallback.** The unconditional `!startsWith("@@")` filter left only `//external:*` bridges on bzlmod-only workspaces, which `excludeExternalTargets` default (from #334) then strips to empty. Instead emit the buildable subset (`//...` minus `//external:*`) when non-empty, otherwise every hashed label. Extracted as `isBuildableWorkspaceTarget`.

- **Log-noise downgrade.** Per-module "no external repository found" goes from `WARN` to `INFO`, plus a single aggregate `INFO` at the end.

**Tests** in `CalculateImpactedTargetsInteractorModuleQueryTest`: substring no-over-match, sentinel for `execute`, both branches of the shape-aware fallback, canonical dedup on add+remove version bumps, and the `excludeExternalTargets` interaction with the catch-fallback. New `ModuleGraphParserTest` case for empty-name rejection.

Changes vs the previous PR draft:

- Drops the "two-tier predicate / Tier A / Tier B" framing from previous; canonicalRepoIsBaseForModule from #334 does this more concisely
- Drops the long-form test enumeration in favour of a short paragraph that names the invariants covered, not individual test methods
- Adds the new excludeExternalTargets interaction tests to the test summary.