### PR TITLE
test: reproducer for #398 (--keep_going silently drops targets on repo-rule failure)

### DIFF
--- a/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
@@ -1276,6 +1276,67 @@ class E2ETest {
     assertThat(hashes.contains("failing_analysis_target")).isEqualTo(false)
   }
 
+  @Test
+  fun testKeepGoingSilentlyDropsTargetsOnRepoRuleFailure_reproducerForIssue398() {
+    // Reproducer for https://github.com/Tinder/bazel-diff/issues/398
+    //
+    // `--keep_going` defaults to `true`, and bazel-diff treats a partial
+    // `bazel query` (exit code 3) as success. When a repository rule fails to resolve --
+    // e.g. a transient network error fetching a remote dependency such as
+    //
+    //   fetch_repo: buf.build/go/protovalidate@v1.1.3:
+    //       Get "https://proxy.golang.org/...": net/http: TLS handshake timeout
+    //
+    // -- the package that references that repo silently disappears from the query results,
+    // and bazel-diff emits a hash set that is missing those targets WITHOUT any error. This
+    // makes hashes non-deterministic across runs (a target present when the fetch succeeds
+    // vanishes when it flakes). Setting `--no-keep_going` instead fails loudly, which keeps
+    // hashes deterministic.
+    //
+    // The `keep_going_repo_failure` workspace has two packages:
+    //   //good -- a plain genrule with no external deps (always resolvable)
+    //   //bad  -- loads a .bzl from @failing_dep, whose repository rule always fails to fetch
+    //
+    // This test pins the CURRENT (buggy) behavior so a future fix / default change is caught.
+    val workspace = copyTestWorkspace("keep_going_repo_failure")
+    val outputDir = temp.newFolder()
+
+    val cli = CommandLine(BazelDiff())
+
+    // Default behavior (--keep_going=true): generate-hashes SUCCEEDS despite the unresolvable
+    // repo, because bazel query returns exit code 3 (partial results) which bazel-diff allows.
+    val keepGoingOutput = File(outputDir, "hashes_keep_going.json")
+    val keepGoingExit =
+        cli.execute(
+            "generate-hashes",
+            "-w",
+            workspace.absolutePath,
+            "-b",
+            "bazel",
+            keepGoingOutput.absolutePath)
+    assertThat(keepGoingExit).isEqualTo(0)
+
+    // The healthy //good target is hashed, but //bad has been silently dropped -- this is the
+    // incorrect/non-deterministic hash set the bug produces.
+    val keepGoingHashes = keepGoingOutput.readText()
+    assertThat(keepGoingHashes.contains("//good:good")).isEqualTo(true)
+    assertThat(keepGoingHashes.contains("//bad:")).isEqualTo(false)
+
+    // With --no-keep_going, bazel query fails outright (non-zero, non-partial exit code) and
+    // bazel-diff surfaces the error instead of writing a truncated hash set.
+    val noKeepGoingOutput = File(outputDir, "hashes_no_keep_going.json")
+    val noKeepGoingExit =
+        cli.execute(
+            "generate-hashes",
+            "-w",
+            workspace.absolutePath,
+            "-b",
+            "bazel",
+            "--no-keep_going",
+            noKeepGoingOutput.absolutePath)
+    assertThat(noKeepGoingExit).isEqualTo(1)
+  }
+
   /**
    * Returns the Bazel version triple by running `bazel version`, or null if it cannot be
    * determined.

--- a/cli/src/test/resources/workspaces/keep_going_repo_failure/BUILD
+++ b/cli/src/test/resources/workspaces/keep_going_repo_failure/BUILD
@@ -1,0 +1,1 @@
+# Root package intentionally left without targets; see //good and //bad.

--- a/cli/src/test/resources/workspaces/keep_going_repo_failure/MODULE.bazel
+++ b/cli/src/test/resources/workspaces/keep_going_repo_failure/MODULE.bazel
@@ -1,0 +1,18 @@
+module(
+    name = "keep_going_repo_failure",
+    version = "0.0.0",
+)
+
+# A module extension that declares a repository whose fetch implementation always
+# fails. This simulates a repo rule that cannot be resolved at query time -- e.g. an
+# http_archive / go_deps repo that fails to download because of a network error like:
+#
+#   fetch_repo: buf.build/go/protovalidate@v1.1.3:
+#       Get "https://proxy.golang.org/...": net/http: TLS handshake timeout
+#
+# The extension itself resolves fine (so `bazel mod`/module resolution succeeds); only
+# fetching the `@failing_dep` repo fails, and that only happens when a package that
+# references it is loaded (see //bad:BUILD).
+failing_ext = use_extension("//:ext.bzl", "failing_ext")
+
+use_repo(failing_ext, "failing_dep")

--- a/cli/src/test/resources/workspaces/keep_going_repo_failure/bad/BUILD
+++ b/cli/src/test/resources/workspaces/keep_going_repo_failure/bad/BUILD
@@ -1,0 +1,9 @@
+# This package loads a .bzl file from @failing_dep. Resolving that load forces Bazel
+# to fetch the @failing_dep repo, whose repository rule always fails (see //:ext.bzl).
+# Loading this package therefore errors out. With `--keep_going` bazel query reports
+# the error but returns partial results (exit code 3), which bazel-diff currently
+# treats as success -- so //bad silently disappears from the hashes. With
+# `--no-keep_going`, bazel query fails outright and bazel-diff surfaces the error.
+load("@failing_dep//:defs.bzl", "noop")
+
+noop(name = "bad")

--- a/cli/src/test/resources/workspaces/keep_going_repo_failure/ext.bzl
+++ b/cli/src/test/resources/workspaces/keep_going_repo_failure/ext.bzl
@@ -1,0 +1,22 @@
+"""A module extension whose repository rule always fails to fetch.
+
+This models the real-world failure described in the bug report: a repo rule that
+cannot be resolved (e.g. a transient network error while fetching a Go/remote
+dependency). Module resolution succeeds -- the extension just *declares* the repo --
+but any attempt to actually fetch `@failing_dep` blows up in the repository rule's
+implementation function, which is exactly what happens when Bazel tries to load a
+package that depends on the repo.
+"""
+
+def _failing_repo_impl(_rctx):
+    fail(
+        "simulated network error resolving repository rule: " +
+        "Get \"https://proxy.golang.org/...\": net/http: TLS handshake timeout",
+    )
+
+failing_repo = repository_rule(implementation = _failing_repo_impl)
+
+def _failing_ext_impl(_mctx):
+    failing_repo(name = "failing_dep")
+
+failing_ext = module_extension(implementation = _failing_ext_impl)

--- a/cli/src/test/resources/workspaces/keep_going_repo_failure/good/BUILD
+++ b/cli/src/test/resources/workspaces/keep_going_repo_failure/good/BUILD
@@ -1,0 +1,10 @@
+# A perfectly healthy target that has nothing to do with the broken repo. It loads
+# and hashes fine on its own. The bug is that when the sibling //bad package fails to
+# load, `--keep_going` (the default) lets bazel-diff silently emit hashes for //good
+# alone -- producing a hash set that is missing //bad without any error.
+genrule(
+    name = "good",
+    outs = ["good.txt"],
+    cmd = "echo good > $@",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Reproduces #398.

## What

`--keep_going` defaults to `true`, so bazel-diff accepts a partial `bazel query` (exit code 3) as success. When a repository rule fails to resolve — e.g. a transient network error fetching a remote dependency like:

```
gazelle++go_deps+build_buf_go_protovalidate: fetch_repo: buf.build/go/protovalidate@v1.1.3:
    Get "https://proxy.golang.org/...": net/http: TLS handshake timeout
```

— the package referencing that repo silently drops out of the query results, and `generate-hashes` emits an incomplete, **non-deterministic** hash set with no error. Root cause is the `allowedExitCodes.add(3)` under `keepGoing` in [`BazelQueryService.runQuery`](https://github.com/Tinder/bazel-diff/blob/master/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt#L203-L206).

## Reproducer

New `keep_going_repo_failure` fixture workspace (bzlmod; works on Bazel 7/8/9):

- `//good` — a plain genrule with no external deps (always resolvable)
- `//bad` — loads a `.bzl` from `@failing_dep`, a module-extension repo whose repository rule always `fail()`s (offline, deterministic — models the fetch failure)

New E2E test `testKeepGoingSilentlyDropsTargetsOnRepoRuleFailure_reproducerForIssue398` pins the current behavior:

- **Default (`--keep_going=true`)** — `generate-hashes` exits `0`, output contains `//good:good` but **silently omits `//bad`**.
- **`--no-keep_going`** — exits `1`, failing loudly instead of writing a truncated hash set.

Verified against real Bazel: `--keep_going` → query exit `3` (accepted), `--no-keep_going` → exit `7` (rejected).

## Follow-up (not in this PR)

Consider making `--keep_going=false` the default, or at least warning/failing on exit code 3, so hashes stay deterministic. This PR only lands the reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)