### PR TITLE
fix(ci): parse flag-shaped --real-clone-args so serve-stress-real can run

### DIFF
--- a/.github/workflows/serve-stress-real.yml
+++ b/.github/workflows/serve-stress-real.yml
@@ -60,13 +60,19 @@ jobs:
       - name: Run serve stress harness (${{ matrix.size }})
         # --bazel points the harness (and the serve subprocess) at bazelisk; the bazel version for
         # the CLONED repo comes from that repo's own .bazelversion, which bazelisk honors.
+        #
+        # --real-clone-args must keep the `=` spelling: its value is itself a flag (`--depth=50`),
+        # and argparse reads a space-separated `--real-clone-args --depth=50` as two options, not an
+        # option and its value ("expected one argument" -- quoting does not help, the shell strips
+        # the quotes before argparse sees the token). The harness also folds the space spelling, but
+        # keeping `=` here means the matrix parses under plain argparse rules regardless.
         run: >
           python3 tools/serve_stress.py
           --bazel "$HOME/go/bin/bazelisk"
           --real-repo-url "${{ matrix.repo }}"
           --real-from HEAD~1
           --real-to HEAD
-          --real-clone-args "${{ matrix.clone_args }}"
+          --real-clone-args="${{ matrix.clone_args }}"
           --metrics-out "serve-stress-real-${{ matrix.size }}-metrics.json"
           --summary-out "serve-stress-real-${{ matrix.size }}-summary.md"
       - name: Publish step summary

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -60,3 +60,24 @@ py_test(
 # deadlock on the output-base lock if they were themselves launched via `bazel run` (nested bazel,
 # same output base). Run them directly: `python3 tools/serve_harness.py` /
 # `python3 tools/serve_stress.py` (see their module docstrings). They use only the Python stdlib.
+#
+# A py_test over their *pure* helpers is fine, though -- it imports the module and calls functions
+# that never shell out, so no nested bazel and no deadlock. serve_stress_test.py covers the CLI
+# parsing that the serve-stress-real cron depends on (a flag-shaped --real-clone-args value, which
+# argparse rejects unless folded into the `=` spelling; that broke the cron's first two runs).
+py_library(
+    name = "serve_stress_lib",
+    srcs = [
+        "serve_harness.py",  # imported by serve_stress as `base`
+        "serve_stress.py",
+    ],
+    imports = ["."],
+    visibility = ["//visibility:private"],
+)
+
+py_test(
+    name = "serve_stress_test",
+    srcs = ["serve_stress_test.py"],
+    python_version = "PY3",
+    deps = [":serve_stress_lib"],
+)

--- a/tools/serve_stress.py
+++ b/tools/serve_stress.py
@@ -1053,7 +1053,37 @@ def run_phases(ctx: Ctx, only: str) -> None:
     phase_final(ctx)
 
 
-def main() -> int:
+# Options whose value is itself flag-shaped, which argparse cannot take in the space-separated
+# spelling. See fold_flag_values.
+FLAG_VALUED_OPTS = ("--real-clone-args",)
+
+
+def fold_flag_values(argv: list, opts: tuple = FLAG_VALUED_OPTS) -> list:
+    """Rewrites `--opt <value>` into `--opt=<value>` for each of [opts], returning a new argv.
+
+    argparse treats *any* token starting with `-` as an option, so an option whose value is itself a
+    flag dies at parse time: `--real-clone-args --depth=50` fails with a bare "expected one
+    argument", and no amount of shell quoting saves it, because the quotes are long gone by the time
+    argparse sees the token. Only the `=` spelling survives. The space-separated spelling is the
+    natural one -- it is what this module's own usage examples show, and what a CI matrix
+    interpolates -- so fold it into the `=` form up front and let both work. For a value that is not
+    flag-shaped the two spellings are already equivalent, so this is a no-op.
+    """
+    out: list = []
+    i = 0
+    while i < len(argv):
+        # A trailing `--opt` with no value is passed through untouched, so argparse still reports it
+        # as missing rather than swallowing the next option.
+        if argv[i] in opts and i + 1 < len(argv):
+            out.append(f"{argv[i]}={argv[i + 1]}")
+            i += 2
+        else:
+            out.append(argv[i])
+            i += 1
+    return out
+
+
+def build_parser() -> argparse.ArgumentParser:
     ap = argparse.ArgumentParser(description="Stress `bazel-diff serve` and capture metrics.")
     ap.add_argument("--skip-build", action="store_true", help="reuse existing bazel-bin launcher")
     ap.add_argument("--quick", action="store_true", help="reduced request counts")
@@ -1077,7 +1107,17 @@ def main() -> int:
     real.add_argument("--real-clone-args", default="",
                       help="extra `git clone` args, e.g. '--depth=50' (deep enough for the lock "
                            "phases' ancestry walk)")
-    args = ap.parse_args()
+    return ap
+
+
+def parse_args(argv: list) -> argparse.Namespace:
+    """Parses [argv] (without the program name), accepting either spelling of the flag-valued
+    options -- `--real-clone-args --depth=50` or `--real-clone-args=--depth=50`."""
+    return build_parser().parse_args(fold_flag_values(argv))
+
+
+def main() -> int:
+    args = parse_args(sys.argv[1:])
     base.VERBOSE = args.verbose
     base.BAZEL = args.bazel
 

--- a/tools/serve_stress_test.py
+++ b/tools/serve_stress_test.py
@@ -1,0 +1,98 @@
+"""Unit tests for tools/serve_stress.py's argument parsing.
+
+The stress harness itself needs git, bazel and a live serve process, so it is exercised by the
+serve-stress* workflows rather than here. What *is* unit-testable -- and what broke the
+serve-stress-real cron on both of its first two runs -- is the CLI surface: an option whose value is
+itself a flag (`--real-clone-args --depth=50`) is rejected by argparse unless it is folded into the
+`=` spelling. These tests pin both spellings, using the exact argv the workflow matrix produces.
+
+Run via Bazel:
+    bazel test //tools:serve_stress_test
+"""
+
+import contextlib
+import io
+import unittest
+
+from serve_stress import build_parser, fold_flag_values, parse_args
+
+
+def ci_argv(clone_args: str, equals_spelling: bool) -> list:
+    """The argv .github/workflows/serve-stress-real.yml expands to for one matrix leg, in either the
+    `--real-clone-args=<v>` spelling (what the workflow pins) or the space-separated one."""
+    tail = ([f"--real-clone-args={clone_args}"] if equals_spelling
+            else ["--real-clone-args", clone_args])
+    return [
+        "--bazel", "/home/runner/go/bin/bazelisk",
+        "--real-repo-url", "https://github.com/bazelbuild/bazel-skylib.git",
+        "--real-from", "HEAD~1",
+        "--real-to", "HEAD",
+        *tail,
+        "--metrics-out", "serve-stress-real-small-metrics.json",
+        "--summary-out", "serve-stress-real-small-summary.md",
+    ]
+
+
+class FoldFlagValuesTest(unittest.TestCase):
+    def test_folds_flag_shaped_value(self):
+        self.assertEqual(
+            fold_flag_values(["--real-clone-args", "--depth=50"]),
+            ["--real-clone-args=--depth=50"],
+        )
+
+    def test_folded_value_is_equivalent_for_non_flag_values(self):
+        self.assertEqual(fold_flag_values(["--real-clone-args", "x"]), ["--real-clone-args=x"])
+
+    def test_leaves_other_options_untouched(self):
+        argv = ["--real-from", "HEAD~1", "--bazel", "bazelisk", "-v"]
+        self.assertEqual(fold_flag_values(argv), argv)
+
+    def test_already_folded_value_is_untouched(self):
+        argv = ["--real-clone-args=--depth=50"]
+        self.assertEqual(fold_flag_values(argv), argv)
+
+    def test_trailing_option_without_a_value_is_untouched(self):
+        # Nothing to fold onto: leave it for argparse to report as missing rather than swallowing
+        # whatever follows (here, nothing).
+        self.assertEqual(fold_flag_values(["--real-clone-args"]), ["--real-clone-args"])
+
+
+class ParseArgsTest(unittest.TestCase):
+    def test_ci_argv_parses_in_both_spellings(self):
+        # The regression: the space-separated spelling used to die with "expected one argument".
+        for equals_spelling in (True, False):
+            with self.subTest(equals_spelling=equals_spelling):
+                args = parse_args(ci_argv("--depth=50", equals_spelling))
+                self.assertEqual(args.real_clone_args, "--depth=50")
+                self.assertEqual(args.real_repo_url,
+                                 "https://github.com/bazelbuild/bazel-skylib.git")
+                self.assertEqual(args.real_from, "HEAD~1")
+                self.assertEqual(args.real_to, "HEAD")
+
+    def test_clone_args_split_into_git_argv(self):
+        # setup_real_clone splits the value into `git clone` args; multiple flags must survive.
+        args = parse_args(["--real-clone-args", "--depth=50 --filter=blob:none"])
+        self.assertEqual(args.real_clone_args.split(), ["--depth=50", "--filter=blob:none"])
+
+    def test_empty_clone_args_means_full_clone(self):
+        # An unset matrix row expands to `--real-clone-args=`, which must mean "no extra git args".
+        self.assertEqual(parse_args(["--real-clone-args="]).real_clone_args, "")
+        self.assertEqual(parse_args([]).real_clone_args, "")
+
+    def test_missing_clone_args_value_still_errors(self):
+        with self.assertRaises(SystemExit), contextlib.redirect_stderr(io.StringIO()):
+            parse_args(["--real-clone-args"])
+
+    def test_hermetic_defaults(self):
+        # No --real-repo-url: real-repo mode stays off and the hermetic phases run.
+        args = parse_args([])
+        self.assertEqual(args.real_repo_url, "")
+        self.assertEqual(args.bazel, "bazel")
+        self.assertFalse(args.skip_build)
+
+    def test_parser_builds(self):
+        self.assertIsNotNone(build_parser())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The [Serve Stress (real repos)](https://github.com/Tinder/bazel-diff/actions/runs/29320860891) cron has failed on both of its runs so far, in all three matrix legs, before doing any work:

```
serve_stress.py: error: argument --real-clone-args: expected one argument
```

argparse classifies *any* token beginning with `-` as an option, so the matrix's `--real-clone-args "--depth=50"` is read as two options rather than an option and its value. The shell strips the quotes long before argparse sees the token, so quoting cannot help — only the `=` spelling survives. Real-repo mode has therefore never once gotten past argument parsing, and the `real_*` phases have never run in CI. The harness's own usage examples in the module docstring show the same spelling that cannot parse, so this was documented as well as shipped.

- **workflow**: pin `--real-clone-args="..."`, with a comment on why the `=` has to stay, so it does not get "cleaned up" back into the broken spelling
- **harness**: fold `--opt <value>` into `--opt=<value>` before parsing, so the natural spelling works too and the documented examples become true; `main()` is split into `build_parser()` / `parse_args()` so the CLI surface is testable at all
- **test**: `//tools:serve_stress_test` pins both spellings against the exact argv the matrix produces. Verified it is a real regression test: the raw parser rejects the CI argv, `parse_args` accepts it

## Validation

Fixing the parse only gets the harness to the starting line, so the previously-unexercised `real_*` phases were run end-to-end locally against two of the three real matrix targets — **10 pass / 0 fail, exit 0** on each:

| leg | repo | cold checkout | phases |
|---|---|---|---|
| small | bazel-skylib | 18 impacted targets | cold / hot / lock_heal / lock_storm all pass |
| medium | abseil-cpp | 912 impacted targets | cold / hot / lock_heal / lock_storm all pass |

Both runs exercised real large-tree checkouts, a real `bazel query`, concurrent cache hits, the orphaned-`index.lock` self-heal (#425), and the lock storm, with the background health prober seeing zero non-200s across 33 probes and a well-formed metrics table for the step summary.

The `bazel` leg (bazelbuild/bazel) was not run locally — it differs only in scale, not code path, and its `bazel query` is minutes-scale — so the first scheduled run after this lands is what will confirm it.

Also worth noting: the `Restore cache failed: ... go.sum` lines in that run are benign `actions/setup-go` warnings, not the failure.

Since scheduled runs execute from the default branch, this has to land on `master` before the cron can go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)