### PR TITLE
Make rules_python, rules_nodejs, rules_foreign_cc dev_dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,10 +25,14 @@ single_version_override(
 
 bazel_dep(name = "grpc", version = "1.76.0", repo_name = "com_github_grpc_grpc")
 
-# Override transitive dependencies to Bazel 9 compatible versions
-bazel_dep(name = "rules_nodejs", version = "6.7.3")
-bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
-bazel_dep(name = "rules_python", version = "1.8.4")
+# Override transitive dependencies to Bazel 9 compatible versions.
+# Marked dev_dependency: these are only needed when building bazel-diff itself
+# (as the root module). rules_nodejs and rules_foreign_cc are not referenced by
+# any bazel-diff target, and rules_python is supplied transitively (proto codegen)
+# regardless, so consumers resolve their own versions via MVS.
+bazel_dep(name = "rules_nodejs", version = "6.7.3", dev_dependency = True)
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.8.4", dev_dependency = True)
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(


### PR DESCRIPTION
## What

Marks `rules_python`, `rules_nodejs`, and `rules_foreign_cc` as `dev_dependency = True` in `MODULE.bazel`.

## Why
Adding these non-dev `bazel_dep`s is disruptive to downstream consumers and should only be added if necessary.

These `bazel_dep`s exist only to override transitive dependencies to Bazel 9 compatible versions — a concern that only applies when building bazel-diff itself as the root module. `bazel mod graph` confirms all three are present transitively regardless, so the explicit edges only contribute a version pin (via MVS):

| Module | Pinned at root | Transitive fallback when consumed |
|---|---|---|
| rules_python | 1.8.4 | 1.7.0 (Bazel 9) |
| rules_nodejs | 6.7.3 | 5.8.2 |
| rules_foreign_cc | 0.15.1 | 0.10.1 |

`rules_nodejs` and `rules_foreign_cc` are referenced by no bazel-diff target; `rules_python` is supplied transitively (proto codegen). Keeping them out of the non-dev graph reduces what downstream consumers inherit.

## Testing

Verified with **Bazel 9.1.0**:

- Root `bazel build //...` (dev deps active) — all 44 targets build.
- Root `bazel test //cli/...` (mirrors BCR `bcr_test_module`) — 22/22 pass.
- `bazel build //:bazel-diff --ignore_dev_dependency` (mirrors the BCR `build_targets` job: bazel-diff consumed as a non-root module, pins dropped, rules_python at 1.7.0) — builds successfully.