### PR TITLE
fix: use workspace-stable content-hash key for external repo source f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,11 @@ workspace.
                             when invoking `bazel query`
       --contentHashPath=<contentHashPath>
                           Path to content hash json file. It's a map which maps
-                            relative file path from workspace path to its
-                            content hash. Files in this map will skip content
-                            hashing and use provided value
+                            a workspace-relative file path (and
+                            `external/<repoName>/<path>` for fine-grained
+                            external repo files) to its content hash. Files in
+                            this map will skip content hashing and use provided
+                            value
       --cqueryCommandOptions=<cqueryCommandOptions>
                           Additional space separated Bazel command options used
                             when invoking `bazel cquery`. This flag is has no

--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -45,7 +45,7 @@ open class GenerateHashesCommand : Callable<Int> {
       names = ["--contentHashPath"],
       description =
           [
-              "Path to content hash json file. It's a map which maps relative file path from workspace path to its content hash. Files in this map will skip content hashing and use provided value"],
+              "Path to content hash json file. It's a map which maps a workspace-relative file path (and `external/<repoName>/<path>` for fine-grained external repo files) to its content hash. Files in this map will skip content hashing and use provided value"],
       scope = CommandLine.ScopeType.INHERIT,
       required = false)
   var contentHashPath: File? = null

--- a/cli/src/main/kotlin/com/bazel_diff/hash/SourceFileHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/SourceFileHasher.kt
@@ -66,29 +66,37 @@ class SourceFileHasherImpl : KoinComponent, SourceFileHasher {
     return sha256 {
       val name = sourceFileTarget.name
       val index = isMainRepo(name)
-      val filenamePath =
-          if (index != -1) {
-            val filenameSubstring = name.substring(index)
-            Paths.get(filenameSubstring.removePrefix(":").replace(':', '/'))
-          } else if (name.startsWith("@")) {
-            val parts = name.replaceFirst("@+".toRegex(), "").split("//")
-            if (parts.size != 2) {
-              logger.w { "Invalid source label $name" }
-              return@sha256
-            }
-            val repoName = parts[0]
-            if (repoName !in fineGrainedHashExternalRepoNames) {
-              return@sha256
-            }
-            val relativePath = Paths.get(parts[1].removePrefix(":").replace(':', '/'))
-            val externalRepoRoot = externalRepoResolver.resolveExternalRepoRoot(repoName)
-            externalRepoRoot.resolve(relativePath)
-          } else {
-            return@sha256
-          }
-      val filenamePathString = filenamePath.toString()
-      if (relativeFilenameToContentHash?.contains(filenamePathString) == true) {
-        val contentHash = relativeFilenameToContentHash.getValue(filenamePathString)
+      // `filenamePath` locates the file on disk (absolute for external repos, since they live under
+      // the Bazel output base). `contentHashKey` is the key used to look the file up in a
+      // user-provided content-hash map and MUST stay workspace-relative / machine-independent so the
+      // map is portable across machines — the resolved external repo root is an absolute path under
+      // the output base (which embeds machine-specific components like the build-agent dir), so it
+      // must never be used as the lookup key.
+      val filenamePath: Path
+      val contentHashKey: String
+      if (index != -1) {
+        val filenameSubstring = name.substring(index)
+        filenamePath = Paths.get(filenameSubstring.removePrefix(":").replace(':', '/'))
+        contentHashKey = filenamePath.toString()
+      } else if (name.startsWith("@")) {
+        val parts = name.replaceFirst("@+".toRegex(), "").split("//")
+        if (parts.size != 2) {
+          logger.w { "Invalid source label $name" }
+          return@sha256
+        }
+        val repoName = parts[0]
+        if (repoName !in fineGrainedHashExternalRepoNames) {
+          return@sha256
+        }
+        val relativePath = Paths.get(parts[1].removePrefix(":").replace(':', '/'))
+        val externalRepoRoot = externalRepoResolver.resolveExternalRepoRoot(repoName)
+        filenamePath = externalRepoRoot.resolve(relativePath)
+        contentHashKey = Paths.get("external", repoName).resolve(relativePath).toString()
+      } else {
+        return@sha256
+      }
+      if (relativeFilenameToContentHash?.contains(contentHashKey) == true) {
+        val contentHash = relativeFilenameToContentHash.getValue(contentHashKey)
         safePutBytes(contentHash.toByteArray())
         putBytes(byteArrayOf(0x01))
         val absoluteFilePath = workingDirectory.resolve(filenamePath)

--- a/cli/src/test/kotlin/com/bazel_diff/hash/SourceFileHasherTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/hash/SourceFileHasherTest.kt
@@ -107,6 +107,35 @@ internal class SourceFileHasherTest : KoinTest {
   }
 
   @Test
+  fun testHashExternalRepoWithProvidedContentHash() = runBlocking {
+    // The content-hash map key for an external-repo file must be the workspace-stable
+    // `external/<repoName>/<relativePath>` form, NOT the absolute path under the (machine-specific)
+    // Bazel output base. Otherwise a content-hash map generated on one machine never matches on
+    // another.
+    val externalRepoFilePath = outputBasePath.resolve("external/external_repo/path/to/my_file.txt")
+    Files.createDirectories(externalRepoFilePath.parent)
+    externalRepoFilePath.toFile().writeText("on disk content that must be ignored")
+    val externalRepoFileTarget = "@external_repo//path/to:my_file.txt"
+    val filenameToContentHash =
+        hashMapOf("external/external_repo/path/to/my_file.txt" to "external-content-hash")
+    val hasher =
+        SourceFileHasherImpl(
+            repoAbsolutePath, filenameToContentHash, externalRepoResolver, setOf("external_repo"))
+    val bazelSourceFileTarget = BazelSourceFileTarget(externalRepoFileTarget, seed)
+    val actual = hasher.digest(bazelSourceFileTarget).toHexString()
+    val expected =
+        sha256 {
+              safePutBytes("external-content-hash".toByteArray())
+              putBytes(byteArrayOf(0x01))
+              putBytes(byteArrayOf(0x00)) // writeText creates a non-executable file
+              safePutBytes(seed)
+              safePutBytes(externalRepoFileTarget.toByteArray())
+            }
+            .toHexString()
+    assertThat(actual).isEqualTo(expected)
+  }
+
+  @Test
   fun testSoftHashConcreteFile() = runBlocking {
     val hasher = SourceFileHasherImpl(repoAbsolutePath, null, externalRepoResolver)
     val bazelSourceFileTarget = BazelSourceFileTarget(fixtureFileTarget, seed)


### PR DESCRIPTION
…iles

Source file digests are already content-based and path-independent, but the content-hash-provider lookup key for fine-grained external repo files was the absolute path under the Bazel output base (e.g.
/var/lib/buildkite-agent/builds/.../external/<repo>/...). That path embeds machine/instance-specific components, so a --contentHashPath map generated on one machine could never match external-repo entries on another, defeating the cross-machine cache and reintroducing non-determinism for any rule depending on those source files.

Use a workspace-stable key (external/<repoName>/<relativePath>) for the content-hash lookup while still resolving the absolute path solely to read the file from disk. Main-repo keys are unchanged.
