### PR TITLE
fix: self-heal //external query on bzlmod-only workspaces

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -17,6 +17,14 @@ class BazelClient(
   private val bazelModService: BazelModService by inject()
 
   /**
+   * Latched once a query proves `//external` is unavailable in this workspace (bzlmod-only mode
+   * where the `bazel mod graph` probe in [BazelModService] returned a false negative). Subsequent
+   * [queryAllTargets] calls -- e.g. later revisions served by a long-running `serve` process --
+   * then skip `//external:all-targets` up front rather than failing and retrying every time.
+   */
+  @Volatile private var externalPackageUnavailable = false
+
+  /**
    * Wraps [query] so that every target matching the user-supplied [excludeTargetsQuery] is removed
    * from the result set via Bazel's `except` operator. Returns [query] unchanged when no exclude
    * query is configured. This is how callers drop, e.g., `manual`-tagged targets from the graph
@@ -31,11 +39,13 @@ class BazelClient(
   suspend fun queryAllTargets(): List<BazelTarget> {
     val queryEpoch = Calendar.getInstance().getTimeInMillis()
 
-    // Skip //external:all-targets when explicitly excluded or when Bzlmod is enabled (//external
-    // not
-    // available).
+    // Skip //external:all-targets when explicitly excluded, when Bzlmod is enabled (//external not
+    // available), or when an earlier query already proved //external is unavailable here (the
+    // Bzlmod probe false-negatived -- see [externalPackageUnavailable]).
     val repoTargetsQuery =
-        if (excludeExternalTargets || bazelModService.isBzlmodEnabled) {
+        if (excludeExternalTargets ||
+            bazelModService.isBzlmodEnabled ||
+            externalPackageUnavailable) {
           emptyList()
         } else {
           listOf("//external:all-targets")
@@ -74,7 +84,14 @@ class BazelClient(
           val mainTargets = queryService.query(expression, useCquery = true)
           val repoTargets =
               if (repoTargetsQuery.isNotEmpty()) {
-                queryService.query(repoTargetsQuery.joinToString(" + ") { "'$it'" })
+                try {
+                  queryService.query(repoTargetsQuery.joinToString(" + ") { "'$it'" })
+                } catch (e: ExternalPackageUnavailableException) {
+                  // //external isn't queryable here despite the Bzlmod probe saying otherwise; the
+                  // main deps() query already succeeded, so just drop the external repo targets.
+                  noteExternalPackageUnavailable()
+                  emptyList()
+                }
               } else {
                 emptyList()
               }
@@ -83,13 +100,40 @@ class BazelClient(
           val buildTargetsQuery =
               listOf("//...:all-targets") +
                   fineGrainedHashExternalRepos.map { "$it//...:all-targets" }
-          queryService.query(
-              withExcludeFilter(
-                  (repoTargetsQuery + buildTargetsQuery).joinToString(" + ") { "'$it'" }))
+          try {
+            queryService.query(
+                withExcludeFilter(
+                    (repoTargetsQuery + buildTargetsQuery).joinToString(" + ") { "'$it'" }))
+          } catch (e: ExternalPackageUnavailableException) {
+            // The combined query failed because //external is unavailable. If we hadn't asked for
+            // it, the error came from elsewhere and must not be masked; otherwise retry without it.
+            if (repoTargetsQuery.isEmpty()) throw e
+            noteExternalPackageUnavailable()
+            queryService.query(withExcludeFilter(buildTargetsQuery.joinToString(" + ") { "'$it'" }))
+          }
         }
     val allTargets = (targets + bzlmodRepoTargets).distinctBy { it.name }
     val queryDuration = Calendar.getInstance().getTimeInMillis() - queryEpoch
     logger.i { "All targets queried in $queryDuration" }
     return allTargets
+  }
+
+  /**
+   * Latches [externalPackageUnavailable] the first time a query proves `//external` is unqueryable,
+   * emitting a one-time explanation. This means the Bzlmod probe (`bazel mod graph`) reported that
+   * Bzlmod was off when it is actually on -- common in restricted environments where `bazel mod
+   * graph` cannot resolve the module graph. Dropping `//external:all-targets` is correct here: when
+   * the package genuinely isn't available, there are no WORKSPACE-defined external targets to hash.
+   */
+  private fun noteExternalPackageUnavailable() {
+    if (!externalPackageUnavailable) {
+      externalPackageUnavailable = true
+      logger.w {
+        "//external is not available in this workspace (WORKSPACE deprecated / bzlmod-only), but " +
+            "Bzlmod auto-detection did not catch it; dropping //external:all-targets from the " +
+            "query and continuing. Pass --excludeExternalTargets to skip it up front and silence " +
+            "this."
+      }
+    }
   }
 }

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
@@ -9,12 +9,26 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.runBlocking
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 private val versionComparator =
     compareBy<Triple<Int, Int, Int>> { it.first }.thenBy { it.second }.thenBy { it.third }
+
+/**
+ * Thrown by [BazelQueryService.query] when a `bazel query` fails specifically because the
+ * `//external` package is unavailable. Bazel reports `no such package 'external'` once the
+ * WORKSPACE file is deprecated (bzlmod-only mode -- e.g. Bazel 8/9 with
+ * `--enable_workspace=false`).
+ *
+ * [BazelClient] catches this to transparently drop `//external:all-targets` and retry, self-healing
+ * the case where bzlmod auto-detection via `bazel mod graph` returned a false negative (e.g. a
+ * restricted deploy environment where `bazel mod graph` cannot resolve the module graph, so the
+ * `//external`-availability prediction disagrees with what Bazel actually does).
+ */
+class ExternalPackageUnavailableException(message: String) : RuntimeException(message)
 
 class BazelQueryService(
     private val workingDirectory: Path,
@@ -220,22 +234,49 @@ class BazelQueryService(
 
     logger.i { "Executing Query: $query" }
     logger.i { "Command: ${cmd.toTypedArray().joinToString()}" }
+    // Tee Bazel's stderr to our own stderr (preserving the live progress/error output the user
+    // expects) while also capturing it, so a failure can be classified. Specifically, this lets us
+    // recognise the "//external package is not available" error and raise it as a typed
+    // [ExternalPackageUnavailableException] the caller can recover from, instead of an opaque
+    // "exit code 7". The captured lines are fully populated by the time [process] returns.
+    val stderrLines = mutableListOf<String>()
     val result =
         process(
             *cmd.toTypedArray(),
             stdout = if (canUseOutputFile) Redirect.SILENT else Redirect.ToFile(outputFile),
             workingDirectory = workingDirectory.toFile(),
-            stderr = Redirect.PRINT,
+            stderr =
+                Redirect.Consume { flow ->
+                  flow.collect { line ->
+                    System.err.println(line)
+                    stderrLines.add(line)
+                  }
+                },
             destroyForcibly = true,
         )
 
     if (!allowedExitCodes.contains(result.resultCode)) {
-      logger.w { "Bazel query failed, output: ${result.output.joinToString("\n")}" }
+      val stderrText = stderrLines.joinToString("\n")
+      logger.w { "Bazel query failed with exit code ${result.resultCode}" }
+      if (indicatesExternalPackageUnavailable(stderrText)) {
+        throw ExternalPackageUnavailableException(
+            "Bazel query failed because the //external package is unavailable " +
+                "(WORKSPACE deprecated / bzlmod-only), exit code ${result.resultCode}")
+      }
       throw RuntimeException(
           "Bazel query failed, exit code ${result.resultCode}, allowed exit codes: ${allowedExitCodes.joinToString()}")
     }
     return outputFile
   }
+
+  /**
+   * True if [stderr] from a failed `bazel query` indicates the `//external` package is unavailable
+   * because the WORKSPACE file is deprecated (bzlmod-only mode). Matches the stable fragments of
+   * Bazel's error message: `no such package 'external'` / `//external package is not available`.
+   */
+  private fun indicatesExternalPackageUnavailable(stderr: String): Boolean =
+      stderr.contains("no such package 'external'") ||
+          stderr.contains("//external package is not available")
 
   /**
    * Queries bzlmod-managed external repo definitions using `bazel mod show_repo`. Requires Bazel

--- a/cli/src/test/kotlin/com/bazel_diff/bazel/BazelClientTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/bazel/BazelClientTest.kt
@@ -15,6 +15,7 @@ import org.koin.dsl.module
 import org.koin.test.KoinTest
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -166,6 +167,87 @@ class BazelClientTest : KoinTest {
       val targets = client.queryAllTargets()
 
       assertThat(targets).hasSize(1)
+    }
+  }
+
+  @Test
+  fun queryAllTargets_retriesWithoutExternal_whenExternalPackageUnavailable() {
+    runBlocking {
+      val mainTarget = mockRuleTarget("//src:lib")
+
+      // Bzlmod probe false-negatives (reports disabled), so //external:all-targets is included, but
+      // the combined query fails because //external is not actually available. The retry without it
+      // succeeds.
+      whenever(modService.isBzlmodEnabled).thenReturn(false)
+      whenever(queryService.query("'//external:all-targets' + '//...:all-targets'"))
+          .thenThrow(ExternalPackageUnavailableException("no such package 'external'"))
+      whenever(queryService.query("'//...:all-targets'")).thenReturn(listOf(mainTarget))
+
+      val client =
+          BazelClient(
+              useCquery = false,
+              cqueryExpression = null,
+              fineGrainedHashExternalRepos = emptySet(),
+              excludeExternalTargets = false,
+              excludeTargetsQuery = null)
+
+      val targets = client.queryAllTargets()
+
+      assertThat(targets.map { it.name }).containsOnly("//src:lib")
+      verify(queryService).query("'//...:all-targets'")
+    }
+  }
+
+  @Test
+  fun queryAllTargets_cquery_dropsExternalRepoTargets_whenExternalPackageUnavailable() {
+    runBlocking {
+      val mainTarget = mockRuleTarget("//src:lib")
+
+      whenever(modService.isBzlmodEnabled).thenReturn(false)
+      whenever(queryService.query("deps(//...:all-targets)", useCquery = true))
+          .thenReturn(listOf(mainTarget))
+      whenever(queryService.query("'//external:all-targets'"))
+          .thenThrow(ExternalPackageUnavailableException("no such package 'external'"))
+
+      val client =
+          BazelClient(
+              useCquery = true,
+              cqueryExpression = null,
+              fineGrainedHashExternalRepos = emptySet(),
+              excludeExternalTargets = false,
+              excludeTargetsQuery = null)
+
+      val targets = client.queryAllTargets()
+
+      assertThat(targets.map { it.name }).containsOnly("//src:lib")
+    }
+  }
+
+  @Test
+  fun queryAllTargets_skipsExternalOnSubsequentCalls_afterUnavailable() {
+    runBlocking {
+      val mainTarget = mockRuleTarget("//src:lib")
+
+      whenever(modService.isBzlmodEnabled).thenReturn(false)
+      whenever(queryService.query("'//external:all-targets' + '//...:all-targets'"))
+          .thenThrow(ExternalPackageUnavailableException("no such package 'external'"))
+      whenever(queryService.query("'//...:all-targets'")).thenReturn(listOf(mainTarget))
+
+      val client =
+          BazelClient(
+              useCquery = false,
+              cqueryExpression = null,
+              fineGrainedHashExternalRepos = emptySet(),
+              excludeExternalTargets = false,
+              excludeTargetsQuery = null)
+
+      client.queryAllTargets() // learns //external is unavailable
+      client.queryAllTargets() // should skip //external up front now
+
+      // The combined (with-//external) query is attempted only on the first call; both calls fall
+      // back to the //external-free query.
+      verify(queryService, times(1)).query("'//external:all-targets' + '//...:all-targets'")
+      verify(queryService, times(2)).query("'//...:all-targets'")
     }
   }
 


### PR DESCRIPTION
## Problem

`generate-hashes` and the `serve` warmup could hard-fail on a Bzlmod-only workspace with:

```
ERROR: no such package 'external': //external package is not available since the WORKSPACE file is deprecated, please migrate to Bzlmod.
[Warn] warmup for revision 'main' failed; ... Bazel query failed, exit code 7, allowed exit codes: 0
```

`BazelClient.queryAllTargets` decides whether to query `//external:all-targets` from `BazelModService.isBzlmodEnabled`, whose only signal is "`bazel mod graph` exited 0". In restricted/cloud deploy environments that probe can **false-negative** (it can't resolve the module graph / lockfile), so `//external:all-targets` gets included and Bazel rejects it because the package is unavailable in bzlmod-only mode (e.g. Bazel 8/9 with `--enable_workspace=false`).

For `serve` this was worse than the warmup warning implies — a **cold on-demand request hits the same crash**, so the service was effectively broken for such workspaces.

## Fix

React to ground truth instead of the probe:

- **`BazelQueryService.runQuery`** now tees + captures Bazel's stderr (switching `stderr` from `Redirect.PRINT` to `Redirect.Consume`) and, when a query fails specifically because `//external` is unavailable (`no such package 'external'` / `//external package is not available`), throws a typed **`ExternalPackageUnavailableException`** instead of an opaque "exit code 7".
- **`BazelClient`** catches it, drops `//external:all-targets`, and retries once. It latches a `@Volatile externalPackageUnavailable` flag so later revisions served by a long-running `serve` process skip `//external` up front rather than failing-then-retrying every time.

This **cannot misfire for genuine WORKSPACE mode**: there the query succeeds, so no retry happens and `//external` targets are still hashed as before. It also fixes `generate-hashes`, which shares the same query path.

## Testing

- **`BazelClientTest`** — added 3 cases: non-cquery retry-without-external, cquery external-repo drop, and the subsequent-call latch. All pass; existing cases unchanged.
- **`BazelModServiceTest`, `HashServiceTest`, `ImpactedTargetsServiceTest`, `ServeCommandTest`** — pass.
- **`E2ETest`** — the 4 local failures (`testUseCqueryWith*`, `testBzlmodTransitiveDepsCquery`, `testFineGrainedHashExternalRepo`) are pre-existing and environmental; confirmed identical on baseline with this change stashed (`Unable to run coursier: Unable to locate a Java Runtime` — the local Bazel sandbox has no JDK for `rules_jvm_external`).
- ktfmt applied.

## Notes for reviewers

- Separate, lower-severity residual **not** addressed here: the same probe false-negative also nulls `getModuleGraphJson()`, disabling MODULE.bazel-change detection in that environment. Could be a follow-up (e.g. strengthening `isBzlmodEnabled`), but it's independent of this crash fix.
- The stderr switch to `Redirect.Consume` still forwards Bazel's stderr live (line-buffered), so query progress/errors remain visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)