### PR TITLE
Hash only the owner execute bit on source files

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/hash/SourceFileHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/SourceFileHasher.kt
@@ -92,17 +92,7 @@ class SourceFileHasherImpl : KoinComponent, SourceFileHasher {
         safePutBytes(contentHash.toByteArray())
         putBytes(byteArrayOf(0x01))
         val absoluteFilePath = workingDirectory.resolve(filenamePath)
-        val isExecutable =
-            try {
-              Files.getPosixFilePermissions(absoluteFilePath).let { perms ->
-                perms.contains(PosixFilePermission.OWNER_EXECUTE) ||
-                    perms.contains(PosixFilePermission.GROUP_EXECUTE) ||
-                    perms.contains(PosixFilePermission.OTHERS_EXECUTE)
-              }
-            } catch (_: Exception) {
-              absoluteFilePath.toFile().canExecute()
-            }
-        putBytes(byteArrayOf(if (isExecutable) 0x01 else 0x00))
+        putBytes(byteArrayOf(if (isOwnerExecutable(absoluteFilePath)) 0x01 else 0x00))
       } else {
         val absoluteFilePath = workingDirectory.resolve(filenamePath)
         val file = absoluteFilePath.toFile()
@@ -115,17 +105,7 @@ class SourceFileHasherImpl : KoinComponent, SourceFileHasher {
             }
             // Mark that file exists
             putBytes(byteArrayOf(0x01))
-            val isExecutable =
-                try {
-                  Files.getPosixFilePermissions(absoluteFilePath).let { perms ->
-                    perms.contains(PosixFilePermission.OWNER_EXECUTE) ||
-                        perms.contains(PosixFilePermission.GROUP_EXECUTE) ||
-                        perms.contains(PosixFilePermission.OTHERS_EXECUTE)
-                  }
-                } catch (_: Exception) {
-                  file.canExecute()
-                }
-            putBytes(byteArrayOf(if (isExecutable) 0x01 else 0x00))
+            putBytes(byteArrayOf(if (isOwnerExecutable(absoluteFilePath)) 0x01 else 0x00))
           }
         } else {
           logger.w { "File $absoluteFilePath not found" }
@@ -154,6 +134,16 @@ class SourceFileHasherImpl : KoinComponent, SourceFileHasher {
 
     return digest(sourceFileTarget, modifiedFilepaths)
   }
+
+  // Git's index only tracks the owner execute bit (100644 vs 100755); group/others bits don't
+  // affect the build and differ between checkouts under different umasks. Mirror that behavior so
+  // hashes don't churn when only group/others bits flip.
+  private fun isOwnerExecutable(absoluteFilePath: Path): Boolean =
+      try {
+        Files.getPosixFilePermissions(absoluteFilePath).contains(PosixFilePermission.OWNER_EXECUTE)
+      } catch (_: Exception) {
+        absoluteFilePath.toFile().canExecute()
+      }
 
   private fun isMainRepo(name: String): Int {
     if (name.startsWith("//")) {

--- a/cli/src/test/kotlin/com/bazel_diff/hash/SourceFileHasherTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/hash/SourceFileHasherTest.kt
@@ -240,16 +240,45 @@ internal class SourceFileHasherTest : KoinTest {
         val permsWithoutExec =
             Files.getPosixFilePermissions(filePath) - PosixFilePermission.OWNER_EXECUTE
         Files.setPosixFilePermissions(filePath, permsWithoutExec)
-        val nonExecutableHash =
-            hasher.digest(BazelSourceFileTarget(target, seed)).toHexString()
+        val nonExecutableHash = hasher.digest(BazelSourceFileTarget(target, seed)).toHexString()
 
         val permsWithExec = permsWithoutExec + PosixFilePermission.OWNER_EXECUTE
         Files.setPosixFilePermissions(filePath, permsWithExec)
-        val executableHash =
-            hasher.digest(BazelSourceFileTarget(target, seed)).toHexString()
+        val executableHash = hasher.digest(BazelSourceFileTarget(target, seed)).toHexString()
 
         // Hashes must differ when executable bit changes — currently fails (issue #325)
         assertThat(nonExecutableHash).isNotEqualTo(executableHash)
+      }
+
+  // Only the OWNER execute bit matters — git's index only tracks 100644 vs 100755, so toggling the
+  // group/others execute bits should not produce a different hash (avoids churn from umask
+  // differences between checkouts).
+  @Test
+  fun testHashIgnoresGroupAndOthersExecuteBits() =
+      runBlocking<Unit> {
+        val testDir = Files.createTempDirectory("group_other_exec_test")
+        val filePath = testDir.resolve("path/to/file.txt")
+        Files.createDirectories(filePath.parent)
+        Files.createFile(filePath)
+        filePath.toFile().writeText("contents")
+
+        val target = "//path/to:file.txt"
+        val hasher = SourceFileHasherImpl(testDir, null, externalRepoResolver)
+
+        val ownerOnly = setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+        Files.setPosixFilePermissions(filePath, ownerOnly)
+        val baselineHash = hasher.digest(BazelSourceFileTarget(target, seed)).toHexString()
+
+        val withGroupExec = ownerOnly + PosixFilePermission.GROUP_EXECUTE
+        Files.setPosixFilePermissions(filePath, withGroupExec)
+        val groupExecHash = hasher.digest(BazelSourceFileTarget(target, seed)).toHexString()
+
+        val withOthersExec = ownerOnly + PosixFilePermission.OTHERS_EXECUTE
+        Files.setPosixFilePermissions(filePath, withOthersExec)
+        val othersExecHash = hasher.digest(BazelSourceFileTarget(target, seed)).toHexString()
+
+        assertThat(groupExecHash).isEqualTo(baselineHash)
+        assertThat(othersExecHash).isEqualTo(baselineHash)
       }
 
   @Test


### PR DESCRIPTION
## Summary

- Narrow [`SourceFileHasher`](cli/src/main/kotlin/com/bazel_diff/hash/SourceFileHasher.kt) to check only `PosixFilePermission.OWNER_EXECUTE` instead of OR'ing owner/group/others. Pulled into a private `isOwnerExecutable` helper to avoid duplicating the try/catch at both call sites.
- Add regression test `testHashIgnoresGroupAndOthersExecuteBits` that hashes the same file with mode `rw-------`, `rw---x---`, and `rw------x` and asserts all three hashes are identical.
- Existing `testHashExecutableBitChange` (issue #325) still passes since it only toggles `OWNER_EXECUTE`.

## Why

Cross-referencing how a sibling tool handles this: [bazel-contrib/target-determinator](https://github.com/bazel-contrib/target-determinator) shipped commit [`5bfae36`](https://github.com/bazel-contrib/target-determinator/commit/5bfae36c7d5115c2e7a1d0ad97a25f67341bdcb2) ("fix(hash_cache): only take user execute bits into account") for the same reason:

> There are some cases where files are initially created with some permissions (e.g. 775) but are then created by git with different permissions (e.g. 755) when cloning, checking out a branch or creating a worktree. Such differences don't matter to git nor to Bazel; consequently, they should not change the hash of a source file in target-determinator. The execution bit for the user (e.g. 744 vs 644) does matter, though, and should be part of the hash.

Git's index only records `100644` vs `100755` — the owner execute bit. Group/others execute bits aren't represented and can flip between checkouts under different umasks. Folding them into the hash adds noise without buying any signal that the build cares about.

The current OR-of-three logic was introduced in #331 (fix for #325). #325's example use case (toggling the owner execute bit on a script under a `filegroup`) is preserved by this change.

## Test plan

- [x] `bazel test //cli:SourceFileHasherTest` passes locally (`testHashExecutableBitChange` and the new `testHashIgnoresGroupAndOthersExecuteBits` both green).
- [x] `bazel test //cli:BuildGraphHasherTest //cli:TargetHashTest` passes locally — no broader regressions.
- [ ] CI on ubuntu+macos × Bazel 7/8/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)