### PR TITLE
feat: add --alwaysAffectedTags to always impact non-hermetic tagged targets (#401)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,29 @@ See https://github.com/aspect-extensions/impacted
 
 * We run `bazel-diff` on the starting and final JSON hash filepaths to get our impacted set of targets. This impacted set of targets is written to a file.
 
+## Always-affected targets (non-hermetic tags)
+
+`bazel-diff` hashes a target from its **declared** inputs (its rule attributes and the transitive
+deps in the query graph). A target that reads the workspace at execution time *without* declaring
+those files as inputs — a repo-scanning linter such as `buildifier_test`, `gofmt_test`, or
+`eslint_test`, for example — keeps a **stable hash** across commits that only change those
+undeclared files. Target determination then wrongly skips it even though it would fail if run.
+
+Pass `--alwaysAffectedTags` to `generate-hashes` with one or more [Bazel target
+tags](https://bazel.build/reference/be/common-definitions#common.tags) to opt such targets in:
+
+```bash
+bazel-diff generate-hashes --alwaysAffectedTags=external -w "$WORKSPACE" -b "$BAZEL" hashes.json
+```
+
+Any target whose `tags` attribute contains a listed value (e.g. `external`) gets a per-invocation
+sentinel mixed into its hash, so a diff of the base and head hash files **always** reports it as
+impacted. Every other target's hash is byte-for-byte identical to a run without the flag, so nothing
+else over-invalidates. The tag name is your convention — nothing is hardcoded.
+
+> This is unrelated to `--excludeExternalTargets` / `--fineGrainedHashExternalRepos`, which concern
+> external **repositories** (`@repo//…`), not the `external` **tag**.
+
 ## Build Graph Distance Metrics
 
 `bazel-diff` can optionally compute build graph distance metrics between two revisions. This is
@@ -240,6 +263,7 @@ Usage: bazel-diff generate-hashes [-hkvV] [--[no-]excludeExternalTargets] [--
                                   edHashExternalReposFile>]
                                   [-m=<modifiedFilepaths>] [-s=<seedFilepaths>]
                                   -w=<workspacePath>
+                                  [--alwaysAffectedTags=<alwaysAffectedTags>]...
                                   [-co=<bazelCommandOptions>]...
                                   [--cqueryCommandOptions=<cqueryCommandOptions>
                                   ]...
@@ -255,6 +279,22 @@ workspace.
       <outputPath>        The filepath to write the resulting JSON of
                             dictionary target => SHA-256 values. If not
                             specified, the JSON will be written to STDOUT.
+      --alwaysAffectedTags=<alwaysAffectedTags>
+                          Comma separated list of Bazel target tags (e.g.
+                            `external`). Any target whose `tags` attribute
+                            contains one of these values is always reported as
+                            impacted: a per-invocation sentinel is mixed into
+                            its hash so a diff of two `generate-hashes` runs
+                            always marks it changed. Use this for non-hermetic
+                            targets that read undeclared workspace state at
+                            execution time (e.g. repo-scanning linters such as
+                            buildifier/gofmt/eslint tests) which would
+                            otherwise hash as unchanged and be wrongly skipped
+                            by target determination. This is the Bazel target
+                            `external` *tag* and is unrelated to
+                            --excludeExternalTargets /
+                            --fineGrainedHashExternalRepos, which concern
+                            external *repositories*.
   -b, --bazelPath=<bazelPath>
                           Path to Bazel binary. If not specified, the Bazel
                             binary available in PATH will be used.

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -65,6 +65,12 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "RuleHasherAlwaysAffectedTagsTest",
+    test_class = "com.bazel_diff.hash.RuleHasherAlwaysAffectedTagsTest",
+    runtime_deps = [":cli-test-lib"],
+)
+
+kt_jvm_test(
     name = "SourceFileHasherTest",
     data = [
         ":src/test/kotlin/com/bazel_diff/hash/fixture/foo.ts",

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelRule.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelRule.kt
@@ -89,6 +89,18 @@ class BazelRule(private val rule: Build.Rule) {
 
   val name: String = rule.name
 
+  /**
+   * The values of this rule's `tags` attribute, or an empty set when the attribute is absent. Bazel
+   * emits user-declared tags as a `STRING_LIST` attribute named `tags` in the query proto.
+   * bazel-diff reads them to honour `--alwaysAffectedTags`: a target carrying one of those tags is
+   * treated as always impacted, because it may read undeclared workspace state at execution time
+   * (issue #401). This is the Bazel target *tag* `external`, which is unrelated to the external
+   * *repository* handling behind `--excludeExternalTargets` / `--fineGrainedHashExternalRepos`.
+   */
+  fun tags(): Set<String> =
+      rule.attributeList.firstOrNull { it.name == "tags" }?.stringListValueList?.toSet()
+          ?: emptySet()
+
   private fun transformRuleInput(
       fineGrainedHashExternalRepos: Set<String>,
       ruleInput: String

--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -192,18 +192,29 @@ open class GenerateHashesCommand : Callable<Int> {
   var excludeExternalTargets = false
 
   @CommandLine.Option(
-      names = ["--excludeTargetsQuery"],
-      description =
-          [
-              "A Bazel query expression whose matched targets are excluded from the generated " +
-                  "hashes via the `except` operator. Applied to the main target universe for both " +
-                  "`query` and `cquery`. Use this to drop targets you never want reported as " +
-                  "impacted, e.g. `manual`-tagged targets: " +
-                  "--excludeTargetsQuery='attr(\"tags\", \"[\\[ ]manual[,\\]]\", //...)'. " +
-                  "Excluded targets are absent from hashing, so a kept target that depended on one " +
-                  "no longer tracks changes to it."],
-      scope = CommandLine.ScopeType.INHERIT)
-  var excludeTargetsQuery: String? = null
+@CommandLine.Option(
+    names = ["--excludeTargetsQuery"],
+    description =
+        [
+            "A Bazel query expression whose matched targets are excluded from the generated " +
+                "hashes via the `except` operator. Applied to the main target universe for both " +
+                "`query` and `cquery`. Use this to drop targets you never want reported as " +
+                "impacted, e.g. `manual`-tagged targets: " +
+                "--excludeTargetsQuery='attr(\"tags\", \"[\\[ ]manual[,\\]]\", //...)'. " +
+                "Excluded targets are absent from hashing, so a kept target that depended on one " +
+                "no longer tracks changes to it."],
+    scope = CommandLine.ScopeType.INHERIT)
+var excludeTargetsQuery: String? = null
+
+@CommandLine.Option(
+    names = ["--alwaysAffectedTags"],
+    description =
+        [
+            "Comma separated list of Bazel target tags (e.g. `external`). Any target whose `tags` attribute contains one of these values is always reported as impacted: a per-invocation sentinel is mixed into its hash so a diff of two `generate-hashes` runs always marks it changed. Use this for non-hermetic targets that read undeclared workspace state at execution time (e.g. repo-scanning linters such as buildifier/gofmt/eslint tests) which would otherwise hash as unchanged and be wrongly skipped by target determination. This is the Bazel target `external` *tag* and is unrelated to --excludeExternalTargets / --fineGrainedHashExternalRepos, which concern external *repositories*."],
+    scope = CommandLine.ScopeType.INHERIT,
+    converter = [CommaSeparatedValueConverter::class],
+)
+var alwaysAffectedTags: Set<String> = emptySet()
 
   @CommandLine.Spec lateinit var spec: CommandLine.Model.CommandSpec
 
@@ -229,6 +240,7 @@ open class GenerateHashesCommand : Callable<Int> {
               fineGrainedHashExternalReposFile,
               excludeExternalTargets,
               excludeTargetsQuery,
+              alwaysAffectedTags,
           ),
           loggingModule(parent.verbose),
           serialisationModule(),

--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -192,29 +192,28 @@ open class GenerateHashesCommand : Callable<Int> {
   var excludeExternalTargets = false
 
   @CommandLine.Option(
-@CommandLine.Option(
-    names = ["--excludeTargetsQuery"],
-    description =
-        [
-            "A Bazel query expression whose matched targets are excluded from the generated " +
-                "hashes via the `except` operator. Applied to the main target universe for both " +
-                "`query` and `cquery`. Use this to drop targets you never want reported as " +
-                "impacted, e.g. `manual`-tagged targets: " +
-                "--excludeTargetsQuery='attr(\"tags\", \"[\\[ ]manual[,\\]]\", //...)'. " +
-                "Excluded targets are absent from hashing, so a kept target that depended on one " +
-                "no longer tracks changes to it."],
-    scope = CommandLine.ScopeType.INHERIT)
-var excludeTargetsQuery: String? = null
+      names = ["--excludeTargetsQuery"],
+      description =
+          [
+              "A Bazel query expression whose matched targets are excluded from the generated " +
+                  "hashes via the `except` operator. Applied to the main target universe for both " +
+                  "`query` and `cquery`. Use this to drop targets you never want reported as " +
+                  "impacted, e.g. `manual`-tagged targets: " +
+                  "--excludeTargetsQuery='attr(\"tags\", \"[\\[ ]manual[,\\]]\", //...)'. " +
+                  "Excluded targets are absent from hashing, so a kept target that depended on one " +
+                  "no longer tracks changes to it."],
+      scope = CommandLine.ScopeType.INHERIT)
+  var excludeTargetsQuery: String? = null
 
-@CommandLine.Option(
-    names = ["--alwaysAffectedTags"],
-    description =
-        [
-            "Comma separated list of Bazel target tags (e.g. `external`). Any target whose `tags` attribute contains one of these values is always reported as impacted: a per-invocation sentinel is mixed into its hash so a diff of two `generate-hashes` runs always marks it changed. Use this for non-hermetic targets that read undeclared workspace state at execution time (e.g. repo-scanning linters such as buildifier/gofmt/eslint tests) which would otherwise hash as unchanged and be wrongly skipped by target determination. This is the Bazel target `external` *tag* and is unrelated to --excludeExternalTargets / --fineGrainedHashExternalRepos, which concern external *repositories*."],
-    scope = CommandLine.ScopeType.INHERIT,
-    converter = [CommaSeparatedValueConverter::class],
-)
-var alwaysAffectedTags: Set<String> = emptySet()
+  @CommandLine.Option(
+      names = ["--alwaysAffectedTags"],
+      description =
+          [
+              "Comma separated list of Bazel target tags (e.g. `external`). Any target whose `tags` attribute contains one of these values is always reported as impacted: a per-invocation sentinel is mixed into its hash so a diff of two `generate-hashes` runs always marks it changed. Use this for non-hermetic targets that read undeclared workspace state at execution time (e.g. repo-scanning linters such as buildifier/gofmt/eslint tests) which would otherwise hash as unchanged and be wrongly skipped by target determination. This is the Bazel target `external` *tag* and is unrelated to --excludeExternalTargets / --fineGrainedHashExternalRepos, which concern external *repositories*."],
+      scope = CommandLine.ScopeType.INHERIT,
+      converter = [CommaSeparatedValueConverter::class],
+  )
+  var alwaysAffectedTags: Set<String> = emptySet()
 
   @CommandLine.Spec lateinit var spec: CommandLine.Model.CommandSpec
 

--- a/cli/src/main/kotlin/com/bazel_diff/di/Modules.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/di/Modules.kt
@@ -36,6 +36,7 @@ fun hasherModule(
     fineGrainedHashExternalReposFile: File?,
     excludeExternalTargets: Boolean,
     excludeTargetsQuery: String? = null,
+    alwaysAffectedTags: Set<String> = emptySet(),
 ): Module = module {
   if (fineGrainedHashExternalReposFile != null && fineGrainedHashExternalRepos.isNotEmpty()) {
     System.err.println(
@@ -80,6 +81,14 @@ fun hasherModule(
   }
   val outputPath = Paths.get(result.output.single())
   val debug = System.getProperty("DEBUG", "false").equals("true")
+
+  // issue #401: when the user opts targets in via --alwaysAffectedTags, mint one per-invocation
+  // random sentinel and hand it to RuleHasher, which mixes it into those targets' hashes so a
+  // base/head diff always marks them impacted. Left empty (and never mixed) when the feature is
+  // unused, so every hash stays byte-for-byte identical to a run without the flag.
+  val alwaysAffectedSeed =
+      if (alwaysAffectedTags.isEmpty()) ByteArray(0)
+      else java.util.UUID.randomUUID().toString().toByteArray()
   single {
     BazelQueryService(
         workingDirectory,
@@ -101,7 +110,14 @@ fun hasherModule(
   }
   single { BuildGraphHasher(get()) }
   single { TargetHasher() }
-  single { RuleHasher(useCquery, trackDeps, updatedFineGrainedHashExternalRepos) }
+  single {
+    RuleHasher(
+        useCquery,
+        trackDeps,
+        updatedFineGrainedHashExternalRepos,
+        alwaysAffectedTags,
+        alwaysAffectedSeed)
+  }
   single<SourceFileHasher> { SourceFileHasherImpl(updatedFineGrainedHashExternalRepos) }
   single { ExternalRepoResolver(workingDirectory, bazelPath, outputPath) }
   single(named("working-directory")) { workingDirectory }

--- a/cli/src/main/kotlin/com/bazel_diff/hash/RuleHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/RuleHasher.kt
@@ -13,7 +13,9 @@ import org.koin.core.component.inject
 class RuleHasher(
     private val useCquery: Boolean,
     private val trackDepLabels: Boolean,
-    private val fineGrainedHashExternalRepos: Set<String>
+    private val fineGrainedHashExternalRepos: Set<String>,
+    private val alwaysAffectedTags: Set<String> = emptySet(),
+    private val alwaysAffectedSeed: ByteArray = ByteArray(0),
 ) : KoinComponent {
   private val logger: Logger by inject()
   private val sourceFileHasher: SourceFileHasher by inject()
@@ -52,6 +54,15 @@ class RuleHasher(
       return it
     }
 
+    // issue #401: a target carrying an --alwaysAffectedTags tag (e.g. `external`) may read
+    // undeclared workspace state at execution time, so its *declared* inputs can't make its hash
+    // change when that state does, and target determination wrongly skips it. Mix a per-invocation
+    // sentinel into its digest so two generate-hashes runs never agree and a base/head diff always
+    // marks it impacted. Only tagged rules are touched -- every other target's hash stays
+    // byte-for-byte identical to a run without the flag.
+    val alwaysAffected =
+        alwaysAffectedTags.isNotEmpty() && rule.tags().any { it in alwaysAffectedTags }
+
     val finalHashValue =
         targetSha256(trackDepLabels) {
           putDirectBytes(rule.digest(ignoredAttrs))
@@ -61,6 +72,12 @@ class RuleHasher(
           // depth-first recursion below and a macro edit re-hashes only the packages that
           // `load()` it (issue #365).
           putDirectBytes(packageBzlSeeds[labelToPackage(rule.name)])
+          // Mixed into the *direct* digest (not transitively) so the tagged target is classified
+          // as DIRECT-impacted for distance metrics; it still bubbles into the overall digest, so
+          // any rdeps are conservatively re-hashed too.
+          if (alwaysAffected) {
+            putDirectBytes(alwaysAffectedSeed)
+          }
 
           for (ruleInput in rule.ruleInputList(useCquery, fineGrainedHashExternalRepos)) {
             // Under --useCquery, `ruleInput` may carry an embedded configurationChecksum (see

--- a/cli/src/test/kotlin/com/bazel_diff/bazel/BazelRuleTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/bazel/BazelRuleTest.kt
@@ -50,6 +50,32 @@ class BazelRuleTest {
         .isEqualTo(BazelRule(rule2Pb).digest(emptySet()))
   }
 
+  // Backs --alwaysAffectedTags (issue #401): the `tags` attribute is emitted as a STRING_LIST.
+  @Test
+  fun testTagsExtractedFromAttribute() {
+    val rulePb =
+        Rule.newBuilder()
+            .setRuleClass("sh_test")
+            .setName("//pkg:lint")
+            .addAttribute(
+                Attribute.newBuilder()
+                    .setType(Attribute.Discriminator.STRING_LIST)
+                    .setName("tags")
+                    .addStringListValue("external")
+                    .addStringListValue("no-cache")
+                    .build())
+            .build()
+
+    assertThat(BazelRule(rulePb).tags()).isEqualTo(setOf("external", "no-cache"))
+  }
+
+  @Test
+  fun testTagsEmptyWhenAttributeAbsent() {
+    val rulePb = Rule.newBuilder().setRuleClass("java_library").setName("//pkg:lib").build()
+
+    assertThat(BazelRule(rulePb).tags()).isEqualTo(emptySet<String>())
+  }
+
   // Fix for https://github.com/Tinder/bazel-diff/issues/359
   //
   // Under --useCquery, BazelRule.ruleInputList() now folds each ConfiguredRuleInput's

--- a/cli/src/test/kotlin/com/bazel_diff/cli/BazelDiffTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/cli/BazelDiffTest.kt
@@ -2,6 +2,8 @@ package com.bazel_diff.cli
 
 import assertk.assertThat
 import assertk.assertions.contains
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import org.junit.Assert.assertThrows
@@ -38,5 +40,28 @@ class BazelDiffTest {
     val diff = BazelDiff()
     diff.debug = true
     assertThat(diff.isVerbose()).isTrue()
+  }
+
+  // --alwaysAffectedTags (issue #401) parses into a comma-separated Set on generate-hashes.
+  @Test
+  fun generateHashesParsesAlwaysAffectedTags() {
+    val parseResult =
+        CommandLine(BazelDiff())
+            .parseArgs(
+                "generate-hashes",
+                "-w",
+                "/tmp/ws",
+                "--alwaysAffectedTags=external,no-cache",
+                "/tmp/out.json")
+    val command = parseResult.subcommand().commandSpec().userObject() as GenerateHashesCommand
+    assertThat(command.alwaysAffectedTags).isEqualTo(setOf("external", "no-cache"))
+  }
+
+  @Test
+  fun generateHashesAlwaysAffectedTagsDefaultsToEmpty() {
+    val parseResult =
+        CommandLine(BazelDiff()).parseArgs("generate-hashes", "-w", "/tmp/ws", "/tmp/out.json")
+    val command = parseResult.subcommand().commandSpec().userObject() as GenerateHashesCommand
+    assertThat(command.alwaysAffectedTags).isEmpty()
   }
 }

--- a/cli/src/test/kotlin/com/bazel_diff/hash/RuleHasherAlwaysAffectedTagsTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/hash/RuleHasherAlwaysAffectedTagsTest.kt
@@ -1,0 +1,127 @@
+package com.bazel_diff.hash
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import com.bazel_diff.bazel.BazelRule
+import com.bazel_diff.extensions.toHexString
+import com.bazel_diff.testModule
+import com.google.devtools.build.lib.query2.proto.proto2api.Build
+import com.google.devtools.build.lib.query2.proto.proto2api.Build.Attribute
+import java.util.concurrent.ConcurrentHashMap
+import org.junit.Rule
+import org.junit.Test
+import org.koin.test.KoinTest
+import org.koin.test.KoinTestRule
+
+/**
+ * Tests for `--alwaysAffectedTags` (issue [#401](https://github.com/Tinder/bazel-diff/issues/401)).
+ *
+ * A target carrying one of the configured tags may read undeclared workspace state at execution
+ * time, so its declared inputs cannot make its hash change when that state does. [RuleHasher] mixes
+ * a per-invocation sentinel into such a target's digest so two `generate-hashes` runs never agree
+ * and a base/head diff always marks it impacted -- while every other target's hash stays
+ * byte-for-byte stable.
+ */
+class RuleHasherAlwaysAffectedTagsTest : KoinTest {
+  @get:Rule val koinTestRule = KoinTestRule.create { modules(testModule()) }
+
+  private fun ruleWith(name: String, vararg tags: String): BazelRule {
+    val builder = Build.Rule.newBuilder().setName(name).setRuleClass("sh_test")
+    if (tags.isNotEmpty()) {
+      val attr = Attribute.newBuilder().setName("tags").setType(Attribute.Discriminator.STRING_LIST)
+      tags.forEach { attr.addStringListValue(it) }
+      builder.addAttribute(attr.build())
+    }
+    return BazelRule(builder.build())
+  }
+
+  /** Hashes [rule] with a fresh, unmemoized [RuleHasher] for the given flag configuration. */
+  private fun digest(
+      rule: BazelRule,
+      alwaysAffectedTags: Set<String>,
+      seed: ByteArray
+  ): TargetDigest {
+    val hasher =
+        RuleHasher(
+            useCquery = false,
+            trackDepLabels = true,
+            fineGrainedHashExternalRepos = emptySet(),
+            alwaysAffectedTags = alwaysAffectedTags,
+            alwaysAffectedSeed = seed)
+    return hasher.digest(
+        rule,
+        mapOf(rule.name to rule),
+        ConcurrentHashMap(),
+        ConcurrentHashMap(),
+        ByteArray(0),
+        emptyMap(),
+        null,
+        emptySet(),
+        emptySet())
+  }
+
+  @Test
+  fun taggedTargetHashChangesAcrossInvocations() {
+    val rule = ruleWith("//pkg:lint", "external")
+    val a = digest(rule, setOf("external"), "seed-A".toByteArray()).overallDigest.toHexString()
+    val b = digest(rule, setOf("external"), "seed-B".toByteArray()).overallDigest.toHexString()
+    // Two runs mint different sentinels, so the tagged target never hashes the same twice.
+    assertThat(a).isNotEqualTo(b)
+  }
+
+  @Test
+  fun taggedTargetDirectHashChangesAcrossInvocations() {
+    // The sentinel is mixed into the DIRECT digest so distance metrics classify the target as
+    // DIRECT-impacted rather than requiring an impacted dependency to explain it.
+    val rule = ruleWith("//pkg:lint", "external")
+    val a = digest(rule, setOf("external"), "seed-A".toByteArray()).directDigest.toHexString()
+    val b = digest(rule, setOf("external"), "seed-B".toByteArray()).directDigest.toHexString()
+    assertThat(a).isNotEqualTo(b)
+  }
+
+  @Test
+  fun untaggedTargetHashIsStableAcrossInvocations() {
+    val rule = ruleWith("//pkg:lib") // no tags
+    val a = digest(rule, setOf("external"), "seed-A".toByteArray()).overallDigest.toHexString()
+    val b = digest(rule, setOf("external"), "seed-B".toByteArray()).overallDigest.toHexString()
+    assertThat(a).isEqualTo(b)
+  }
+
+  @Test
+  fun targetWithAnUnlistedTagIsStableAcrossInvocations() {
+    // A target tagged `no-cache` but not `external` is not opted in, so it stays stable.
+    val rule = ruleWith("//pkg:lint", "no-cache")
+    val a = digest(rule, setOf("external"), "seed-A".toByteArray()).overallDigest.toHexString()
+    val b = digest(rule, setOf("external"), "seed-B".toByteArray()).overallDigest.toHexString()
+    assertThat(a).isEqualTo(b)
+  }
+
+  @Test
+  fun enablingFlagDoesNotPerturbUntaggedTargets() {
+    // Turning the feature on must leave a target that lacks the tag byte-for-byte identical to the
+    // feature-off baseline -- otherwise the whole graph would over-invalidate.
+    val rule = ruleWith("//pkg:lib")
+    val off = digest(rule, emptySet(), ByteArray(0)).overallDigest.toHexString()
+    val on = digest(rule, setOf("external"), "seed-A".toByteArray()).overallDigest.toHexString()
+    assertThat(on).isEqualTo(off)
+  }
+
+  @Test
+  fun taggedTargetMatchesBaselineWhenFeatureDisabled() {
+    // With no configured tags the sentinel is never mixed, even for a would-be-tagged target.
+    val rule = ruleWith("//pkg:lint", "external")
+    val a = digest(rule, emptySet(), "seed-A".toByteArray()).overallDigest.toHexString()
+    val b = digest(rule, emptySet(), "seed-B".toByteArray()).overallDigest.toHexString()
+    assertThat(a).isEqualTo(b)
+  }
+
+  @Test
+  fun anyMatchingTagOptsTheTargetIn() {
+    // The target carries several tags; matching any one of the configured set is enough.
+    val rule = ruleWith("//pkg:lint", "no-cache", "external", "requires-network")
+    val a = digest(rule, setOf("external"), "seed-A".toByteArray()).overallDigest.toHexString()
+    val b = digest(rule, setOf("external"), "seed-B".toByteArray()).overallDigest.toHexString()
+    assertThat(a).isNotEqualTo(b)
+  }
+}


### PR DESCRIPTION
## Problem

Closes #401.

`bazel-diff` hashes a target from its **declared** rule inputs (plus transitive deps in the query graph). A target that reads the workspace at execution time *without* declaring those files as inputs — a repo-scanning linter such as `buildifier_test`, `gofmt_test`, or `eslint_test` — keeps a **stable hash** across commits that only change those undeclared files. Under target determination, the target is then wrongly skipped even though it would fail if run.

Monorepos commonly tag these non-hermetic targets with a Bazel target **tag** (the issue uses `external`). There was no first-class way to say "always treat targets with this tag as impacted" — the existing knobs don't fit (`--seed-filepaths` over-invalidates the whole graph; `--excludeExternalTargets` / `--fineGrainedHashExternalRepos` are about external **repos**, not the tag; `--cqueryExpression` only sees declared deps).

## Change

New `generate-hashes` flag: **`--alwaysAffectedTags`** (comma-separated, e.g. `--alwaysAffectedTags=external`).

Any rule whose `tags` attribute contains a listed value gets a **per-invocation random sentinel** mixed into its hash, so a diff of the base and head hash files **always** reports it as impacted. The tag name is the caller's convention — nothing is hardcoded.

```bash
bazel-diff generate-hashes --alwaysAffectedTags=external -w "$WORKSPACE" -b "$BAZEL" hashes.json
```

### How it works
- `BazelRule.tags()` reads the `tags` `STRING_LIST` attribute from the query/cquery proto.
- `RuleHasher` mixes the sentinel into the tagged rule's **direct** digest, so it is classified `DIRECT`-impacted for build-graph distance metrics. It also bubbles into the overall digest, so any rdeps are conservatively re-hashed too.
- The sentinel is minted once per invocation in `hasherModule`, and **only when the flag is set**. When the feature is unused nothing is mixed, so every hash is byte-for-byte identical to before and untagged targets never over-invalidate.

## Design notes for reviewers

- **Sentinel = per-invocation nonce, not HEAD commit SHA.** The issue floated both. The nonce was chosen because core `generate-hashes` has no git dependency, and it guarantees "always affected" even for non-git workspaces, shallow clones, dirty trees, and same-commit re-runs (a commit SHA would *not* mark the target affected when base == head). Trade-off: tagged targets' hashes are intentionally non-deterministic across runs; everything untagged stays deterministic.
- **Cascade is intentional.** Mixing into the digest necessarily flows into the overall digest that dependents consume, so rdeps of a tagged target are re-hashed. For the leaf test targets in the motivating issue there are no rdeps; for the general case it's a safe over-approximation. Documented in code + README.
- Scope is limited to `generate-hashes`; `serve` / `get-impacted-targets` pass the (defaulted-empty) parameter unchanged.

## Tests

- New `RuleHasherAlwaysAffectedTagsTest`: tagged target changes across invocations (overall + direct digest), untagged/unlisted-tag targets stay stable, enabling the flag doesn't perturb untagged targets, and it's inert when no tags are configured.
- `BazelRuleTest`: `tags()` extraction (present / absent).
- `BazelDiffTest`: CLI parsing of `--alwaysAffectedTags` (and empty default).

`bazel test //cli:all` → 34/35 pass locally. The lone failure is `//cli:E2ETest`, which is environmental in this sandbox (nested Bazel: `Cannot find Java binary bin/java`, `simulated network error resolving repository rule`); it needs a full toolchain + network and never sets the new flag, so this change cannot affect it.

## Docs

- README: new "Always-affected targets (non-hermetic tags)" section with a usage example, plus the regenerated `generate-hashes --help` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
