### PR TITLE
Reproducer test for #335 ModuleGraphParser stderr-pollution

### DIFF
--- a/cli/src/test/kotlin/com/bazel_diff/bazel/ModuleGraphParserTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/bazel/ModuleGraphParserTest.kt
@@ -264,4 +264,61 @@ class ModuleGraphParserTest {
     assertThat(result).hasSize(2)
     assertThat(result).containsExactlyInAnyOrder("root", "abseil-cpp@20240116.2")
   }
+
+  // ------------------------------------------------------------------------
+  // Reproducer for https://github.com/Tinder/bazel-diff/issues/335
+  // ------------------------------------------------------------------------
+  // bazel-diff 18.0.x captured stderr alongside stdout when fetching the bzlmod graph
+  // (BazelModService used Redirect.CAPTURE for both streams, which internally calls
+  // redirectErrorStream(true)). That meant `getModuleGraphJson()` could return a payload
+  // shaped like:
+  //   "INFO: Checking for file changes...\n{...real JSON...}\n"
+  //
+  // 18.1.0 fixed the redirect (PR #330), but a CI workflow that reused a base graph file
+  // produced by an older deployment now feeds this stderr-prefixed string back into
+  // parseModuleGraph(). The current implementation calls JsonParser.parseString() on the
+  // whole input and silently returns emptyMap() when parsing fails. Downstream,
+  // findChangedModules(emptyMap, fullMap) treats every module in the new graph as "added"
+  // and CalculateImpactedTargetsInteractor.queryTargetsDependingOnModules() then spawns
+  // a serial `bazel query rdeps(//..., @@<repo>//...)` subprocess per match -- thousands of
+  // them on a real workspace, taking hours.
+  //
+  // The fix is to make parseModuleGraph tolerant of leading non-JSON noise: locate the
+  // first '{' and parse from there, or strip known stderr prefixes. Once the parser
+  // handles this input, remove @Ignore from this test.
+  @Test
+  @org.junit.Ignore(
+      "Reproducer for https://github.com/Tinder/bazel-diff/issues/335 - parseModuleGraph " +
+          "should be robust to stderr-pollution prefixes from older bazel-diff versions. " +
+          "Today it silently returns emptyMap() and downstream code treats every module " +
+          "as 'added', triggering thousands of serial bazel queries.")
+  fun parseModuleGraph_withStderrPolluted_extractsModules_reproducerForIssue335() {
+    val pollutedJson =
+        """
+      INFO: Checking for file changes...
+      {
+        "key": "root",
+        "name": "my-project",
+        "version": "1.0.0",
+        "apparentName": "my-project",
+        "dependencies": [
+          {
+            "key": "guava@31.1",
+            "name": "guava",
+            "version": "31.1",
+            "apparentName": "guava",
+            "dependencies": []
+          }
+        ]
+      }
+    """
+            .trimIndent()
+
+    val result = parser.parseModuleGraph(pollutedJson)
+
+    // Desired behaviour: the stderr prefix is tolerated and both modules are extracted.
+    // Current behaviour: JsonParser.parseString fails and parseModuleGraph returns emptyMap().
+    assertThat(result).hasSize(2)
+    assertThat(result.keys).containsExactlyInAnyOrder("root", "guava@31.1")
+  }
 }


### PR DESCRIPTION
## Summary
- Adds an `@Ignore`d reproducer test for [#335](https://github.com/Tinder/bazel-diff/issues/335) on `ModuleGraphParser.parseModuleGraph`.
- The test feeds the parser an `INFO: Checking for file changes...\n{json}` payload (the exact shape an 18.0.x base graph could produce because of the old `Redirect.CAPTURE` + `redirectErrorStream(true)` combo in `BazelModService`) and asserts that the parser still extracts both modules.
- Today the parser calls `JsonParser.parseString()` on the whole input, fails, and returns `emptyMap()`. Downstream, `findChangedModules(emptyMap, fullMap)` treats every module in the new graph as "added" and `CalculateImpactedTargetsInteractor.queryTargetsDependingOnModules()` spawns a serial `bazel query rdeps(//..., @@<repo>//...)` subprocess per match — thousands of them on a real workspace, taking hours.
- The fix is to make `parseModuleGraph` tolerant of leading non-JSON noise (strip stderr prefixes or locate the first `{` to parse from). Once that lands, remove `@Ignore` from the test.

This is a test-only change. The reproducer is marked `@org.junit.Ignore` so CI stays green; the annotation also documents the issue it tracks.

## Test plan
- [x] `bazel build //cli:cli-test-lib` succeeds.
- [x] `bazel test //cli:ModuleGraphParserTest` passes (the new test is `@Ignore`d and skipped; existing tests still pass).
- [ ] After the parser fix lands, remove `@Ignore` and re-run `bazel test //cli:ModuleGraphParserTest` — the reproducer should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)