### PR TITLE
feat: add --excludeTargetsQuery to filter out targets (e.g. manual)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Usage: bazel-diff generate-hashes [-hkvV] [--[no-]excludeExternalTargets] [--
                                   [--contentHashPath=<contentHashPath>]
                                   [--cqueryExpression=<cqueryExpression>]
                                   [-d=<depsMappingJSONPath>]
+                                  [--excludeTargetsQuery=<excludeTargetsQuery>]
                                   [--fineGrainedHashExternalReposFile=<fineGrain
                                   edHashExternalReposFile>]
                                   [-m=<modifiedFilepaths>] [-s=<seedFilepaths>]
@@ -292,6 +293,16 @@ workspace.
                             are excluded automatically. Set this when using
                             Bazel with --enable_workspace=false in other
                             configurations. Defaults to false.
+      --excludeTargetsQuery=<excludeTargetsQuery>
+                          A Bazel query expression whose matched targets are
+                            excluded from the generated hashes via the `except`
+                            operator. Applied to the main target universe for
+                            both `query` and `cquery`. Use this to drop targets
+                            you never want reported as impacted, e.g.
+                            `manual`-tagged targets: --excludeTargetsQuery='attr
+                            ("tags", "[\[ ]manual[,\]]", //...)'. Excluded
+                            targets are absent from hashing, so a kept target
+                            that depended on one no longer tracks changes to it.
       --fineGrainedHashExternalRepos=<fineGrainedHashExternalRepos>
                           Comma separate list of external repos in which
                             fine-grained hashes are computed for the targets.
@@ -427,6 +438,7 @@ Usage: bazel-diff serve [-hkvV] [--[no-]excludeExternalTargets]
                         [--no-initial-fetch] [--[no-]trackDeps] [--[no-]
                         useCquery] [-b=<bazelPath>] --cacheDir=<cacheDir>
                         [--cqueryExpression=<cqueryExpression>]
+                        [--excludeTargetsQuery=<excludeTargetsQuery>]
                         [--fineGrainedHashExternalReposFile=<fineGrainedHashExte
                         rnalReposFile>] [--gitEngine=<gitEngine>]
                         [--gitPath=<gitPath>] [--port=<port>]
@@ -457,6 +469,12 @@ targets between two git revisions, caching generated hashes per commit SHA.
       --[no-]excludeExternalTargets
                             If true, exclude external targets (do not query
                               //external:all-targets).
+      --excludeTargetsQuery=<excludeTargetsQuery>
+                            A Bazel query expression whose matched targets are
+                              excluded from the served hashes via the `except`
+                              operator, e.g. `manual`-tagged targets:
+                              --excludeTargetsQuery='attr("tags", "[\[ ]manual[,
+                              \]]", //...)'.
       --fineGrainedHashExternalRepos=<fineGrainedHashExternalRepos>
                             Comma separated list of external repos for which
                               fine-grained hashes are computed.
@@ -638,9 +656,9 @@ bazel run @bazel-diff//cli:bazel-diff -- bazel-diff -h
     <td align="center"><a href="https://github.com/tinder-maxwellelliott"><img src="https://avatars.githubusercontent.com/u/56700854?s=64" width="64" alt="Maxwell Elliott"/><br/><sub><b>Maxwell Elliott</b></sub></a></td>
     <td align="center"><a href="https://github.com/honnix"><img src="https://avatars.githubusercontent.com/u/158892?s=64" width="64" alt="Honnix"/><br/><sub><b>Honnix</b></sub></a></td>
     <td align="center"><a href="https://github.com/fa93hws"><img src="https://avatars.githubusercontent.com/u/10626756?s=64" width="64" alt="eric wang"/><br/><sub><b>eric wang</b></sub></a></td>
+    <td align="center"><a href="https://github.com/github-actions[bot]"><img src="https://avatars.githubusercontent.com/in/15368?s=64" width="64" alt="github-actions[bot]"/><br/><sub><b>github-actions[bot]</b></sub></a></td>
     <td align="center"><a href="https://github.com/fa93hws"><img src="https://avatars.githubusercontent.com/u/10626756?s=64" width="64" alt="Eric Wang"/><br/><sub><b>Eric Wang</b></sub></a></td>
     <td align="center"><a href="https://github.com/tgeng"><img src="https://avatars.githubusercontent.com/u/29584386?s=64" width="64" alt="Tianyu Geng"/><br/><sub><b>Tianyu Geng</b></sub></a></td>
-    <td align="center"><a href="https://github.com/github-actions[bot]"><img src="https://avatars.githubusercontent.com/in/15368?s=64" width="64" alt="github-actions[bot]"/><br/><sub><b>github-actions[bot]</b></sub></a></td>
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/BalestraPatrick"><img src="https://avatars.githubusercontent.com/u/3658887?s=64" width="64" alt="Patrick Balestra"/><br/><sub><b>Patrick Balestra</b></sub></a></td>

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -10,10 +10,23 @@ class BazelClient(
     private val cqueryExpression: String?,
     private val fineGrainedHashExternalRepos: Set<String>,
     private val excludeExternalTargets: Boolean,
+    private val excludeTargetsQuery: String?,
 ) : KoinComponent {
   private val logger: Logger by inject()
   private val queryService: BazelQueryService by inject()
   private val bazelModService: BazelModService by inject()
+
+  /**
+   * Wraps [query] so that every target matching the user-supplied [excludeTargetsQuery] is removed
+   * from the result set via Bazel's `except` operator. Returns [query] unchanged when no exclude
+   * query is configured. This is how callers drop, e.g., `manual`-tagged targets from the graph
+   * (issue #392): `--excludeTargetsQuery='attr("tags", "[\[ ]manual[,\]]", //...)'`. Excluded
+   * targets are simply absent from hashing; any kept target that depended on one logs an "Unable to
+   * calculate digest" warning and hashes without that input, which is the intended behavior for
+   * leaf targets like `manual`-tagged tests/binaries.
+   */
+  private fun withExcludeFilter(query: String): String =
+      excludeTargetsQuery?.takeIf { it.isNotBlank() }?.let { "($query) except ($it)" } ?: query
 
   suspend fun queryAllTargets(): List<BazelTarget> {
     val queryEpoch = Calendar.getInstance().getTimeInMillis()
@@ -57,7 +70,7 @@ class BazelClient(
           // In addition, we must include all source dependencies in this query in order for them to
           // show up in
           // `configuredRuleInput`. Hence, one must not filter them out with `kind(rule, deps(..))`.
-          val expression = cqueryExpression ?: "deps(//...:all-targets)"
+          val expression = withExcludeFilter(cqueryExpression ?: "deps(//...:all-targets)")
           val mainTargets = queryService.query(expression, useCquery = true)
           val repoTargets =
               if (repoTargetsQuery.isNotEmpty()) {
@@ -70,7 +83,9 @@ class BazelClient(
           val buildTargetsQuery =
               listOf("//...:all-targets") +
                   fineGrainedHashExternalRepos.map { "$it//...:all-targets" }
-          queryService.query((repoTargetsQuery + buildTargetsQuery).joinToString(" + ") { "'$it'" })
+          queryService.query(
+              withExcludeFilter(
+                  (repoTargetsQuery + buildTargetsQuery).joinToString(" + ") { "'$it'" }))
         }
     val allTargets = (targets + bzlmodRepoTargets).distinctBy { it.name }
     val queryDuration = Calendar.getInstance().getTimeInMillis() - queryEpoch

--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -191,6 +191,20 @@ open class GenerateHashesCommand : Callable<Int> {
       scope = CommandLine.ScopeType.INHERIT)
   var excludeExternalTargets = false
 
+  @CommandLine.Option(
+      names = ["--excludeTargetsQuery"],
+      description =
+          [
+              "A Bazel query expression whose matched targets are excluded from the generated " +
+                  "hashes via the `except` operator. Applied to the main target universe for both " +
+                  "`query` and `cquery`. Use this to drop targets you never want reported as " +
+                  "impacted, e.g. `manual`-tagged targets: " +
+                  "--excludeTargetsQuery='attr(\"tags\", \"[\\[ ]manual[,\\]]\", //...)'. " +
+                  "Excluded targets are absent from hashing, so a kept target that depended on one " +
+                  "no longer tracks changes to it."],
+      scope = CommandLine.ScopeType.INHERIT)
+  var excludeTargetsQuery: String? = null
+
   @CommandLine.Spec lateinit var spec: CommandLine.Model.CommandSpec
 
   override fun call(): Int {
@@ -214,6 +228,7 @@ open class GenerateHashesCommand : Callable<Int> {
               fineGrainedHashExternalRepos,
               fineGrainedHashExternalReposFile,
               excludeExternalTargets,
+              excludeTargetsQuery,
           ),
           loggingModule(parent.verbose),
           serialisationModule(),

--- a/cli/src/main/kotlin/com/bazel_diff/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/ServeCommand.kt
@@ -178,6 +178,15 @@ class ServeCommand : Callable<Int> {
   var excludeExternalTargets = false
 
   @CommandLine.Option(
+      names = ["--excludeTargetsQuery"],
+      description =
+          [
+              "A Bazel query expression whose matched targets are excluded from the served hashes " +
+                  "via the `except` operator, e.g. `manual`-tagged targets: " +
+                  "--excludeTargetsQuery='attr(\"tags\", \"[\\[ ]manual[,\\]]\", //...)'."])
+  var excludeTargetsQuery: String? = null
+
+  @CommandLine.Option(
       names = ["--trackDeps"],
       negatable = true,
       description =
@@ -205,6 +214,7 @@ class ServeCommand : Callable<Int> {
               fineGrainedHashExternalRepos,
               fineGrainedHashExternalReposFile,
               excludeExternalTargets,
+              excludeTargetsQuery,
           ),
           loggingModule(parent.verbose),
           serialisationModule(),
@@ -316,6 +326,7 @@ class ServeCommand : Callable<Int> {
       append("cqueryExpression=").append(cqueryExpression ?: "").append('\n')
       append("keepGoing=").append(keepGoing).append('\n')
       append("excludeExternalTargets=").append(excludeExternalTargets).append('\n')
+      append("excludeTargetsQuery=").append(excludeTargetsQuery ?: "").append('\n')
       append("bazelCommandOptions=").append(bazelCommandOptions.joinToString(" ")).append('\n')
       append("cqueryCommandOptions=").append(cqueryCommandOptions.joinToString(" ")).append('\n')
       append("bazelStartupOptions=").append(bazelStartupOptions.joinToString(" ")).append('\n')

--- a/cli/src/main/kotlin/com/bazel_diff/di/Modules.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/di/Modules.kt
@@ -35,6 +35,7 @@ fun hasherModule(
     fineGrainedHashExternalRepos: Set<String>,
     fineGrainedHashExternalReposFile: File?,
     excludeExternalTargets: Boolean,
+    excludeTargetsQuery: String? = null,
 ): Module = module {
   if (fineGrainedHashExternalReposFile != null && fineGrainedHashExternalRepos.isNotEmpty()) {
     System.err.println(
@@ -92,7 +93,11 @@ fun hasherModule(
   single { BazelModService(workingDirectory, bazelPath, startupOptions, debug) }
   single {
     BazelClient(
-        useCquery, cqueryExpression, updatedFineGrainedHashExternalRepos, excludeExternalTargets)
+        useCquery,
+        cqueryExpression,
+        updatedFineGrainedHashExternalRepos,
+        excludeExternalTargets,
+        excludeTargetsQuery)
   }
   single { BuildGraphHasher(get()) }
   single { TargetHasher() }

--- a/cli/src/test/kotlin/com/bazel_diff/Modules.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/Modules.kt
@@ -15,7 +15,7 @@ fun testModule(): Module = module {
   val workingDirectory = Paths.get("working-directory")
   val bazelPath = Paths.get("bazel")
   single<Logger> { SilentLogger }
-  single { BazelClient(false, null, emptySet(), false) }
+  single { BazelClient(false, null, emptySet(), false, null) }
   single { BuildGraphHasher(get()) }
   single { TargetHasher() }
   single { RuleHasher(false, true, emptySet()) }

--- a/cli/src/test/kotlin/com/bazel_diff/bazel/BazelClientTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/bazel/BazelClientTest.kt
@@ -56,7 +56,8 @@ class BazelClientTest : KoinTest {
               useCquery = false,
               cqueryExpression = null,
               fineGrainedHashExternalRepos = emptySet(),
-              excludeExternalTargets = false)
+              excludeExternalTargets = false,
+              excludeTargetsQuery = null)
 
       val targets = client.queryAllTargets()
 
@@ -80,7 +81,8 @@ class BazelClientTest : KoinTest {
               useCquery = false,
               cqueryExpression = null,
               fineGrainedHashExternalRepos = emptySet(),
-              excludeExternalTargets = false)
+              excludeExternalTargets = false,
+              excludeTargetsQuery = null)
 
       val targets = client.queryAllTargets()
 
@@ -104,7 +106,8 @@ class BazelClientTest : KoinTest {
               useCquery = false,
               cqueryExpression = null,
               fineGrainedHashExternalRepos = emptySet(),
-              excludeExternalTargets = false)
+              excludeExternalTargets = false,
+              excludeTargetsQuery = null)
 
       val targets = client.queryAllTargets()
 
@@ -130,7 +133,8 @@ class BazelClientTest : KoinTest {
               useCquery = true,
               cqueryExpression = null,
               fineGrainedHashExternalRepos = emptySet(),
-              excludeExternalTargets = false)
+              excludeExternalTargets = false,
+              excludeTargetsQuery = null)
 
       val targets = client.queryAllTargets()
 
@@ -156,11 +160,87 @@ class BazelClientTest : KoinTest {
               useCquery = false,
               cqueryExpression = null,
               fineGrainedHashExternalRepos = emptySet(),
-              excludeExternalTargets = false)
+              excludeExternalTargets = false,
+              excludeTargetsQuery = null)
 
       val targets = client.queryAllTargets()
 
       assertThat(targets).hasSize(1)
+    }
+  }
+
+  @Test
+  fun queryAllTargets_excludeTargetsQuery_wrapsNonCqueryQuery() {
+    runBlocking {
+      val mainTarget = mockRuleTarget("//src:lib")
+      val excludeQuery = "attr(\"tags\", \"manual\", //...)"
+      val wrapped = "('//external:all-targets' + '//...:all-targets') except ($excludeQuery)"
+
+      whenever(modService.isBzlmodEnabled).thenReturn(false)
+      whenever(queryService.query(wrapped)).thenReturn(listOf(mainTarget))
+
+      val client =
+          BazelClient(
+              useCquery = false,
+              cqueryExpression = null,
+              fineGrainedHashExternalRepos = emptySet(),
+              excludeExternalTargets = false,
+              excludeTargetsQuery = excludeQuery)
+
+      val targets = client.queryAllTargets()
+
+      assertThat(targets.map { it.name }).containsOnly("//src:lib")
+      verify(queryService).query(wrapped)
+    }
+  }
+
+  @Test
+  fun queryAllTargets_excludeTargetsQuery_wrapsCqueryExpression() {
+    runBlocking {
+      val mainTarget = mockRuleTarget("//src:lib")
+      val excludeQuery = "attr(\"tags\", \"manual\", //...)"
+      val wrapped = "(deps(//...:all-targets)) except ($excludeQuery)"
+
+      whenever(modService.isBzlmodEnabled).thenReturn(true)
+      whenever(queryService.canUseBzlmodShowRepo).thenReturn(false)
+      whenever(queryService.query(wrapped, useCquery = true)).thenReturn(listOf(mainTarget))
+
+      val client =
+          BazelClient(
+              useCquery = true,
+              cqueryExpression = null,
+              fineGrainedHashExternalRepos = emptySet(),
+              excludeExternalTargets = false,
+              excludeTargetsQuery = excludeQuery)
+
+      val targets = client.queryAllTargets()
+
+      assertThat(targets.map { it.name }).containsOnly("//src:lib")
+      verify(queryService).query(wrapped, useCquery = true)
+    }
+  }
+
+  @Test
+  fun queryAllTargets_blankExcludeTargetsQuery_doesNotWrapQuery() {
+    runBlocking {
+      val mainTarget = mockRuleTarget("//src:lib")
+
+      whenever(modService.isBzlmodEnabled).thenReturn(false)
+      whenever(queryService.query("'//external:all-targets' + '//...:all-targets'"))
+          .thenReturn(listOf(mainTarget))
+
+      val client =
+          BazelClient(
+              useCquery = false,
+              cqueryExpression = null,
+              fineGrainedHashExternalRepos = emptySet(),
+              excludeExternalTargets = false,
+              excludeTargetsQuery = "   ")
+
+      val targets = client.queryAllTargets()
+
+      assertThat(targets.map { it.name }).containsOnly("//src:lib")
+      verify(queryService).query("'//external:all-targets' + '//...:all-targets'")
     }
   }
 

--- a/cli/src/test/kotlin/com/bazel_diff/cli/ServeCommandTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/cli/ServeCommandTest.kt
@@ -102,8 +102,13 @@ class ServeCommandTest : KoinTest {
         ServeCommand()
             .apply { fineGrainedHashExternalRepos = setOf("@maven") }
             .computeConfigFingerprint()
+    val withExcludeQuery =
+        ServeCommand()
+            .apply { excludeTargetsQuery = "attr(\"tags\", \"manual\", //...)" }
+            .computeConfigFingerprint()
     assertThat(withCquery).isNotEqualTo(base)
     assertThat(withRepos).isNotEqualTo(base)
+    assertThat(withExcludeQuery).isNotEqualTo(base)
   }
 
   @Test

--- a/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
@@ -352,6 +352,58 @@ class E2ETest {
   }
 
   @Test
+  fun testExcludeTargetsQueryFiltersManualTargets() {
+    // Reproducer + fix for https://github.com/Tinder/bazel-diff/issues/392: --excludeTargetsQuery
+    // lets users drop `manual`-tagged targets (or any query-matched targets) from generate-hashes
+    // output via Bazel's `except` operator. Reuses the locked `distance_metrics` workspace and
+    // appends a manual-tagged target to the *copied* BUILD so no new MODULE.bazel.lock is needed.
+    val workspace = copyTestWorkspace("distance_metrics")
+    File(workspace, "BUILD")
+        .appendText(
+            "\nsh_library(\n" +
+                "    name = \"manual_only\",\n" +
+                "    srcs = [\"lib.sh\"],\n" +
+                "    tags = [\"manual\"],\n" +
+                ")\n")
+
+    val outputDir = temp.newFolder()
+    val withoutFilter = File(outputDir, "without_filter.json")
+    val withFilter = File(outputDir, "with_filter.json")
+    val cli = CommandLine(BazelDiff())
+
+    // Baseline: the manual target is present when no filter is applied.
+    assertThat(
+            cli.execute(
+                "generate-hashes",
+                "-w",
+                workspace.absolutePath,
+                "-b",
+                "bazel",
+                withoutFilter.absolutePath))
+        .isEqualTo(0)
+    val baseline = readTargetHashes(withoutFilter)
+    assertThat(baseline.containsKey("//:manual_only")).isEqualTo(true)
+    assertThat(baseline.containsKey("//:lib")).isEqualTo(true)
+
+    // With the filter, the manual target is gone but the normal target remains. The regex is
+    // Bazel's documented incantation for matching the `manual` element of a `tags` list.
+    assertThat(
+            cli.execute(
+                "generate-hashes",
+                "-w",
+                workspace.absolutePath,
+                "-b",
+                "bazel",
+                "--excludeTargetsQuery",
+                """attr("tags", "[\[ ]manual[,\]]", //...)""",
+                withFilter.absolutePath))
+        .isEqualTo(0)
+    val filtered = readTargetHashes(withFilter)
+    assertThat(filtered.containsKey("//:manual_only")).isEqualTo(false)
+    assertThat(filtered.containsKey("//:lib")).isEqualTo(true)
+  }
+
+  @Test
   fun testFineGrainedHashExternalRepo() {
     // The difference between these two snapshots is simply upgrading the Guava version.
     // Following is the diff.
@@ -2689,6 +2741,18 @@ class E2ETest {
               it
             }
         .isEqualTo(true)
+  }
+
+  /**
+   * Reads a `generate-hashes` output file into a flat `target -> hash` map, tolerating both the
+   * bzlmod "new format" (`{"hashes": {...}, "metadata": {...}}`) and the legacy flat format
+   * (`{target: hash}`) emitted for non-bzlmod workspaces.
+   */
+  @Suppress("UNCHECKED_CAST")
+  private fun readTargetHashes(file: File): Map<String, Any> {
+    val root: Map<String, Any> =
+        Gson().fromJson(file.readText(), object : TypeToken<Map<String, Any>>() {}.type)
+    return (root["hashes"] as? Map<String, Any>) ?: root
   }
 
   private fun copyTestWorkspace(path: String): File {


### PR DESCRIPTION
## Summary

Fixes #392 — adds a general-purpose `--excludeTargetsQuery` flag to `generate-hashes` and `serve` that lets users filter targets out of the generated hashes using any Bazel query expression.

The flag takes a query expression and wraps the main target query with Bazel's `except` operator, so matched targets are dropped from the output. To solve the issue's specific ask (excluding `manual`-tagged targets):

```
bazel-diff generate-hashes -w . \
  --excludeTargetsQuery='attr("tags", "[\[ ]manual[,\]]", //...)' out.json
```

## Why a query instead of a dedicated `--manual` flag

A query expression is strictly more flexible — it handles the `manual` case (via the documented `attr(tags, ...)` incantation) and any other "targets I never want reported as impacted" case, with no new special-casing in the hashing pipeline.

## What changed

- **`BazelClient`** — new `withExcludeFilter()` helper wraps the query as `(<original>) except (<userQuery>)`, applied to the non-cquery combined query and the cquery main expression. Composes with `--cqueryExpression`. No-op when unset, so existing behavior is byte-for-byte unchanged.
- **`hasherModule` (DI)** — threaded the param through (defaults to `null`).
- **`GenerateHashesCommand` / `ServeCommand`** — the CLI option. On `serve` it is also mixed into the per-SHA cache fingerprint so a differently-configured server never serves stale hashes.
- **README** — regenerated via `//tools:generate-readme` so the CLI help documents the flag.

`get-impacted-targets` is unchanged: it only reads hash JSONs and does bzlmod detection, never querying targets.

## Behavior note for reviewers

Filtering happens at the **query level** (`except`), not post-hashing. Excluded targets are absent from the graph entirely; a kept target that depended on one hashes without that input and logs an "Unable to calculate digest" warning. This is the intended behavior for leaf targets like `manual`-tagged tests/binaries (nothing depends on them), and matches how the flag is documented.

## Tests

- **Unit** (`BazelClientTest`): verifies the `except` wrapping for both `query` and `cquery`, plus a blank/whitespace no-op case.
- **Serve** (`ServeCommandTest`): asserts `excludeTargetsQuery` changes the config fingerprint.
- **E2E** (`E2ETest`): real-bazel test that appends a `manual`-tagged target to a copied workspace and confirms it is present without the flag and absent with it, while the normal target is kept — validating the actual `attr(tags, ...)` regex end-to-end.

All added/affected tests pass locally (`BazelClientTest`, `ServeCommandTest`, `BazelDiffTest`, and the new E2E case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)