### PR TITLE
serve: add /metrics endpoint for instance and cache size info

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,28 @@ curl 'http://localhost:8080/impacted_targets_with_distances?from=main&to=my-feat
 }
 ```
 
+* `GET /metrics` — returns a JSON snapshot of the instance so callers and monitoring can see its
+  identity, liveness, and cache size usage without scraping logs. Unlike the query endpoints it is
+  never gated on readiness, so it still responds on an un-ready or lame-ducked instance (the `ready`
+  field reports the current state). The `cache` size fields are populated for the local-disk backend
+  and are `null` for a backend whose size is not cheaply knowable in-process.
+
+```bash
+curl 'http://localhost:8080/metrics'
+```
+
+```json
+{
+  "version": "31.4.0",
+  "uptimeSeconds": 3600,
+  "ready": true,
+  "gitEngine": "jgit",
+  "trackDeps": false,
+  "cache": {"directory": "/var/cache/bazel-diff", "entries": 128, "sizeBytes": 4823913, "sizeHuman": "4.6 MB"},
+  "jvm": {"usedBytes": 123456789, "maxBytes": 2147483648}
+}
+```
+
 Notes and current limitations:
 
 * Distance metrics (`/impacted_targets_with_distances`) require the dependency-edge graph, which is

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -244,6 +244,12 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "MetricsServiceTest",
+    test_class = "com.bazel_diff.server.MetricsServiceTest",
+    runtime_deps = [":cli-test-lib"],
+)
+
+kt_jvm_test(
     name = "GitClientTest",
     test_class = "com.bazel_diff.server.GitClientTest",
     runtime_deps = [":cli-test-lib"],

--- a/cli/src/main/kotlin/com/bazel_diff/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/ServeCommand.kt
@@ -16,6 +16,7 @@ import com.bazel_diff.server.HashService
 import com.bazel_diff.server.ImpactedTargetsService
 import com.bazel_diff.server.JGitClient
 import com.bazel_diff.server.LocalDiskHashCacheStorage
+import com.bazel_diff.server.MetricsService
 import com.bazel_diff.server.ProcessGitClient
 import java.io.File
 import java.nio.file.Path
@@ -288,7 +289,20 @@ class ServeCommand : Callable<Int> {
         ImpactedTargetsService(gitClient, hashService, depsTracked = trackDeps)
 
     val ready = AtomicBoolean(false)
-    val server = BazelDiffServer(port, impactedTargetsService, requestTimeoutSeconds) { ready.get() }
+    val metrics =
+        MetricsService(
+            version = VersionProvider().version.firstOrNull() ?: "unknown",
+            startedAtMillis = System.currentTimeMillis(),
+            gitEngine = gitEngine,
+            trackDeps = trackDeps,
+            cacheDir = cacheDir.toString(),
+            storage = storage,
+            readiness = { ready.get() },
+        )
+    val server =
+        BazelDiffServer(port, impactedTargetsService, requestTimeoutSeconds, metrics) {
+          ready.get()
+        }
     server.start()
     performInitialFetch(gitClient, hashService, ready, server)
     return server

--- a/cli/src/main/kotlin/com/bazel_diff/server/BazelDiffServer.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/BazelDiffServer.kt
@@ -29,6 +29,9 @@ import org.koin.core.component.inject
  * - `GET /impacted_targets_with_distances?from=<rev>&to=<rev>[&targetType=...]` -- like above but
  *   each impacted target is `{"label", "targetDistance", "packageDistance"}`. Requires the server
  *   to have been started with `--trackDeps`; returns `400` otherwise.
+ * - `GET /metrics` -- a JSON snapshot of the instance (version, uptime, readiness, git engine,
+ *   cache size usage, JVM heap) when a [metricsProvider] is wired. Intentionally not gated on
+ *   readiness, so a scrape of an un-ready or lame-ducked instance still returns data.
  *
  * Built on the JDK's [HttpServer] so the service needs no new third-party dependency. The handler
  * pool is unbounded (cached) so that health checks are always served even while a long hash
@@ -38,6 +41,7 @@ class BazelDiffServer(
     private val port: Int,
     private val impactedTargetsProvider: ImpactedTargetsProvider,
     private val requestTimeoutSeconds: Long = 0,
+    private val metricsProvider: MetricsProvider? = null,
     private val readiness: () -> Boolean,
 ) : KoinComponent {
   private val logger: Logger by inject()
@@ -66,6 +70,7 @@ class BazelDiffServer(
     httpServer.createContext("/impacted_targets", ::handleImpactedTargets)
     httpServer.createContext(
         "/impacted_targets_with_distances", ::handleImpactedTargetsWithDistances)
+    httpServer.createContext("/metrics", ::handleMetrics)
     httpServer.start()
     server = httpServer
     logger.i { "bazel-diff query service listening on port ${boundPort()} " }
@@ -97,6 +102,21 @@ class BazelDiffServer(
         } else {
           respond(exchange, 503, "NOT_READY\n")
         }
+      }
+
+  private fun handleMetrics(exchange: HttpExchange) =
+      withExchange(exchange) {
+        if (!exchange.requestMethod.equals("GET", ignoreCase = true)) {
+          respondJson(exchange, 405, mapOf("error" to "method not allowed, use GET"))
+          return@withExchange
+        }
+        val provider = metricsProvider
+        if (provider == null) {
+          respondJson(exchange, 404, mapOf("error" to "metrics unavailable"))
+          return@withExchange
+        }
+        // Deliberately not gated on readiness: metrics must be scrapeable even when un-ready.
+        respondJson(exchange, 200, provider.snapshot())
       }
 
   private fun handleImpactedTargets(exchange: HttpExchange) =
@@ -158,9 +178,9 @@ class BazelDiffServer(
 
   /**
    * Runs [compute] bounded by [requestTimeoutSeconds]. When the budget is exceeded the in-flight
-   * task is interrupted and a [TimeoutException] is thrown so the caller can respond `504`. Note the
-   * underlying `bazel query` may not honor the interrupt and can keep running in the background —
-   * abandoning it frees the client and the handler thread, and the query will still populate the
+   * task is interrupted and a [TimeoutException] is thrown so the caller can respond `504`. Note
+   * the underlying `bazel query` may not honor the interrupt and can keep running in the background
+   * — abandoning it frees the client and the handler thread, and the query will still populate the
    * per-SHA cache so a retry is fast. A non-positive timeout (the default) runs [compute] inline on
    * the handler thread with no bound, preserving the original behavior.
    */

--- a/cli/src/main/kotlin/com/bazel_diff/server/HashCacheStorage.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/HashCacheStorage.kt
@@ -1,5 +1,6 @@
 package com.bazel_diff.server
 
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
@@ -24,11 +25,23 @@ interface HashCacheStorage {
   fun contains(key: String): Boolean = get(key) != null
 }
 
+/** Footprint of a cache: how many entries are stored and their total size in bytes. */
+data class CacheStorageStats(val entryCount: Long, val totalBytes: Long)
+
+/**
+ * A [HashCacheStorage] that can cheaply report its footprint, surfaced by the `/metrics` endpoint
+ * so callers can watch cache growth. Backends where size is not cheaply knowable in-process (e.g. a
+ * remote store) simply do not implement this, and metrics report the size as unavailable.
+ */
+interface MeasurableHashCacheStorage : HashCacheStorage {
+  fun stats(): CacheStorageStats
+}
+
 /**
  * [HashCacheStorage] that stores each entry as a file `<key>.json` under [directory]. The directory
  * is created if it does not exist.
  */
-class LocalDiskHashCacheStorage(private val directory: Path) : HashCacheStorage {
+class LocalDiskHashCacheStorage(private val directory: Path) : MeasurableHashCacheStorage {
   init {
     Files.createDirectories(directory)
   }
@@ -54,4 +67,25 @@ class LocalDiskHashCacheStorage(private val directory: Path) : HashCacheStorage 
   }
 
   override fun contains(key: String): Boolean = Files.isRegularFile(pathFor(key))
+
+  override fun stats(): CacheStorageStats {
+    if (!Files.isDirectory(directory)) return CacheStorageStats(0, 0)
+    var entryCount = 0L
+    var totalBytes = 0L
+    // Only the `<key>.json` cache entries count -- in-progress `.tmp` writes are excluded, matching
+    // what a cache read would ever see.
+    Files.newDirectoryStream(directory, "*.json").use { stream ->
+      for (path in stream) {
+        try {
+          if (Files.isRegularFile(path)) {
+            entryCount++
+            totalBytes += Files.size(path)
+          }
+        } catch (e: IOException) {
+          // An entry that vanished mid-scan just doesn't count; keep tallying the rest.
+        }
+      }
+    }
+    return CacheStorageStats(entryCount, totalBytes)
+  }
 }

--- a/cli/src/main/kotlin/com/bazel_diff/server/MetricsService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/MetricsService.kt
@@ -1,0 +1,102 @@
+package com.bazel_diff.server
+
+import java.util.Locale
+
+/**
+ * A point-in-time snapshot of a running server instance, returned by `GET /metrics` so operators
+ * and callers can see the instance's identity, liveness, and resource usage without scraping logs.
+ */
+data class ServerMetrics(
+    val version: String,
+    val uptimeSeconds: Long,
+    val ready: Boolean,
+    val gitEngine: String,
+    val trackDeps: Boolean,
+    val cache: CacheMetrics,
+    val jvm: JvmMetrics,
+)
+
+/**
+ * Footprint of the hash cache. [entries]/[sizeBytes]/[sizeHuman] are null when the backend does not
+ * cheaply report its size (e.g. a remote store) -- see [MeasurableHashCacheStorage].
+ */
+data class CacheMetrics(
+    val directory: String?,
+    val entries: Long?,
+    val sizeBytes: Long?,
+    val sizeHuman: String?,
+)
+
+/** JVM heap usage of the instance, in bytes. */
+data class JvmMetrics(val usedBytes: Long, val maxBytes: Long)
+
+/**
+ * Supplies a fresh [ServerMetrics] snapshot. Behind an interface so the HTTP layer can be tested
+ * with a fake.
+ */
+interface MetricsProvider {
+  fun snapshot(): ServerMetrics
+}
+
+/**
+ * [MetricsProvider] that assembles a snapshot from the instance's configuration, its readiness
+ * flag, live JVM state, and -- when the backing [storage] supports it
+ * ([MeasurableHashCacheStorage]) -- the on-disk cache footprint. The cache size is read on demand
+ * per request; `/metrics` is expected to be polled by monitoring at a low rate, so walking the
+ * cache directory each call is acceptable.
+ *
+ * @param clock source of "now" in epoch millis, injectable so uptime is deterministic under test.
+ * @param readiness the same liveness flag `/health` reports; surfaced here so a scrape of an
+ *   un-ready or lame-ducked instance still returns data (metrics are intentionally not gated on
+ *   it).
+ */
+class MetricsService(
+    private val version: String,
+    private val startedAtMillis: Long,
+    private val gitEngine: String,
+    private val trackDeps: Boolean,
+    private val cacheDir: String,
+    private val storage: HashCacheStorage,
+    private val readiness: () -> Boolean,
+    private val clock: () -> Long = System::currentTimeMillis,
+) : MetricsProvider {
+  override fun snapshot(): ServerMetrics {
+    val cacheStats = (storage as? MeasurableHashCacheStorage)?.stats()
+    val runtime = Runtime.getRuntime()
+    return ServerMetrics(
+        version = version,
+        uptimeSeconds = (clock() - startedAtMillis).coerceAtLeast(0) / 1000,
+        ready = readiness(),
+        gitEngine = gitEngine,
+        trackDeps = trackDeps,
+        cache =
+            CacheMetrics(
+                directory = cacheDir,
+                entries = cacheStats?.entryCount,
+                sizeBytes = cacheStats?.totalBytes,
+                sizeHuman = cacheStats?.totalBytes?.let(::humanReadableBytes),
+            ),
+        jvm =
+            JvmMetrics(
+                usedBytes = runtime.totalMemory() - runtime.freeMemory(),
+                maxBytes = runtime.maxMemory(),
+            ),
+    )
+  }
+
+  /**
+   * Formats a byte count as a compact base-1024 string (matching the `--cacheMaxSize` unit scale),
+   * e.g. `4.6 MB`.
+   */
+  private fun humanReadableBytes(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val units = listOf("KB", "MB", "GB", "TB")
+    var value = bytes.toDouble() / 1024
+    var unit = 0
+    while (value >= 1024 && unit < units.size - 1) {
+      value /= 1024
+      unit++
+    }
+    return String.format(Locale.US, "%.1f %s", value, units[unit])
+  }
+}

--- a/cli/src/test/kotlin/com/bazel_diff/cli/ServeCommandTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/cli/ServeCommandTest.kt
@@ -11,7 +11,10 @@ import com.bazel_diff.server.GitClient
 import com.bazel_diff.server.GitClientException
 import com.bazel_diff.server.HashCacheStorage
 import com.bazel_diff.server.JGitClient
+import com.bazel_diff.server.LocalDiskHashCacheStorage
 import com.bazel_diff.server.ProcessGitClient
+import com.bazel_diff.server.ServerMetrics
+import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import java.net.HttpURLConnection
 import java.net.URL
@@ -81,11 +84,8 @@ class ServeCommandTest : KoinTest {
   }
 
   private object NoopImpactedTargets : com.bazel_diff.server.ImpactedTargetsProvider {
-    override fun getImpactedTargets(
-        fromRev: String,
-        toRev: String,
-        targetTypes: Set<String>?
-    ) = com.bazel_diff.server.ImpactedTargetsResult(fromRev, toRev, emptyList())
+    override fun getImpactedTargets(fromRev: String, toRev: String, targetTypes: Set<String>?) =
+        com.bazel_diff.server.ImpactedTargetsResult(fromRev, toRev, emptyList())
 
     override fun getImpactedTargetsWithDistances(
         fromRev: String,
@@ -241,7 +241,8 @@ class ServeCommandTest : KoinTest {
     val provider = RecordingHashProvider(failFor = setOf("bogus"))
     val ready = java.util.concurrent.atomic.AtomicBoolean(false)
     val server =
-        com.bazel_diff.server.BazelDiffServer(0, NoopImpactedTargets) { ready.get() }
+        com.bazel_diff.server
+            .BazelDiffServer(0, NoopImpactedTargets) { ready.get() }
             .also { startedServers += it }
     server.start()
 
@@ -259,5 +260,29 @@ class ServeCommandTest : KoinTest {
 
     // Fetch failed, so the instance stays un-ready and reports 503 for the load balancer to remove.
     assertThat(healthCode(server)).isEqualTo(503)
+  }
+
+  @Test
+  fun metricsEndpointReportsInstanceAndCacheUsage() {
+    val cmd = command()
+    // Back the service with a real on-disk cache under the configured --cacheDir so the endpoint
+    // reports live size usage through the full ServeCommand -> BazelDiffServer -> storage wiring.
+    val storage = LocalDiskHashCacheStorage(cmd.cacheDir)
+    storage.put("k", ByteArray(64))
+    val server = cmd.buildAndStartServer(FakeGitClient(), storage).also { startedServers += it }
+
+    val conn =
+        URL("http://localhost:${server.boundPort()}/metrics").openConnection() as HttpURLConnection
+    try {
+      assertThat(conn.responseCode).isEqualTo(200)
+      val parsed =
+          Gson().fromJson(conn.inputStream.bufferedReader().readText(), ServerMetrics::class.java)
+      assertThat(parsed.cache.directory).isEqualTo(cmd.cacheDir.toString())
+      assertThat(parsed.cache.entries).isEqualTo(1L)
+      assertThat(parsed.cache.sizeBytes).isEqualTo(64L)
+      assertThat(parsed.ready).isEqualTo(true)
+    } finally {
+      conn.disconnect()
+    }
   }
 }

--- a/cli/src/test/kotlin/com/bazel_diff/server/BazelDiffServerTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/BazelDiffServerTest.kt
@@ -37,7 +37,21 @@ class BazelDiffServerTest : KoinTest {
   private val gson = Gson()
   private val ready = AtomicBoolean(true)
   private var provider: ImpactedTargetsProvider = FixedProvider()
+  private val metrics: MetricsProvider = FixedMetrics()
   private lateinit var server: BazelDiffServer
+
+  private class FixedMetrics : MetricsProvider {
+    override fun snapshot() =
+        ServerMetrics(
+            version = "9.9.9",
+            uptimeSeconds = 42,
+            ready = true,
+            gitEngine = "jgit",
+            trackDeps = false,
+            cache = CacheMetrics("/cache", 2, 2048, "2.0 KB"),
+            jvm = JvmMetrics(1000, 2000),
+        )
+  }
 
   private class FixedProvider(
       var result: ImpactedTargetsResult =
@@ -77,7 +91,7 @@ class BazelDiffServerTest : KoinTest {
   @Before
   fun setUp() {
     // Port 0 binds an ephemeral port so parallel test runs never collide.
-    server = BazelDiffServer(0, providerProxy()) { ready.get() }
+    server = BazelDiffServer(0, providerProxy(), metricsProvider = metrics) { ready.get() }
     server.start()
   }
 
@@ -270,5 +284,42 @@ class BazelDiffServerTest : KoinTest {
     val response = get("/impacted_targets_with_distances?from=a&to=b")
     assertThat(response.code).isEqualTo(400)
     assertThat(response.body).contains("--trackDeps")
+  }
+
+  @Test
+  fun metricsReturnsSnapshotJson() {
+    val response = get("/metrics")
+    assertThat(response.code).isEqualTo(200)
+    val parsed = gson.fromJson(response.body, ServerMetrics::class.java)
+    assertThat(parsed.version).isEqualTo("9.9.9")
+    assertThat(parsed.cache.entries).isEqualTo(2L)
+    assertThat(parsed.jvm.maxBytes).isEqualTo(2000L)
+  }
+
+  @Test
+  fun metricsIsServedEvenWhenNotReady() {
+    // Metrics must be scrapeable on an un-ready/lame-ducked instance, so it is not gated on
+    // readiness.
+    ready.set(false)
+    assertThat(get("/metrics").code).isEqualTo(200)
+  }
+
+  @Test
+  fun metricsRejectsNonGetWith405() {
+    assertThat(request("/metrics", "POST").code).isEqualTo(405)
+  }
+
+  @Test
+  fun metricsReturns404WhenNoProviderWired() {
+    val bare = BazelDiffServer(0, providerProxy()) { ready.get() }
+    bare.start()
+    try {
+      val conn =
+          URL("http://localhost:${bare.boundPort()}/metrics").openConnection() as HttpURLConnection
+      assertThat(conn.responseCode).isEqualTo(404)
+      conn.disconnect()
+    } finally {
+      bare.stop()
+    }
   }
 }

--- a/cli/src/test/kotlin/com/bazel_diff/server/LocalDiskHashCacheStorageTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/LocalDiskHashCacheStorageTest.kt
@@ -55,4 +55,30 @@ class LocalDiskHashCacheStorageTest {
     assertThat(String(LocalDiskHashCacheStorage(dir).get("k")!!, StandardCharsets.UTF_8))
         .isEqualTo("v")
   }
+
+  @Test
+  fun statsCountsEntriesAndTotalBytes() {
+    val storage = storage()
+    storage.put("a", ByteArray(100))
+    storage.put("b", ByteArray(50))
+
+    val stats = storage.stats()
+
+    assertThat(stats.entryCount).isEqualTo(2L)
+    assertThat(stats.totalBytes).isEqualTo(150L)
+  }
+
+  @Test
+  fun statsIsEmptyWithNoEntriesAndIgnoresNonJsonFiles() {
+    val dir = temp.root.toPath()
+    val storage = LocalDiskHashCacheStorage(dir)
+    assertThat(storage.stats()).isEqualTo(CacheStorageStats(0, 0))
+
+    Files.write(dir.resolve("notes.txt"), "hello".toByteArray(StandardCharsets.UTF_8))
+    storage.put("k", ByteArray(10))
+
+    val stats = storage.stats()
+    assertThat(stats.entryCount).isEqualTo(1L) // the .txt file is not counted
+    assertThat(stats.totalBytes).isEqualTo(10L)
+  }
 }

--- a/cli/src/test/kotlin/com/bazel_diff/server/MetricsServiceTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/MetricsServiceTest.kt
@@ -1,0 +1,82 @@
+package com.bazel_diff.server
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import org.junit.Test
+
+class MetricsServiceTest {
+  private class FakeMeasurable(private val stats: CacheStorageStats) : MeasurableHashCacheStorage {
+    override fun get(key: String): ByteArray? = null
+
+    override fun put(key: String, data: ByteArray) = Unit
+
+    override fun stats(): CacheStorageStats = stats
+  }
+
+  private class FakePlain : HashCacheStorage {
+    override fun get(key: String): ByteArray? = null
+
+    override fun put(key: String, data: ByteArray) = Unit
+  }
+
+  private fun service(
+      storage: HashCacheStorage,
+      ready: Boolean = true,
+      nowMillis: Long = 10_000,
+      startedAtMillis: Long = 4_000,
+  ) =
+      MetricsService(
+          version = "1.2.3",
+          startedAtMillis = startedAtMillis,
+          gitEngine = "jgit",
+          trackDeps = true,
+          cacheDir = "/var/cache/bazel-diff",
+          storage = storage,
+          readiness = { ready },
+          clock = { nowMillis },
+      )
+
+  @Test
+  fun reportsInstanceInfoAndCacheStats() {
+    val snap =
+        service(FakeMeasurable(CacheStorageStats(entryCount = 3, totalBytes = 3072))).snapshot()
+
+    assertThat(snap.version).isEqualTo("1.2.3")
+    assertThat(snap.uptimeSeconds).isEqualTo(6) // (10000 - 4000) / 1000
+    assertThat(snap.ready).isTrue()
+    assertThat(snap.gitEngine).isEqualTo("jgit")
+    assertThat(snap.trackDeps).isTrue()
+    assertThat(snap.cache.directory).isEqualTo("/var/cache/bazel-diff")
+    assertThat(snap.cache.entries).isEqualTo(3L)
+    assertThat(snap.cache.sizeBytes).isEqualTo(3072L)
+    assertThat(snap.cache.sizeHuman).isEqualTo("3.0 KB")
+    assertThat(snap.jvm.maxBytes > 0L).isTrue()
+  }
+
+  @Test
+  fun cacheStatsAreNullWhenBackendIsNotMeasurable() {
+    val snap = service(FakePlain()).snapshot()
+
+    // The configured directory is still reported, but the size is unknown for a non-measurable
+    // store.
+    assertThat(snap.cache.directory).isEqualTo("/var/cache/bazel-diff")
+    assertThat(snap.cache.entries).isNull()
+    assertThat(snap.cache.sizeBytes).isNull()
+    assertThat(snap.cache.sizeHuman).isNull()
+  }
+
+  @Test
+  fun readinessIsReflectedLive() {
+    assertThat(service(FakePlain(), ready = false).snapshot().ready).isFalse()
+  }
+
+  @Test
+  fun uptimeIsClampedToZeroOnClockSkew() {
+    // Started "after" the current clock reading -> report 0, never a negative uptime.
+    val snap = service(FakePlain(), nowMillis = 1_000, startedAtMillis = 5_000).snapshot()
+    assertThat(snap.uptimeSeconds).isEqualTo(0)
+  }
+}

--- a/tools/readme_template.md
+++ b/tools/readme_template.md
@@ -171,6 +171,28 @@ curl 'http://localhost:8080/impacted_targets_with_distances?from=main&to=my-feat
 }
 ```
 
+* `GET /metrics` — returns a JSON snapshot of the instance so callers and monitoring can see its
+  identity, liveness, and cache size usage without scraping logs. Unlike the query endpoints it is
+  never gated on readiness, so it still responds on an un-ready or lame-ducked instance (the `ready`
+  field reports the current state). The `cache` size fields are populated for the local-disk backend
+  and are `null` for a backend whose size is not cheaply knowable in-process.
+
+```bash
+curl 'http://localhost:8080/metrics'
+```
+
+```json
+{
+  "version": "31.4.0",
+  "uptimeSeconds": 3600,
+  "ready": true,
+  "gitEngine": "jgit",
+  "trackDeps": false,
+  "cache": {"directory": "/var/cache/bazel-diff", "entries": 128, "sizeBytes": 4823913, "sizeHuman": "4.6 MB"},
+  "jvm": {"usedBytes": 123456789, "maxBytes": 2147483648}
+}
+```
+
 Notes and current limitations:
 
 * Distance metrics (`/impacted_targets_with_distances`) require the dependency-edge graph, which is


### PR DESCRIPTION
## What

Adds `GET /metrics` to the `serve` query service so callers and monitoring can see a running instance's identity, liveness, and **cache size usage** without scraping logs.

Example:

```bash
curl 'http://localhost:8080/metrics'
```
```json
{
  "version": "31.4.0",
  "uptimeSeconds": 3600,
  "ready": true,
  "gitEngine": "jgit",
  "trackDeps": false,
  "cache": {"directory": "/var/cache/bazel-diff", "entries": 128, "sizeBytes": 4823913, "sizeHuman": "4.6 MB"},
  "jvm": {"usedBytes": 123456789, "maxBytes": 2147483648}
}
```

## How

- **`MetricsService`** assembles the snapshot from the instance's config, its readiness flag, live JVM state, and — when the backing store supports it — the on-disk cache footprint. Read on demand per request (metrics are polled at a low rate, so walking the cache dir each call is fine).
- **`MeasurableHashCacheStorage`** capability interface (mirrors the existing pluggable-storage design). `LocalDiskHashCacheStorage` reports entry count + total bytes by summing its `*.json` entries. A backend that can't cheaply report size (a future S3 store) simply doesn't implement it, and the `cache` size fields are `null`.
- Wired into `BazelDiffServer` as an **always-on** endpoint. Deliberately **not gated on readiness** — a scrape of an un-ready or lame-ducked instance still returns data, with the current state in the `ready` field.
- **No new CLI flags.**

## Notes for reviewers

- Independent of the cache-pruning PR (#417) — based off `master`. There is a small, intentional overlap in `HashCacheStorage.kt`: this PR adds a `MeasurableHashCacheStorage` capability while #417 adds a `PrunableHashCacheStorage` one. They're separate interfaces/methods and will reconcile trivially when both land.
- `sizeHuman` uses base-1024 units to match the `--cacheMaxSize` scale from #417.

## Testing

- Unit: `MetricsService` snapshot assembly (injected clock for deterministic uptime; `null` cache for a non-measurable backend), and `LocalDiskHashCacheStorage.stats()`.
- HTTP: `/metrics` returns `200` + JSON, `405` on non-GET, `404` when no provider is wired, and is **served even when not ready**.
- End-to-end: a `ServeCommandTest` case that stands up the real server via `buildAndStartServer` and curls `/metrics` over real HTTP, reading live on-disk cache stats parsed from JSON.
- `ktfmt`/`buildifier` clean; docs in `readme_template.md` + regenerated `README.md`.

> Note: a full real-binary smoke of `serve` requires a real Bazel workspace (its DI eagerly runs `bazel info` at startup, unrelated to metrics), which is what `E2ETest#testServeEndToEnd` covers; the endpoint here is exercised end-to-end via the in-process `ServeCommandTest` over real HTTP.