### PR TITLE
feat(serve): opt-in per-request profile and memoryProfile data on query endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Endpoints:
   balancer should use this to route only to ready instances. If a fatal git error occurs at startup
   the instance "lame-ducks" itself by continuing to report `503` so the load balancer removes it.
 * `GET /impacted_targets?from=<rev>&to=<rev>` — returns the impacted targets as JSON. The optional
-  `targetType` parameter (e.g. `&targetType=Rule,SourceFile`) filters by target type.
+  `targetType` parameter (e.g. `&targetType=Rule,SourceFile`) filters by target type. The optional
+  `profile=true` parameter additionally returns per-request profiling data (see below).
 
 ```bash
 curl 'http://localhost:8080/impacted_targets?from=main&to=my-feature-branch'
@@ -151,7 +152,8 @@ curl 'http://localhost:8080/impacted_targets?from=main&to=my-feature-branch'
 
 * `POST /impacted_targets` — the same query as a JSON body, which additionally accepts a
   `modifiedFilepaths` list to speed up cold hashing on large repositories. Body fields: `from` and
-  `to` (required), `targetType` (optional array), and `modifiedFilepaths` (optional array of
+  `to` (required), `targetType` (optional array), `profile` (optional boolean, same as the GET
+  parameter), and `modifiedFilepaths` (optional array of
   workspace-relative paths that changed between the two revisions, e.g. from
   `git diff --name-only <from> <to>`). When `modifiedFilepaths` is present the server reads and
   hashes the *content* of only those files on **both** revisions and treats every other source file
@@ -188,6 +190,51 @@ curl 'http://localhost:8080/impacted_targets_with_distances?from=main&to=my-feat
   ]
 }
 ```
+
+* Per-request profiling — adding `profile=true` (GET parameter or POST body field) to
+  `/impacted_targets` or `/impacted_targets_with_distances` attaches two extra objects to the
+  response so callers can feed per-request latency, cache effectiveness, and memory pressure into
+  their metrics and monitoring: `profile` (a wall-clock breakdown of the query) and `memoryProfile`
+  (JVM heap/GC movement over the query). Without the flag the response shape is unchanged.
+
+```bash
+curl 'http://localhost:8080/impacted_targets?from=main&to=my-feature-branch&profile=true'
+```
+
+```json
+{
+  "from": "9a1c0e2…",
+  "to": "3f7b8d4…",
+  "impactedTargets": ["//foo:bar", "//foo:baz"],
+  "profile": {
+    "totalDurationMillis": 1843,
+    "resolveRevisionsDurationMillis": 12,
+    "hashRetrievals": [
+      {"sha": "9a1c0e2…", "cacheHit": true, "durationMillis": 95},
+      {"sha": "3f7b8d4…", "cacheHit": false, "durationMillis": 1701}
+    ],
+    "diffDurationMillis": 21
+  },
+  "memoryProfile": {
+    "heapUsedBeforeBytes": 231452416,
+    "heapUsedAfterBytes": 512665600,
+    "heapUsedDeltaBytes": 281213184,
+    "heapMaxBytes": 4294967296,
+    "gcCollections": 3,
+    "gcTimeMillis": 41
+  }
+}
+```
+
+  Field notes: `hashRetrievals` reports each side's hash fetch — `cacheHit: false` means this
+  request ran the git checkout + `bazel query` itself (typically orders of magnitude slower than a
+  hit), while a hit includes the case where the request waited for a concurrent generation of the
+  same revision to finish. `totalDurationMillis` spans dispatch to response assembly (including any
+  wait for the workspace lock), so it can exceed the sum of the phases;
+  `resolveRevisionsDurationMillis` includes any on-demand `git fetch`; `diffDurationMillis` includes
+  the live `rdeps` query issued when the module graph changed between the revisions. Heap and GC
+  numbers are process-wide, so concurrent requests bleed into each other's deltas — treat them as
+  indicative, not exact.
 
 * `GET /metrics` — returns a JSON snapshot of the instance so callers and monitoring can see its
   identity, liveness, and cache size usage without scraping logs. Unlike the query endpoints it is

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -284,6 +284,12 @@ kt_jvm_test(
     runtime_deps = [":cli-test-lib"],
 )
 
+kt_jvm_test(
+    name = "QueryProfilerTest",
+    test_class = "com.bazel_diff.server.QueryProfilerTest",
+    runtime_deps = [":cli-test-lib"],
+)
+
 kt_jvm_library(
     name = "cli-test-lib",
     testonly = True,

--- a/cli/src/main/kotlin/com/bazel_diff/server/BazelDiffServer.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/BazelDiffServer.kt
@@ -27,13 +27,17 @@ import org.koin.core.component.inject
  * - `GET /health` -- `200 OK` once [readiness] reports ready, `503` otherwise. A load balancer uses
  *   this to route only to instances that have completed their initial git fetch and have not been
  *   lame-ducked by a fatal git error.
- * - `GET /impacted_targets?from=<rev>&to=<rev>[&targetType=Rule,SourceFile]` -- returns `{"from":
- *   <sha>, "to": <sha>, "impactedTargets": [...]}`.
+ * - `GET /impacted_targets?from=<rev>&to=<rev>[&targetType=Rule,SourceFile][&profile=true]` --
+ *   returns `{"from": <sha>, "to": <sha>, "impactedTargets": [...]}`. With `profile=true` the
+ *   response additionally carries `profile` (per-phase wall-clock breakdown, including per-side
+ *   cache hit/miss -- see [QueryProfile]) and `memoryProfile` (JVM heap/GC movement -- see
+ *   [MemoryProfile]) so callers can feed per-request metrics into their monitoring.
  * - `POST /impacted_targets` with a JSON body `{"from", "to", "targetType"?: [...],
- *   "modifiedFilepaths"?: [...]}` -- same result as the GET form, but additionally accepts
- *   `modifiedFilepaths` (workspace-relative paths changed between the revisions) to scope content
- *   hashing (see [ImpactedTargetsService]/[HashService]). A changed-file list is too large for a
- *   URL, so it rides in the body; a GET is always the full-content hash.
+ *   "modifiedFilepaths"?: [...], "profile"?: bool}` -- same result as the GET form, but
+ *   additionally accepts `modifiedFilepaths` (workspace-relative paths changed between the
+ *   revisions) to scope content hashing (see [ImpactedTargetsService]/[HashService]). A
+ *   changed-file list is too large for a URL, so it rides in the body; a GET is always the
+ *   full-content hash.
  * - `GET /impacted_targets_with_distances?from=<rev>&to=<rev>[&targetType=...]` (and its `POST`
  *   form) -- like above but each impacted target is `{"label", "targetDistance",
  *   "packageDistance"}`. Requires the server to have been started with `--trackDeps`; returns `400`
@@ -129,14 +133,15 @@ class BazelDiffServer(
       }
 
   private fun handleImpactedTargets(exchange: HttpExchange) =
-      handleQuery(exchange) { from, to, targetTypes, modifiedFilepaths ->
-        impactedTargetsProvider.getImpactedTargets(from, to, targetTypes, modifiedFilepaths)
+      handleQuery(exchange) { from, to, targetTypes, modifiedFilepaths, profiler ->
+        impactedTargetsProvider.getImpactedTargets(
+            from, to, targetTypes, modifiedFilepaths, profiler)
       }
 
   private fun handleImpactedTargetsWithDistances(exchange: HttpExchange) =
-      handleQuery(exchange) { from, to, targetTypes, modifiedFilepaths ->
+      handleQuery(exchange) { from, to, targetTypes, modifiedFilepaths, profiler ->
         impactedTargetsProvider.getImpactedTargetsWithDistances(
-            from, to, targetTypes, modifiedFilepaths)
+            from, to, targetTypes, modifiedFilepaths, profiler)
       }
 
   /** Normalized inputs for a query, parsed from either a GET query string or a POST JSON body. */
@@ -145,6 +150,7 @@ class BazelDiffServer(
       val to: String,
       val targetTypes: Set<String>?,
       val modifiedFilepaths: Set<Path>,
+      val profile: Boolean,
   )
 
   /**
@@ -156,6 +162,7 @@ class BazelDiffServer(
       val to: String? = null,
       val targetType: List<String>? = null,
       val modifiedFilepaths: List<String>? = null,
+      val profile: Boolean? = null,
   )
 
   /** Local signal that request parsing failed; [handleQuery] maps it to a `400`. */
@@ -169,7 +176,12 @@ class BazelDiffServer(
   private fun handleQuery(
       exchange: HttpExchange,
       compute:
-          (from: String, to: String, targetTypes: Set<String>?, modifiedFilepaths: Set<Path>) -> Any
+          (
+              from: String,
+              to: String,
+              targetTypes: Set<String>?,
+              modifiedFilepaths: Set<Path>,
+              profiler: QueryProfiler?) -> Any
   ) =
       withExchange(exchange) {
         val isGet = exchange.requestMethod.equals("GET", ignoreCase = true)
@@ -191,12 +203,16 @@ class BazelDiffServer(
               return@withExchange
             }
 
+        // Created before dispatch so the profile's total also covers any wait for a compute slot /
+        // the workspace lock -- the parts of latency a caller most wants visible.
+        val profiler = if (inputs.profile) QueryProfiler() else null
         try {
           respondJson(
               exchange,
               200,
               computeWithTimeout {
-                compute(inputs.from, inputs.to, inputs.targetTypes, inputs.modifiedFilepaths)
+                compute(
+                    inputs.from, inputs.to, inputs.targetTypes, inputs.modifiedFilepaths, profiler)
               })
         } catch (e: TimeoutException) {
           logger.w { "request exceeded ${requestTimeoutSeconds}s timeout, abandoning" }
@@ -252,8 +268,8 @@ class BazelDiffServer(
   }
 
   /**
-   * Parses a GET request's `from`/`to`/`targetType` from the query string. A GET never carries
-   * modified filepaths (a changed-file list is too large for a URL), so it is always the
+   * Parses a GET request's `from`/`to`/`targetType`/`profile` from the query string. A GET never
+   * carries modified filepaths (a changed-file list is too large for a URL), so it is always the
    * full-content hash. Throws [BadRequestException] when `from`/`to` are missing.
    */
   private fun parseGetQuery(exchange: HttpExchange): QueryInputs {
@@ -265,7 +281,7 @@ class BazelDiffServer(
     }
     val targetTypes =
         params["targetType"]?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }?.toSet()
-    return QueryInputs(from, to, targetTypes, emptySet())
+    return QueryInputs(from, to, targetTypes, emptySet(), profile = params["profile"].toBoolean())
   }
 
   /**
@@ -300,7 +316,7 @@ class BazelDiffServer(
             ?.filter { it.isNotEmpty() }
             ?.map { File(it).toPath() }
             ?.toSet() ?: emptySet()
-    return QueryInputs(from, to, targetTypes, modifiedFilepaths)
+    return QueryInputs(from, to, targetTypes, modifiedFilepaths, profile = body.profile ?: false)
   }
 
   private fun parseQuery(rawQuery: String?): Map<String, String> {

--- a/cli/src/main/kotlin/com/bazel_diff/server/HashService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/HashService.kt
@@ -31,8 +31,15 @@ interface HashProvider {
    * request using a different set. Empty (the default) is the full-content hash and today's per-SHA
    * cache key. Correctness requires the caller to apply the *same* set to both revisions of a
    * comparison and for it to be a superset of what actually changed (see [ImpactedTargetsService]).
+   *
+   * [profiler], when non-null, receives a [HashRetrievalProfile] for this call (cache hit/miss and
+   * duration).
    */
-  fun getHashes(sha: String, modifiedFilepaths: Set<Path> = emptySet()): HashFileData
+  fun getHashes(
+      sha: String,
+      modifiedFilepaths: Set<Path> = emptySet(),
+      profiler: QueryProfiler? = null,
+  ): HashFileData
 
   /**
    * Runs [block] with the workspace checked out at [sha], holding the workspace lock for the
@@ -95,12 +102,28 @@ class HashService(
     return "$base.$digest"
   }
 
-  override fun getHashes(sha: String, modifiedFilepaths: Set<Path>): HashFileData {
+  override fun getHashes(
+      sha: String,
+      modifiedFilepaths: Set<Path>,
+      profiler: QueryProfiler?
+  ): HashFileData {
+    val startNanos = System.nanoTime()
+    val (data, cacheHit) = retrieve(sha, modifiedFilepaths)
+    profiler?.recordHashRetrieval(sha, cacheHit, (System.nanoTime() - startNanos) / 1_000_000)
+    return data
+  }
+
+  /**
+   * Returns the hash data plus whether it was served from the cache. "Hit" includes the
+   * waited-behind-another-generation case (the after-lock re-check): this request itself ran no
+   * checkout/query, though its duration then includes the lock wait.
+   */
+  private fun retrieve(sha: String, modifiedFilepaths: Set<Path>): Pair<HashFileData, Boolean> {
     val key = cacheKey(sha, modifiedFilepaths)
     storage.get(key)?.let { bytes ->
       logger.i { "Hash cache hit for $sha" }
       return deserialiser.executeTargetHashWithMetadataFromString(
-          String(bytes, StandardCharsets.UTF_8))
+          String(bytes, StandardCharsets.UTF_8)) to true
     }
     return generate(sha, modifiedFilepaths, key)
   }
@@ -111,13 +134,17 @@ class HashService(
         block()
       }
 
-  private fun generate(sha: String, modifiedFilepaths: Set<Path>, key: String): HashFileData =
+  private fun generate(
+      sha: String,
+      modifiedFilepaths: Set<Path>,
+      key: String
+  ): Pair<HashFileData, Boolean> =
       synchronized(generationLock) {
         // Re-check under the lock: another thread may have generated this revision while we waited.
         storage.get(key)?.let {
           logger.i { "Hash cache hit for $sha (after lock)" }
           return deserialiser.executeTargetHashWithMetadataFromString(
-              String(it, StandardCharsets.UTF_8))
+              String(it, StandardCharsets.UTF_8)) to true
         }
         logger.i { "Hash cache miss for $sha - generating hashes" }
         gitClient.checkout(sha)
@@ -128,7 +155,7 @@ class HashService(
         val depEdges = depEdgesOf(hashes)
         storage.put(
             key, serialize(hashes, moduleGraphJson, depEdges).toByteArray(StandardCharsets.UTF_8))
-        HashFileData(hashes, moduleGraphJson, depEdges)
+        HashFileData(hashes, moduleGraphJson, depEdges) to false
       }
 
   /**

--- a/cli/src/main/kotlin/com/bazel_diff/server/ImpactedTargetsService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/ImpactedTargetsService.kt
@@ -9,21 +9,30 @@ import java.nio.file.Path
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-/** Result of an impacted-targets request: the resolved SHAs and the impacted labels. */
+/**
+ * Result of an impacted-targets request: the resolved SHAs and the impacted labels. [profile] and
+ * [memoryProfile] are only populated when the request opted in with `profile=true` (Gson omits the
+ * null fields, keeping the default response shape unchanged).
+ */
 data class ImpactedTargetsResult(
     val from: String,
     val to: String,
     val impactedTargets: List<String>,
+    val profile: QueryProfile? = null,
+    val memoryProfile: MemoryProfile? = null,
 )
 
 /**
  * Result of an impacted-targets-with-distances request: the resolved SHAs and the impacted targets
- * each paired with their build-graph distance metrics.
+ * each paired with their build-graph distance metrics. [profile]/[memoryProfile] behave as in
+ * [ImpactedTargetsResult].
  */
 data class ImpactedTargetsWithDistancesResult(
     val from: String,
     val to: String,
     val impactedTargets: List<ImpactedTargetWithDistance>,
+    val profile: QueryProfile? = null,
+    val memoryProfile: MemoryProfile? = null,
 )
 
 /**
@@ -45,12 +54,16 @@ interface ImpactedTargetsProvider {
    *   revisions. When non-empty, source-file *content* hashing is scoped to just these paths on
    *   both revisions (a large-monorepo speedup); it must be a superset of what actually changed or
    *   impacted targets are missed. Empty (the default) is the full-content hash.
+   * @param profiler when non-null, per-phase timings and memory movement are recorded into it and
+   *   attached to the result as
+   *   [ImpactedTargetsResult.profile]/[ImpactedTargetsResult.memoryProfile].
    */
   fun getImpactedTargets(
       fromRev: String,
       toRev: String,
       targetTypes: Set<String>?,
       modifiedFilepaths: Set<Path> = emptySet(),
+      profiler: QueryProfiler? = null,
   ): ImpactedTargetsResult
 
   /**
@@ -63,6 +76,7 @@ interface ImpactedTargetsProvider {
       toRev: String,
       targetTypes: Set<String>?,
       modifiedFilepaths: Set<Path> = emptySet(),
+      profiler: QueryProfiler? = null,
   ): ImpactedTargetsWithDistancesResult
 }
 
@@ -89,17 +103,19 @@ class ImpactedTargetsService(
       toRev: String,
       targetTypes: Set<String>?,
       modifiedFilepaths: Set<Path>,
+      profiler: QueryProfiler?,
   ): ImpactedTargetsResult {
-    val (fromSha, toSha) = resolveBoth(fromRev, toRev)
+    val (fromSha, toSha) = resolveBothProfiled(fromRev, toRev, profiler)
     logger.i { "Computing impacted targets $fromSha -> $toSha" }
 
     // The same scope on both revisions is what makes a scoped diff correct: an unchanged file is
     // content-skipped on both sides and so hashes identically; a listed file is read on both.
-    val fromData = hashProvider.getHashes(fromSha, modifiedFilepaths)
-    val toData = hashProvider.getHashes(toSha, modifiedFilepaths)
+    val fromData = hashProvider.getHashes(fromSha, modifiedFilepaths, profiler)
+    val toData = hashProvider.getHashes(toSha, modifiedFilepaths, profiler)
 
     val writer = StringWriter()
     val interactor = CalculateImpactedTargetsInteractor()
+    val diffStartNanos = System.nanoTime()
     runOnGraph(fromData.moduleGraphJson, toData.moduleGraphJson, toSha) {
       interactor.execute(
           fromData.hashes,
@@ -110,9 +126,11 @@ class ImpactedTargetsService(
           toData.moduleGraphJson,
           excludeExternalTargets())
     }
+    profiler?.recordDiff(elapsedMillis(diffStartNanos))
 
     val impacted = writer.toString().split("\n").filter { it.isNotBlank() }
-    return ImpactedTargetsResult(fromSha, toSha, impacted)
+    return ImpactedTargetsResult(
+        fromSha, toSha, impacted, profiler?.queryProfile(), profiler?.memoryProfile())
   }
 
   override fun getImpactedTargetsWithDistances(
@@ -120,18 +138,20 @@ class ImpactedTargetsService(
       toRev: String,
       targetTypes: Set<String>?,
       modifiedFilepaths: Set<Path>,
+      profiler: QueryProfiler?,
   ): ImpactedTargetsWithDistancesResult {
     if (!depsTracked) {
       throw DistancesUnavailableException(
           "distances unavailable: server started without --trackDeps")
     }
-    val (fromSha, toSha) = resolveBoth(fromRev, toRev)
+    val (fromSha, toSha) = resolveBothProfiled(fromRev, toRev, profiler)
     logger.i { "Computing impacted targets with distances $fromSha -> $toSha" }
 
-    val fromData = hashProvider.getHashes(fromSha, modifiedFilepaths)
-    val toData = hashProvider.getHashes(toSha, modifiedFilepaths)
+    val fromData = hashProvider.getHashes(fromSha, modifiedFilepaths, profiler)
+    val toData = hashProvider.getHashes(toSha, modifiedFilepaths, profiler)
 
     val interactor = CalculateImpactedTargetsInteractor()
+    val diffStartNanos = System.nanoTime()
     val impacted =
         runOnGraph(fromData.moduleGraphJson, toData.moduleGraphJson, toSha) {
           // Use the `to` revision's dependency edges: distances are measured by traversing the
@@ -145,8 +165,26 @@ class ImpactedTargetsService(
               toData.moduleGraphJson,
               excludeExternalTargets())
         }
-    return ImpactedTargetsWithDistancesResult(fromSha, toSha, impacted)
+    profiler?.recordDiff(elapsedMillis(diffStartNanos))
+    return ImpactedTargetsWithDistancesResult(
+        fromSha, toSha, impacted, profiler?.queryProfile(), profiler?.memoryProfile())
   }
+
+  /** [resolveBoth], recording its duration (including any on-demand fetches) into [profiler]. */
+  private fun resolveBothProfiled(
+      fromRev: String,
+      toRev: String,
+      profiler: QueryProfiler?
+  ): Pair<String, String> {
+    val startNanos = System.nanoTime()
+    try {
+      return resolveBoth(fromRev, toRev)
+    } finally {
+      profiler?.recordResolveRevisions(elapsedMillis(startNanos))
+    }
+  }
+
+  private fun elapsedMillis(startNanos: Long): Long = (System.nanoTime() - startNanos) / 1_000_000
 
   /**
    * Resolves both revisions to commit SHAs, fetching on demand if either is missing from the local

--- a/cli/src/main/kotlin/com/bazel_diff/server/QueryProfiler.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/QueryProfiler.kt
@@ -1,0 +1,124 @@
+package com.bazel_diff.server
+
+import java.lang.management.ManagementFactory
+import java.util.Collections
+
+/**
+ * Timing of one hash retrieval (one side of a query). [cacheHit] is true when the hashes were
+ * served from the per-SHA cache -- including when this request waited behind another request that
+ * generated them -- and false when this request ran the checkout + `bazel query` itself, which is
+ * why a miss is typically orders of magnitude slower than a hit.
+ */
+data class HashRetrievalProfile(
+    val sha: String,
+    val cacheHit: Boolean,
+    val durationMillis: Long,
+)
+
+/**
+ * Wall-clock breakdown of one impacted-targets query, attached to the response when the request
+ * opts in with `profile=true` so callers can feed per-request latency and cache effectiveness into
+ * their metrics and monitoring.
+ *
+ * [totalDurationMillis] spans from request dispatch to response assembly and includes any wait for
+ * the workspace lock, so it can exceed the sum of the individual phases.
+ * [resolveRevisionsDurationMillis] covers git revision resolution including any on-demand fetches.
+ * [diffDurationMillis] covers the hash diff itself and, when the module graph changed between the
+ * revisions, the live `rdeps` query that path issues.
+ */
+data class QueryProfile(
+    val totalDurationMillis: Long,
+    val resolveRevisionsDurationMillis: Long,
+    val hashRetrievals: List<HashRetrievalProfile>,
+    val diffDurationMillis: Long,
+)
+
+/**
+ * JVM memory movement over one impacted-targets query, attached to the response when the request
+ * opts in with `profile=true`. Heap and GC numbers are process-wide, so concurrent requests and
+ * background work bleed into each other's deltas -- treat them as indicative, not exact.
+ */
+data class MemoryProfile(
+    val heapUsedBeforeBytes: Long,
+    val heapUsedAfterBytes: Long,
+    val heapUsedDeltaBytes: Long,
+    val heapMaxBytes: Long,
+    val gcCollections: Long,
+    val gcTimeMillis: Long,
+)
+
+/** Cumulative GC activity of the JVM at a point in time (summed across all collectors). */
+data class GcStats(val collections: Long, val timeMillis: Long)
+
+/** Reads the live cumulative GC stats; a collector that reports -1 (unavailable) counts as 0. */
+private fun liveGcStats(): GcStats {
+  var collections = 0L
+  var timeMillis = 0L
+  for (bean in ManagementFactory.getGarbageCollectorMXBeans()) {
+    collections += bean.collectionCount.coerceAtLeast(0)
+    timeMillis += bean.collectionTime.coerceAtLeast(0)
+  }
+  return GcStats(collections, timeMillis)
+}
+
+/**
+ * Per-request collector for [QueryProfile]/[MemoryProfile]. Constructed by the HTTP layer when a
+ * request asks for profiling (`profile=true`) and threaded through the services, which record each
+ * phase as it completes; the memory/time baselines are captured at construction. All suppliers are
+ * injectable so tests can drive deterministic values.
+ *
+ * Phase durations are recorded (not measured here) so the services stay in control of what a phase
+ * spans; only [totalDurationMillis][QueryProfile.totalDurationMillis] uses [nanoClock] directly.
+ * Recording is thread-safe, but a profiler instance belongs to a single request.
+ */
+class QueryProfiler(
+    private val nanoClock: () -> Long = System::nanoTime,
+    private val heapUsed: () -> Long = {
+      Runtime.getRuntime().let { it.totalMemory() - it.freeMemory() }
+    },
+    private val heapMax: () -> Long = { Runtime.getRuntime().maxMemory() },
+    private val gcStats: () -> GcStats = ::liveGcStats,
+) {
+  private val startNanos = nanoClock()
+  private val heapUsedBefore = heapUsed()
+  private val gcBefore = gcStats()
+
+  @Volatile private var resolveRevisionsMillis = 0L
+  @Volatile private var diffMillis = 0L
+  private val hashRetrievals = Collections.synchronizedList(mutableListOf<HashRetrievalProfile>())
+
+  fun recordResolveRevisions(durationMillis: Long) {
+    resolveRevisionsMillis += durationMillis
+  }
+
+  fun recordHashRetrieval(sha: String, cacheHit: Boolean, durationMillis: Long) {
+    hashRetrievals.add(HashRetrievalProfile(sha, cacheHit, durationMillis))
+  }
+
+  fun recordDiff(durationMillis: Long) {
+    diffMillis += durationMillis
+  }
+
+  /** Snapshot of the recorded phases; total spans construction to this call. */
+  fun queryProfile(): QueryProfile =
+      QueryProfile(
+          totalDurationMillis = (nanoClock() - startNanos) / 1_000_000,
+          resolveRevisionsDurationMillis = resolveRevisionsMillis,
+          hashRetrievals = synchronized(hashRetrievals) { hashRetrievals.toList() },
+          diffDurationMillis = diffMillis,
+      )
+
+  /** Heap/GC movement between construction and this call. */
+  fun memoryProfile(): MemoryProfile {
+    val heapUsedAfter = heapUsed()
+    val gcAfter = gcStats()
+    return MemoryProfile(
+        heapUsedBeforeBytes = heapUsedBefore,
+        heapUsedAfterBytes = heapUsedAfter,
+        heapUsedDeltaBytes = heapUsedAfter - heapUsedBefore,
+        heapMaxBytes = heapMax(),
+        gcCollections = (gcAfter.collections - gcBefore.collections).coerceAtLeast(0),
+        gcTimeMillis = (gcAfter.timeMillis - gcBefore.timeMillis).coerceAtLeast(0),
+    )
+  }
+}

--- a/cli/src/test/kotlin/com/bazel_diff/cli/ServeCommandTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/cli/ServeCommandTest.kt
@@ -79,7 +79,8 @@ class ServeCommandTest : KoinTest {
 
     override fun getHashes(
         sha: String,
-        modifiedFilepaths: Set<java.nio.file.Path>
+        modifiedFilepaths: Set<java.nio.file.Path>,
+        profiler: com.bazel_diff.server.QueryProfiler?
     ): com.bazel_diff.interactor.HashFileData {
       warmed += sha
       if (sha in failFor) throw RuntimeException("boom for $sha")
@@ -94,14 +95,16 @@ class ServeCommandTest : KoinTest {
         fromRev: String,
         toRev: String,
         targetTypes: Set<String>?,
-        modifiedFilepaths: Set<java.nio.file.Path>
+        modifiedFilepaths: Set<java.nio.file.Path>,
+        profiler: com.bazel_diff.server.QueryProfiler?
     ) = com.bazel_diff.server.ImpactedTargetsResult(fromRev, toRev, emptyList())
 
     override fun getImpactedTargetsWithDistances(
         fromRev: String,
         toRev: String,
         targetTypes: Set<String>?,
-        modifiedFilepaths: Set<java.nio.file.Path>
+        modifiedFilepaths: Set<java.nio.file.Path>,
+        profiler: com.bazel_diff.server.QueryProfiler?
     ) = com.bazel_diff.server.ImpactedTargetsWithDistancesResult(fromRev, toRev, emptyList())
   }
 

--- a/cli/src/test/kotlin/com/bazel_diff/server/BazelDiffServerTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/BazelDiffServerTest.kt
@@ -3,7 +3,11 @@ package com.bazel_diff.server
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.containsExactly
+import assertk.assertions.doesNotContain
 import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import com.bazel_diff.SilentLogger
 import com.bazel_diff.interactor.ImpactedTargetWithDistance
@@ -71,16 +75,20 @@ class BazelDiffServerTest : KoinTest {
       var lastTo: String? = null,
       var lastTargetTypes: Set<String>? = null,
       var lastModifiedFilepaths: Set<Path> = emptySet(),
+      var lastProfiler: QueryProfiler? = null,
   ) : ImpactedTargetsProvider {
     override fun getImpactedTargets(
         fromRev: String,
         toRev: String,
         targetTypes: Set<String>?,
         modifiedFilepaths: Set<Path>,
+        profiler: QueryProfiler?,
     ): ImpactedTargetsResult {
-      record(fromRev, toRev, targetTypes, modifiedFilepaths)
+      record(fromRev, toRev, targetTypes, modifiedFilepaths, profiler)
       error?.let { throw it }
-      return result
+      // Mirror the real service: profiles are attached only when a profiler was supplied.
+      return result.copy(
+          profile = profiler?.queryProfile(), memoryProfile = profiler?.memoryProfile())
     }
 
     override fun getImpactedTargetsWithDistances(
@@ -88,22 +96,26 @@ class BazelDiffServerTest : KoinTest {
         toRev: String,
         targetTypes: Set<String>?,
         modifiedFilepaths: Set<Path>,
+        profiler: QueryProfiler?,
     ): ImpactedTargetsWithDistancesResult {
-      record(fromRev, toRev, targetTypes, modifiedFilepaths)
+      record(fromRev, toRev, targetTypes, modifiedFilepaths, profiler)
       distancesError?.let { throw it }
-      return distancesResult
+      return distancesResult.copy(
+          profile = profiler?.queryProfile(), memoryProfile = profiler?.memoryProfile())
     }
 
     private fun record(
         fromRev: String,
         toRev: String,
         targetTypes: Set<String>?,
-        modifiedFilepaths: Set<Path>
+        modifiedFilepaths: Set<Path>,
+        profiler: QueryProfiler?
     ) {
       lastFrom = fromRev
       lastTo = toRev
       lastTargetTypes = targetTypes
       lastModifiedFilepaths = modifiedFilepaths
+      lastProfiler = profiler
     }
   }
 
@@ -126,15 +138,19 @@ class BazelDiffServerTest : KoinTest {
             fromRev: String,
             toRev: String,
             targetTypes: Set<String>?,
-            modifiedFilepaths: Set<Path>
-        ) = provider.getImpactedTargets(fromRev, toRev, targetTypes, modifiedFilepaths)
+            modifiedFilepaths: Set<Path>,
+            profiler: QueryProfiler?
+        ) = provider.getImpactedTargets(fromRev, toRev, targetTypes, modifiedFilepaths, profiler)
 
         override fun getImpactedTargetsWithDistances(
             fromRev: String,
             toRev: String,
             targetTypes: Set<String>?,
-            modifiedFilepaths: Set<Path>
-        ) = provider.getImpactedTargetsWithDistances(fromRev, toRev, targetTypes, modifiedFilepaths)
+            modifiedFilepaths: Set<Path>,
+            profiler: QueryProfiler?
+        ) =
+            provider.getImpactedTargetsWithDistances(
+                fromRev, toRev, targetTypes, modifiedFilepaths, profiler)
       }
 
   private data class Response(val code: Int, val body: String)
@@ -284,6 +300,78 @@ class BazelDiffServerTest : KoinTest {
   }
 
   @Test
+  fun getWithProfileTrueReturnsProfileAndMemoryProfile() {
+    val fixed = FixedProvider()
+    provider = fixed
+    val response = get("/impacted_targets?from=a&to=b&profile=true")
+
+    assertThat(response.code).isEqualTo(200)
+    val parsed = gson.fromJson(response.body, ImpactedTargetsResult::class.java)
+    assertThat(parsed.impactedTargets).containsExactly("//:a", "//:b")
+    // The provider received a live profiler and the profiles rode back on the response.
+    assertThat(fixed.lastProfiler).isNotNull()
+    assertThat(parsed.profile).isNotNull()
+    assertThat(parsed.memoryProfile).isNotNull()
+    assertThat(parsed.profile!!.totalDurationMillis).isGreaterThanOrEqualTo(0)
+    assertThat(parsed.memoryProfile!!.heapMaxBytes).isGreaterThan(0)
+  }
+
+  @Test
+  fun responseOmitsProfileFieldsWhenNotRequested() {
+    provider = FixedProvider()
+    val response = get("/impacted_targets?from=a&to=b")
+
+    assertThat(response.code).isEqualTo(200)
+    // Gson drops null fields, so the default response shape is unchanged for existing clients.
+    assertThat(response.body).doesNotContain("\"profile\"")
+    assertThat(response.body).doesNotContain("\"memoryProfile\"")
+  }
+
+  @Test
+  fun getWithProfileFalseOmitsProfile() {
+    val fixed = FixedProvider()
+    provider = fixed
+    val response = get("/impacted_targets?from=a&to=b&profile=false")
+
+    assertThat(response.code).isEqualTo(200)
+    assertThat(fixed.lastProfiler).isNull()
+    assertThat(response.body).doesNotContain("\"memoryProfile\"")
+  }
+
+  @Test
+  fun postWithProfileTrueReturnsProfileAndMemoryProfile() {
+    provider = FixedProvider()
+    val response = post("/impacted_targets", """{"from":"a","to":"b","profile":true}""")
+
+    assertThat(response.code).isEqualTo(200)
+    val parsed = gson.fromJson(response.body, ImpactedTargetsResult::class.java)
+    assertThat(parsed.profile).isNotNull()
+    assertThat(parsed.memoryProfile).isNotNull()
+  }
+
+  @Test
+  fun postWithoutProfileFieldOmitsProfile() {
+    val fixed = FixedProvider()
+    provider = fixed
+    val response = post("/impacted_targets", """{"from":"a","to":"b"}""")
+
+    assertThat(response.code).isEqualTo(200)
+    assertThat(fixed.lastProfiler).isNull()
+    assertThat(response.body).doesNotContain("\"memoryProfile\"")
+  }
+
+  @Test
+  fun distancesEndpointSupportsProfileToo() {
+    provider = FixedProvider()
+    val response = get("/impacted_targets_with_distances?from=a&to=b&profile=true")
+
+    assertThat(response.code).isEqualTo(200)
+    val parsed = gson.fromJson(response.body, ImpactedTargetsWithDistancesResult::class.java)
+    assertThat(parsed.profile).isNotNull()
+    assertThat(parsed.memoryProfile).isNotNull()
+  }
+
+  @Test
   fun postReturns503WhenNotReady() {
     ready.set(false)
     assertThat(post("/impacted_targets", """{"from":"a","to":"b"}""").code).isEqualTo(503)
@@ -345,7 +433,8 @@ class BazelDiffServerTest : KoinTest {
               fromRev: String,
               toRev: String,
               targetTypes: Set<String>?,
-              modifiedFilepaths: Set<Path>
+              modifiedFilepaths: Set<Path>,
+              profiler: QueryProfiler?
           ): ImpactedTargetsResult {
             Thread.sleep(10_000)
             return ImpactedTargetsResult(fromRev, toRev, emptyList())
@@ -355,7 +444,8 @@ class BazelDiffServerTest : KoinTest {
               fromRev: String,
               toRev: String,
               targetTypes: Set<String>?,
-              modifiedFilepaths: Set<Path>
+              modifiedFilepaths: Set<Path>,
+              profiler: QueryProfiler?
           ) = throw UnsupportedOperationException()
         }
     val slowServer = BazelDiffServer(0, slowProvider, requestTimeoutSeconds = 1) { true }

--- a/cli/src/test/kotlin/com/bazel_diff/server/HashServiceTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/HashServiceTest.kt
@@ -148,6 +148,27 @@ class HashServiceTest : KoinTest {
   }
 
   @Test
+  fun profilerRecordsCacheMissThenHit() {
+    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any()))
+        .thenReturn(sampleHashes)
+    runBlocking { whenever(bazelModService.getModuleGraphJson()).thenReturn(null) }
+    val service = newService(RecordingGitClient(), InMemoryStorage())
+
+    val missProfiler = QueryProfiler()
+    service.getHashes("sha1", profiler = missProfiler)
+    val hitProfiler = QueryProfiler()
+    service.getHashes("sha1", profiler = hitProfiler)
+
+    val miss = missProfiler.queryProfile().hashRetrievals.single()
+    assertThat(miss.sha).isEqualTo("sha1")
+    assertThat(miss.cacheHit).isEqualTo(false)
+    assertThat(miss.durationMillis >= 0).isEqualTo(true)
+    val hit = hitProfiler.queryProfile().hashRetrievals.single()
+    assertThat(hit.sha).isEqualTo("sha1")
+    assertThat(hit.cacheHit).isEqualTo(true)
+  }
+
+  @Test
   fun withWorkspaceAtChecksOutThenRunsBlock() {
     val git = RecordingGitClient()
     val service = newService(git, InMemoryStorage())

--- a/cli/src/test/kotlin/com/bazel_diff/server/ImpactedTargetsServiceTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/ImpactedTargetsServiceTest.kt
@@ -4,6 +4,9 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.containsExactlyInAnyOrder
 import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isNull
 import com.bazel_diff.SilentLogger
 import com.bazel_diff.bazel.BazelModService
 import com.bazel_diff.hash.TargetHash
@@ -149,8 +152,14 @@ class ImpactedTargetsServiceTest : KoinTest {
     val workspaceAtCalls = mutableListOf<String>()
     val modifiedFilepathsByRev = mutableMapOf<String, Set<Path>>()
 
-    override fun getHashes(sha: String, modifiedFilepaths: Set<Path>): HashFileData {
+    override fun getHashes(
+        sha: String,
+        modifiedFilepaths: Set<Path>,
+        profiler: QueryProfiler?
+    ): HashFileData {
       modifiedFilepathsByRev[sha] = modifiedFilepaths
+      // Mirror HashService: each retrieval reports itself to the profiler (canned data = a "hit").
+      profiler?.recordHashRetrieval(sha, cacheHit = true, durationMillis = 1)
       return byRev[sha] ?: error("no canned hashes for $sha")
     }
 
@@ -325,6 +334,66 @@ class ImpactedTargetsServiceTest : KoinTest {
 
     assertThat(result.impactedTargets).containsExactly(ImpactedTargetWithDistance("//:a", 0, 0))
     assertThat(provider.workspaceAtCalls).isEqualTo(listOf("to-sha"))
+  }
+
+  @Test
+  fun profilerAttachesQueryAndMemoryProfiles() {
+    val from = HashFileData(mapOf("//:a" to TargetHash("Rule", "h1", "d1")), null)
+    val to = HashFileData(mapOf("//:a" to TargetHash("Rule", "h2", "d2")), null)
+    val service =
+        ImpactedTargetsService(
+            IdentityGitClient(), FakeHashProvider(mapOf("from-sha" to from, "to-sha" to to)))
+
+    val result = service.getImpactedTargets("from-sha", "to-sha", null, profiler = QueryProfiler())
+
+    val profile = result.profile!!
+    // Both sides' hash retrievals were recorded, in order, with their cache-hit flags.
+    assertThat(profile.hashRetrievals.map { it.sha }).isEqualTo(listOf("from-sha", "to-sha"))
+    assertThat(profile.hashRetrievals.map { it.cacheHit }).isEqualTo(listOf(true, true))
+    assertThat(profile.totalDurationMillis).isGreaterThanOrEqualTo(0)
+    assertThat(profile.resolveRevisionsDurationMillis).isGreaterThanOrEqualTo(0)
+    assertThat(profile.diffDurationMillis).isGreaterThanOrEqualTo(0)
+    val memory = result.memoryProfile!!
+    assertThat(memory.heapMaxBytes).isGreaterThan(0)
+    assertThat(memory.heapUsedAfterBytes - memory.heapUsedBeforeBytes)
+        .isEqualTo(memory.heapUsedDeltaBytes)
+  }
+
+  @Test
+  fun noProfilerMeansNoProfileOnTheResult() {
+    val from = HashFileData(mapOf("//:a" to TargetHash("Rule", "h1", "d1")), null)
+    val to = HashFileData(mapOf("//:a" to TargetHash("Rule", "h2", "d2")), null)
+    val service =
+        ImpactedTargetsService(
+            IdentityGitClient(), FakeHashProvider(mapOf("from-sha" to from, "to-sha" to to)))
+
+    val result = service.getImpactedTargets("from-sha", "to-sha", null)
+
+    assertThat(result.profile).isNull()
+    assertThat(result.memoryProfile).isNull()
+  }
+
+  @Test
+  fun distancesResultCarriesProfilesToo() {
+    val from = HashFileData(mapOf("//:a" to TargetHash("Rule", "h1", "d1")), null)
+    val to =
+        HashFileData(
+            mapOf("//:a" to TargetHash("Rule", "h2", "d2")),
+            null,
+            depEdges = mapOf("//:a" to emptyList()))
+    val service =
+        ImpactedTargetsService(
+            IdentityGitClient(),
+            FakeHashProvider(mapOf("from-sha" to from, "to-sha" to to)),
+            depsTracked = true)
+
+    val result =
+        service.getImpactedTargetsWithDistances(
+            "from-sha", "to-sha", null, profiler = QueryProfiler())
+
+    assertThat(result.profile!!.hashRetrievals.map { it.sha })
+        .isEqualTo(listOf("from-sha", "to-sha"))
+    assertThat(result.memoryProfile!!.heapMaxBytes).isGreaterThan(0)
   }
 
   @Test

--- a/cli/src/test/kotlin/com/bazel_diff/server/QueryProfilerTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/QueryProfilerTest.kt
@@ -1,0 +1,89 @@
+package com.bazel_diff.server
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isGreaterThanOrEqualTo
+import org.junit.Test
+
+class QueryProfilerTest {
+
+  @Test
+  fun computesPhaseTimingsAndTotalFromInjectedClock() {
+    var nowNanos = 0L
+    val profiler =
+        QueryProfiler(
+            nanoClock = { nowNanos },
+            heapUsed = { 0 },
+            heapMax = { 1 },
+            gcStats = { GcStats(0, 0) })
+
+    profiler.recordResolveRevisions(3)
+    profiler.recordHashRetrieval("from-sha", cacheHit = true, durationMillis = 10)
+    profiler.recordHashRetrieval("to-sha", cacheHit = false, durationMillis = 250)
+    profiler.recordDiff(7)
+    nowNanos = 321_000_000 // 321ms since construction
+
+    val profile = profiler.queryProfile()
+
+    assertThat(profile.totalDurationMillis).isEqualTo(321)
+    assertThat(profile.resolveRevisionsDurationMillis).isEqualTo(3)
+    assertThat(profile.diffDurationMillis).isEqualTo(7)
+    assertThat(profile.hashRetrievals)
+        .isEqualTo(
+            listOf(
+                HashRetrievalProfile("from-sha", true, 10),
+                HashRetrievalProfile("to-sha", false, 250)))
+  }
+
+  @Test
+  fun computesMemoryDeltasBetweenConstructionAndSnapshot() {
+    var heap = 100L
+    var gc = GcStats(collections = 5, timeMillis = 50)
+    val profiler =
+        QueryProfiler(nanoClock = { 0 }, heapUsed = { heap }, heapMax = { 4096 }, gcStats = { gc })
+
+    heap = 350
+    gc = GcStats(collections = 7, timeMillis = 90)
+    val memory = profiler.memoryProfile()
+
+    assertThat(memory.heapUsedBeforeBytes).isEqualTo(100)
+    assertThat(memory.heapUsedAfterBytes).isEqualTo(350)
+    assertThat(memory.heapUsedDeltaBytes).isEqualTo(250)
+    assertThat(memory.heapMaxBytes).isEqualTo(4096)
+    assertThat(memory.gcCollections).isEqualTo(2)
+    assertThat(memory.gcTimeMillis).isEqualTo(40)
+  }
+
+  @Test
+  fun heapDeltaCanBeNegativeButGcDeltasNever() {
+    // Heap shrinking across the query (a GC ran) is meaningful and must be reported as-is; a GC
+    // counter moving backwards is only ever collector-bean noise and is clamped instead.
+    var heap = 500L
+    var gc = GcStats(collections = 5, timeMillis = 50)
+    val profiler =
+        QueryProfiler(nanoClock = { 0 }, heapUsed = { heap }, heapMax = { 4096 }, gcStats = { gc })
+
+    heap = 200
+    gc = GcStats(collections = 4, timeMillis = 40)
+    val memory = profiler.memoryProfile()
+
+    assertThat(memory.heapUsedDeltaBytes).isEqualTo(-300)
+    assertThat(memory.gcCollections).isEqualTo(0)
+    assertThat(memory.gcTimeMillis).isEqualTo(0)
+  }
+
+  @Test
+  fun liveDefaultsProduceSaneValues() {
+    val profiler = QueryProfiler()
+
+    val profile = profiler.queryProfile()
+    val memory = profiler.memoryProfile()
+
+    assertThat(profile.totalDurationMillis).isGreaterThanOrEqualTo(0)
+    assertThat(memory.heapMaxBytes).isGreaterThan(0)
+    assertThat(memory.heapUsedBeforeBytes).isGreaterThan(0)
+    assertThat(memory.gcCollections).isGreaterThanOrEqualTo(0)
+    assertThat(memory.gcTimeMillis).isGreaterThanOrEqualTo(0)
+  }
+}

--- a/tools/serve_harness.py
+++ b/tools/serve_harness.py
@@ -633,6 +633,32 @@ def _full_extras(rep: Report, case: str, s: Serve, remote: Remote, track_deps: b
     rep.check(case, "malformed POST body -> 400", code == 400,
               fail_detail=f"code={code} body={body[:120]}")
 
+    # profile=true attaches the timing + memory breakdown; both C1/C2 sides are cached by the
+    # earlier checks, so the hash retrievals must report cache hits.
+    code, body = http(s.port, f"/impacted_targets?from={sh['C1']}&to={sh['C2']}&profile=true")
+    try:
+        pd = json.loads(body)
+    except ValueError:
+        pd = {}
+    prof, mem = pd.get("profile", {}), pd.get("memoryProfile", {})
+    retrievals = prof.get("hashRetrievals", [])
+    rep.check(case, "profile=true returns profile + memoryProfile",
+              code == 200
+              and prof.get("totalDurationMillis", -1) >= 0
+              and len(retrievals) == 2
+              and all(r.get("cacheHit") for r in retrievals)
+              and mem.get("heapMaxBytes", 0) > 0
+              and mem.get("gcCollections", -1) >= 0,
+              ok_detail=f"total={prof.get('totalDurationMillis')}ms "
+                        f"hits={[r.get('cacheHit') for r in retrievals]}",
+              fail_detail=f"code={code} body={body[:300]}")
+
+    # Without the flag the response shape is unchanged (no profile keys leak in).
+    code, body, _ = _impacted(s, sh["C1"], sh["C2"])
+    rep.check(case, "no profile keys without profile=true",
+              code == 200 and "memoryProfile" not in body,
+              fail_detail=f"code={code} body={body[:200]}")
+
     # Distances endpoint: with --trackDeps, core is directly changed (d0), mid depends on core
     # (d>=1); without it, the endpoint 400s.
     code, body = http(s.port, f"/impacted_targets_with_distances?from={sh['C1']}&to={sh['C2']}")

--- a/tools/serve_stress.py
+++ b/tools/serve_stress.py
@@ -35,6 +35,15 @@ Every request is timed. The run emits per-phase throughput (req/s) and latency p
 (p50/p90/p95/p99/max), plus /metrics snapshots at phase boundaries, as JSON (--metrics-out)
 and a GitHub-flavored markdown summary (--summary-out) for a CI step summary.
 
+Server-side query profiling (`profile=true`) is woven through the load phases: cold/lock
+requests and a sample of hot requests carry the flag, and the server-reported breakdown
+(revision resolution, per-side hash retrieval with cache hit/miss, diff, heap/GC movement)
+is aggregated per phase into the same JSON + summary alongside the client-observed numbers.
+It also gates two invariants the client cannot see on its own: hot responses must report
+cache hits on both sides, and a concurrent cold fan-out must report *exactly one* generation
+per new SHA (everyone else a cache hit) -- the server's own accounting of the workspace-lock
+collapse.
+
 There are two modes. The default (above) fabricates a hermetic genrule workspace so impacted-target
 values are known exactly. Real-repo mode (`--real-repo-url`) instead points serve at a clone of an
 actual repo and drives it over real commit SHAs -- exercising real large-tree checkouts (real
@@ -101,12 +110,29 @@ class Sample:
     detail: str = ""
 
 
+@dataclass
+class ProfileSample:
+    """The server-reported breakdown of one profiled (`profile=true`) request, paired with the
+    client-observed latency so the harness can also report the transport/dispatch overhead."""
+
+    phase: str
+    client_ms: float
+    total_ms: float
+    resolve_ms: float
+    diff_ms: float
+    retrievals: list  # [{sha, cacheHit, durationMillis}] -- one per side of the diff
+    heap_delta_bytes: int
+    gc_collections: int
+    gc_time_ms: int
+
+
 class Metrics:
     """Thread-safe request-sample sink plus phase wall-clock windows."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self.samples: list[Sample] = []
+        self.profiles: list[ProfileSample] = []
         self.phase_wall: dict[str, float] = {}
         self.server_snapshots: list[dict] = []
         self.time_to_ready_seconds: float | None = None
@@ -115,6 +141,29 @@ class Metrics:
                detail: str = "") -> None:
         with self._lock:
             self.samples.append(Sample(phase, op, status, latency_ms, ok, detail))
+
+    def record_profile(self, phase: str, client_ms: float, profile: dict | None,
+                       memory: dict | None) -> None:
+        """Stores one server-reported profile. A None [profile] (unprofiled or non-200 response)
+        is silently skipped so callers can pass whatever extract_profiles() returned."""
+        if not profile:
+            return
+        mem = memory or {}
+        sample = ProfileSample(
+            phase=phase,
+            client_ms=client_ms,
+            total_ms=float(profile.get("totalDurationMillis", 0)),
+            resolve_ms=float(profile.get("resolveRevisionsDurationMillis", 0)),
+            diff_ms=float(profile.get("diffDurationMillis", 0)),
+            retrievals=[{"sha": r.get("sha", ""), "cacheHit": bool(r.get("cacheHit")),
+                         "durationMillis": float(r.get("durationMillis", 0))}
+                        for r in profile.get("hashRetrievals") or []],
+            heap_delta_bytes=int(mem.get("heapUsedDeltaBytes", 0)),
+            gc_collections=int(mem.get("gcCollections", 0)),
+            gc_time_ms=int(mem.get("gcTimeMillis", 0)),
+        )
+        with self._lock:
+            self.profiles.append(sample)
 
     @contextlib.contextmanager
     def phase(self, name: str):
@@ -169,6 +218,41 @@ class Metrics:
             "latency_ms": _latency_summary(lat),
         }
 
+    def profile_stats(self, phase: str) -> dict:
+        """Aggregates the server-reported profiles captured in [phase]; {} when none were."""
+        with self._lock:
+            samples = [p for p in self.profiles if p.phase == phase]
+        if not samples:
+            return {}
+        hit_ms = sorted(r["durationMillis"] for p in samples for r in p.retrievals
+                        if r["cacheHit"])
+        miss_ms = sorted(r["durationMillis"] for p in samples for r in p.retrievals
+                         if not r["cacheHit"])
+        heap_deltas = [p.heap_delta_bytes for p in samples]
+        return {
+            "name": phase,
+            "profiled_requests": len(samples),
+            "cache_hits": len(hit_ms),
+            "cache_misses": len(miss_ms),
+            "server_total_ms": _latency_summary(sorted(p.total_ms for p in samples)),
+            "resolve_ms": _latency_summary(sorted(p.resolve_ms for p in samples)),
+            "diff_ms": _latency_summary(sorted(p.diff_ms for p in samples)),
+            "hit_retrieval_ms": _latency_summary(hit_ms),
+            "miss_retrieval_ms": _latency_summary(miss_ms),
+            # Client wall-clock minus server-reported total: transport + dispatch + JSON cost.
+            "client_overhead_ms": _latency_summary(
+                sorted(max(p.client_ms - p.total_ms, 0.0) for p in samples)),
+            "heap_delta_bytes": {
+                "min": min(heap_deltas),
+                "mean": round(statistics.fmean(heap_deltas)),
+                "max": max(heap_deltas),
+            },
+            "gc": {
+                "collections": sum(p.gc_collections for p in samples),
+                "time_ms": sum(p.gc_time_ms for p in samples),
+            },
+        }
+
 
 def _latency_summary(sorted_ms: list[float]) -> dict:
     if not sorted_ms:
@@ -206,15 +290,20 @@ def timed_http(port: int, path: str, method: str = "GET", body: str | None = Non
     return code, text, (time.perf_counter() - t0) * 1000.0
 
 
-def impacted_get(s: base.Serve, frm: str, to: str, timeout: float = 600.0):
-    code, text, ms = timed_http(s.port, f"/impacted_targets?from={frm}&to={to}", timeout=timeout)
+def impacted_get(s: base.Serve, frm: str, to: str, timeout: float = 600.0,
+                 profile: bool = False):
+    q = f"/impacted_targets?from={frm}&to={to}" + ("&profile=true" if profile else "")
+    code, text, ms = timed_http(s.port, q, timeout=timeout)
     return code, text, ms
 
 
-def impacted_post(s: base.Serve, frm: str, to: str, timeout: float = 600.0):
-    body = json.dumps({"from": frm, "to": to})
-    code, text, ms = timed_http(s.port, "/impacted_targets", method="POST", body=body,
-                                timeout=timeout)
+def impacted_post(s: base.Serve, frm: str, to: str, timeout: float = 600.0,
+                  profile: bool = False):
+    payload: dict = {"from": frm, "to": to}
+    if profile:
+        payload["profile"] = True
+    code, text, ms = timed_http(s.port, "/impacted_targets", method="POST",
+                                body=json.dumps(payload), timeout=timeout)
     return code, text, ms
 
 
@@ -225,6 +314,23 @@ def stable_set(text: str) -> frozenset:
     except (ValueError, TypeError):
         return frozenset()
     return frozenset(base._stable(data))
+
+
+def extract_profiles(text: str) -> tuple:
+    """(profile, memoryProfile) from a profiled response body; (None, None) when absent (an
+    unprofiled request, an error body, or non-JSON)."""
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        return None, None
+    if not isinstance(data, dict):
+        return None, None
+    return data.get("profile"), data.get("memoryProfile")
+
+
+# Sample every Nth hot request with profile=true: enough coverage to gate on and aggregate,
+# while the unprofiled majority keeps the throughput numbers comparable with earlier runs.
+PROFILE_EVERY = 4
 
 
 # ----------------------------------------------------------------------------------------------
@@ -422,9 +528,10 @@ def phase_warm(ctx: Ctx) -> None:
     sh = ctx.remote.shas
     with ctx.metrics.phase(case):
         for frm, to, expect in ((sh["C0"], sh["C1"], CORE_EDIT), (sh["C1"], sh["C2"], CORE_EDIT)):
-            code, text, ms = impacted_get(ctx.serve, frm, to)
+            code, text, ms = impacted_get(ctx.serve, frm, to, profile=True)
             good = code == 200 and stable_set(text) == frozenset(expect)
             ctx.metrics.record(case, "impacted_cold", code, ms, good)
+            ctx.metrics.record_profile(case, ms, *extract_profiles(text))
             ctx.rep.check(case, f"cold generation {frm[:8]}->{to[:8]}", good,
                           ok_detail=f"{ms/1000:.1f}s",
                           fail_detail=f"code={code} got={sorted(stable_set(text))} "
@@ -433,21 +540,39 @@ def phase_warm(ctx: Ctx) -> None:
 
 
 def phase_hot(ctx: Ctx) -> None:
-    """Concurrent GET/POST bursts against the two already-cached pairs."""
+    """Concurrent GET/POST bursts against the two already-cached pairs. Every [PROFILE_EVERY]th
+    request carries profile=true: the server's own accounting must report a cache hit on both
+    sides of every one of them (a reported miss here means the cache is being bypassed)."""
     case = "hot"
     sh = ctx.remote.shas
     pairs = [(sh["C0"], sh["C1"]), (sh["C1"], sh["C2"])]
     results: list[tuple[int | None, frozenset]] = []
+    prof_problems: list[str] = []
+    profiled = 0
     lock = threading.Lock()
 
     def one(i: int) -> None:
+        nonlocal profiled
         frm, to = pairs[i % len(pairs)]
         fn = impacted_post if i % 3 == 0 else impacted_get  # mix in the POST body form
-        code, text, ms = fn(ctx.serve, frm, to)
+        with_profile = i % PROFILE_EVERY == 0
+        code, text, ms = fn(ctx.serve, frm, to, profile=with_profile)
         good = code == 200
         ctx.metrics.record(case, "impacted_hot", code, ms, good)
+        problem = ""
+        if with_profile and good:
+            prof, mem = extract_profiles(text)
+            ctx.metrics.record_profile(case, ms, prof, mem)
+            if not prof or not mem:
+                problem = f"req{i}: profile/memoryProfile missing from 200 response"
+            elif any(not r.get("cacheHit") for r in prof.get("hashRetrievals", [])):
+                problem = f"req{i}: server reported a cache miss on a cached pair"
         with lock:
             results.append((code, stable_set(text)))
+            if with_profile and good:
+                profiled += 1
+            if problem:
+                prof_problems.append(problem)
 
     with ctx.metrics.phase(case):
         with ThreadPoolExecutor(max_workers=ctx.profile.hot_workers) as pool:
@@ -460,12 +585,19 @@ def phase_hot(ctx: Ctx) -> None:
                   fail_detail=f"codes={codes}\n{ctx.serve.stderr_tail()}")
     ctx.rep.check(case, "hot responses consistent", len(sets) == 1 and next(iter(sets)) == frozenset(CORE_EDIT),
                   fail_detail=f"distinct_sets={[sorted(s) for s in sets]}")
+    ctx.rep.check(case, "profiled hot responses all report cache hits on both sides",
+                  profiled > 0 and not prof_problems,
+                  ok_detail=f"{profiled} profiled",
+                  fail_detail=f"profiled={profiled}; " + "; ".join(prof_problems[:5]))
     ctx.metrics.snapshot_server(case, ctx.serve.port)
 
 
 def phase_cold_concurrent(ctx: Ctx) -> None:
     """For each uncached pair, [cold_fanout] identical concurrent requests: the workspace lock
-    plus the per-key double-check must yield one generation and identical 200s for all."""
+    plus the per-key double-check must yield one generation and identical 200s for all. Every
+    request carries profile=true, and the server's own accounting must agree: across the fan-out,
+    exactly one response reports cacheHit=false for the new SHA (the request that generated it);
+    everyone else waited and got a hit."""
     case = "cold"
     sh = ctx.remote.shas
     with ctx.metrics.phase(case):
@@ -473,13 +605,17 @@ def phase_cold_concurrent(ctx: Ctx) -> None:
         for i in range(ctx.profile.cold_pairs):
             to = sh[f"S{i}"]
             outcomes: list[tuple[int | None, frozenset]] = []
+            profs: list = []
             lock = threading.Lock()
 
             def one(_: int, frm: str = prev, dst: str = to) -> None:
-                code, text, ms = impacted_get(ctx.serve, frm, dst)
+                code, text, ms = impacted_get(ctx.serve, frm, dst, profile=True)
                 ctx.metrics.record(case, "impacted_cold", code, ms, code == 200)
+                prof, mem = extract_profiles(text)
+                ctx.metrics.record_profile(case, ms, prof, mem)
                 with lock:
                     outcomes.append((code, stable_set(text)))
+                    profs.append(prof)
 
             with ThreadPoolExecutor(max_workers=ctx.profile.cold_fanout) as pool:
                 list(pool.map(one, range(ctx.profile.cold_fanout)))
@@ -489,6 +625,14 @@ def phase_cold_concurrent(ctx: Ctx) -> None:
                           codes == {200} and len(sets) == 1,
                           ok_detail=f"{sorted(next(iter(sets)))}",
                           fail_detail=f"codes={codes} sets={len(sets)}\n{ctx.serve.stderr_tail()}")
+            generations = sum(1 for p in profs if p
+                              for r in p.get("hashRetrievals", [])
+                              if r.get("sha") == to and not r.get("cacheHit"))
+            ctx.rep.check(case, f"S{i}: server profiles report exactly one generation",
+                          codes == {200} and all(profs) and generations == 1,
+                          ok_detail=f"1 miss + {ctx.profile.cold_fanout - 1} hits",
+                          fail_detail=f"generations={generations} "
+                                      f"missing_profiles={sum(1 for p in profs if not p)}")
             prev = to
     ctx.metrics.snapshot_server(case, ctx.serve.port)
 
@@ -563,9 +707,12 @@ def phase_lock_heal(ctx: Ctx) -> None:
         for i in range(ctx.profile.lock_heal_rounds):
             to = sh[f"L{i}"]
             lock_path = plant_index_lock(ctx.clone)
-            code, text, ms = impacted_get(ctx.serve, prev, to)
+            # profile=true here surfaces what the heal costs: the retry lands inside the new
+            # SHA's hashRetrieval duration, visible in the aggregated miss_retrieval_ms.
+            code, text, ms = impacted_get(ctx.serve, prev, to, profile=True)
             healed = code == 200 and not lock_path.exists()
             ctx.metrics.record(case, "impacted_cold_locked", code, ms, healed)
+            ctx.metrics.record_profile(case, ms, *extract_profiles(text))
             ctx.rep.check(case, f"L{i}: orphaned index.lock self-heals -> 200",
                           healed,
                           ok_detail=f"{ms/1000:.1f}s",
@@ -593,10 +740,12 @@ def phase_lock_storm(ctx: Ctx) -> None:
         with LockStorm(ctx.clone) as storm:
             for i in range(ctx.profile.storm_commits):
                 to = sh[f"T{i}"]
-                code, text, ms = impacted_get(ctx.serve, prev, to)
+                code, text, ms = impacted_get(ctx.serve, prev, to, profile=True)
                 acceptable = code in (200, 400)
                 ctx.metrics.record(case, "impacted_cold_storm", code, ms, acceptable,
                                    detail="" if acceptable else text[:120])
+                # Only a 200 carries a profile; a mid-storm 400's body is just the error.
+                ctx.metrics.record_profile(case, ms, *extract_profiles(text))
                 attempted.append((prev, to, code))
                 prev = to
         plants = storm.plants
@@ -742,6 +891,10 @@ def build_metrics_json(ctx: Ctx, wall_seconds: float, quick: bool, failures: int
         "meta": meta,
         "time_to_ready_seconds": ctx.metrics.time_to_ready_seconds,
         "phases": [ctx.metrics.phase_stats(p) for p in _ordered_phases(ctx.metrics)],
+        "server_profiles": [
+            ps for ps in (ctx.metrics.profile_stats(p) for p in _ordered_phases(ctx.metrics))
+            if ps
+        ],
         "health": ctx.metrics.health_stats(),
         "server_metrics": ctx.metrics.server_snapshots,
         "checks": [
@@ -788,6 +941,38 @@ def build_summary_md(data: dict) -> str:
         "",
         f"Health prober: {health['probes']} probes, {health['non_200']} non-200, "
         f"p99 {hlat.get('p99', '—')} ms.",
+    ]
+    server_profiles = data.get("server_profiles") or []
+    if server_profiles:
+        lines += [
+            "",
+            "## Server-side query profiles (`profile=true`)",
+            "",
+            "Server-reported breakdown of the profiled requests: hash-retrieval cache "
+            "hits/misses, total time as measured inside the service, retrieval latency by "
+            "hit/miss, client-vs-server overhead (transport + dispatch), and heap/GC movement.",
+            "",
+            "| phase | profiled | hits / misses | server total p50/p95 (ms) | hit p95 (ms) "
+            "| miss p95 (ms) | overhead p50 (ms) | heap Δ max | GC (n / ms) |",
+            "|---|---|---|---|---|---|---|---|---|",
+        ]
+        for ps in server_profiles:
+            total = ps.get("server_total_ms") or {}
+            hit = ps.get("hit_retrieval_ms") or {}
+            miss = ps.get("miss_retrieval_ms") or {}
+            over = ps.get("client_overhead_ms") or {}
+            heap = ps.get("heap_delta_bytes") or {}
+            gc = ps.get("gc") or {}
+            heap_max = heap.get("max")
+            heap_h = f"{heap_max / 1048576:.1f} MB" if heap_max is not None else "—"
+            lines.append(
+                f"| {ps['name']} | {ps['profiled_requests']} "
+                f"| {ps['cache_hits']} / {ps['cache_misses']} "
+                f"| {total.get('p50', '—')} / {total.get('p95', '—')} "
+                f"| {hit.get('p95', '—')} | {miss.get('p95', '—')} "
+                f"| {over.get('p50', '—')} | {heap_h} "
+                f"| {gc.get('collections', '—')} / {gc.get('time_ms', '—')} |")
+    lines += [
         "",
         "## Checks",
         "",
@@ -861,16 +1046,22 @@ def derive_ancestry_pairs(clone: Path, tip: str, count: int) -> list:
 def phase_real_cold(ctx: Ctx, frm: str, to: str) -> None:
     """The headline real generation: [cold_fanout] identical concurrent (frm->to) requests. The
     first triggers a real checkout + `bazel query` + hash of each revision; the workspace lock
-    collapses them to one generation and every caller gets the identical impacted set."""
+    collapses them to one generation and every caller gets the identical impacted set. All
+    requests carry profile=true: both revisions are uncached, so across the fan-out the server
+    must report exactly one generation (cacheHit=false) per revision."""
     case = "real_cold"
     outcomes: list = []
+    profs: list = []
     lock = threading.Lock()
 
     def one(_: int) -> None:
-        code, text, ms = impacted_get(ctx.serve, frm, to, timeout=REAL_REQ_TIMEOUT)
+        code, text, ms = impacted_get(ctx.serve, frm, to, timeout=REAL_REQ_TIMEOUT, profile=True)
         ctx.metrics.record(case, "impacted_cold", code, ms, code == 200)
+        prof, mem = extract_profiles(text)
+        ctx.metrics.record_profile(case, ms, prof, mem)
         with lock:
             outcomes.append((code, stable_set(text)))
+            profs.append(prof)
 
     with ctx.metrics.phase(case):
         with ThreadPoolExecutor(max_workers=ctx.profile.cold_fanout) as pool:
@@ -884,21 +1075,49 @@ def phase_real_cold(ctx: Ctx, frm: str, to: str) -> None:
                   fail_detail=f"codes={codes} distinct_sets={len(sets)}\n{ctx.serve.stderr_tail()}")
     if codes == {200} and size == 0:
         ctx.rep.add(case, "impacted set is empty (the diff touches no build-relevant files)", base.INFO)
+    generations = {
+        rev: sum(1 for p in profs if p
+                 for r in p.get("hashRetrievals", [])
+                 if r.get("sha") == rev and not r.get("cacheHit"))
+        for rev in (frm, to)
+    }
+    ctx.rep.check(case, "server profiles report exactly one generation per revision",
+                  codes == {200} and all(profs) and set(generations.values()) == {1},
+                  ok_detail=f"{{frm: {generations[frm]}, to: {generations[to]}}}",
+                  fail_detail=f"generations={generations} "
+                              f"missing_profiles={sum(1 for p in profs if not p)}")
     ctx.metrics.snapshot_server(case, ctx.serve.port)
 
 
 def phase_real_hot(ctx: Ctx, frm: str, to: str) -> None:
-    """Concurrent cache-hit throughput for the now-cached (frm->to) pair (GET + POST body form)."""
+    """Concurrent cache-hit throughput for the now-cached (frm->to) pair (GET + POST body form).
+    Every [PROFILE_EVERY]th request is profiled and must report cache hits on both sides."""
     case = "real_hot"
     codes: set = set()
+    prof_problems: list = []
+    profiled = 0
     lock = threading.Lock()
 
     def one(i: int) -> None:
+        nonlocal profiled
         fn = impacted_post if i % 3 == 0 else impacted_get
-        code, _, ms = fn(ctx.serve, frm, to, timeout=REAL_REQ_TIMEOUT)
+        with_profile = i % PROFILE_EVERY == 0
+        code, text, ms = fn(ctx.serve, frm, to, timeout=REAL_REQ_TIMEOUT, profile=with_profile)
         ctx.metrics.record(case, "impacted_hot", code, ms, code == 200)
+        problem = ""
+        if with_profile and code == 200:
+            prof, mem = extract_profiles(text)
+            ctx.metrics.record_profile(case, ms, prof, mem)
+            if not prof or not mem:
+                problem = f"req{i}: profile/memoryProfile missing from 200 response"
+            elif any(not r.get("cacheHit") for r in prof.get("hashRetrievals", [])):
+                problem = f"req{i}: server reported a cache miss on a cached pair"
         with lock:
             codes.add(code)
+            if with_profile and code == 200:
+                profiled += 1
+            if problem:
+                prof_problems.append(problem)
 
     with ctx.metrics.phase(case):
         with ThreadPoolExecutor(max_workers=ctx.profile.hot_workers) as pool:
@@ -906,6 +1125,10 @@ def phase_real_hot(ctx: Ctx, frm: str, to: str) -> None:
     ctx.rep.check(case, f"{ctx.profile.hot_requests} concurrent cache-hit requests all 200",
                   codes == {200}, ok_detail=f"codes={codes}",
                   fail_detail=f"codes={codes}\n{ctx.serve.stderr_tail()}")
+    ctx.rep.check(case, "profiled hot responses all report cache hits on both sides",
+                  profiled > 0 and not prof_problems,
+                  ok_detail=f"{profiled} profiled",
+                  fail_detail=f"profiled={profiled}; " + "; ".join(prof_problems[:5]))
     ctx.metrics.snapshot_server(case, ctx.serve.port)
 
 


### PR DESCRIPTION
## What

Adds opt-in per-request profiling to the `serve` query endpoints. Passing `profile=true` (GET parameter or POST body field) to `/impacted_targets` or `/impacted_targets_with_distances` attaches two extra objects to the response:

- **`profile`** — wall-clock breakdown of the query: `totalDurationMillis`, `resolveRevisionsDurationMillis` (includes any on-demand `git fetch`), `hashRetrievals` (`{sha, cacheHit, durationMillis}` for each side of the diff), and `diffDurationMillis` (includes the live `rdeps` query on the module-graph-changed path).
- **`memoryProfile`** — JVM heap used before/after/delta, heap max, and GC collections/time over the query (process-wide, documented as indicative).

```json
{
  "from": "9a1c0e2…",
  "to": "3f7b8d4…",
  "impactedTargets": ["//foo:bar", "//foo:baz"],
  "profile": {
    "totalDurationMillis": 1843,
    "resolveRevisionsDurationMillis": 12,
    "hashRetrievals": [
      {"sha": "9a1c0e2…", "cacheHit": true, "durationMillis": 95},
      {"sha": "3f7b8d4…", "cacheHit": false, "durationMillis": 1701}
    ],
    "diffDurationMillis": 21
  },
  "memoryProfile": {
    "heapUsedBeforeBytes": 231452416,
    "heapUsedAfterBytes": 512665600,
    "heapUsedDeltaBytes": 281213184,
    "heapMaxBytes": 4294967296,
    "gcCollections": 3,
    "gcTimeMillis": 41
  }
}
```

## Why

Lets external users of the query service surface per-request latency, cache effectiveness (hit vs. cold `bazel query`), and memory pressure in their own metrics/monitoring — complementing the instance-level `GET /metrics` snapshot with per-query data.

## How

- New `server/QueryProfiler.kt`: per-request collector (`QueryProfile`/`MemoryProfile`/`HashRetrievalProfile` data classes) with injectable clock and heap/GC suppliers for deterministic tests.
- `BazelDiffServer` parses the flag from both request forms and creates the profiler **before** dispatch, so the total also covers compute-slot and workspace-lock wait — the latency a caller most wants visible.
- An optional `profiler` parameter (default `null`) threads through `ImpactedTargetsProvider` and `HashProvider`; `HashService` reports each side's cache hit/miss. A request that waited behind a concurrent generation of the same SHA counts as a hit (it ran no checkout/query itself), though its duration then includes the lock wait.

## Notes for reviewers

- **Backwards compatible**: without the flag the new result fields stay `null` and Gson omits them, so the response shape is byte-for-byte unchanged; no new CLI flags, nothing enters the cache key.
- JSON field names use the API's existing camelCase convention (`memoryProfile`), not `memory_profile`.
- README "Query Service" section documents the parameter, example response, and field semantics.

## Testing

- New `QueryProfilerTest` (deterministic injected clocks) plus profile cases in `BazelDiffServerTest`, `ImpactedTargetsServiceTest`, and `HashServiceTest` (cache miss→hit flags).
- Full `bazel test //cli/...` passes; `bazel run //cli/format` applied.
- `tools/serve_harness.py` gained two checks (profile fields present with cache hits; no keys leak without the flag) — full harness run against a live server: 32 pass, 0 fail.

## Stress harness integration (second commit)

`tools/serve_stress.py` now exercises the feature under load: cold/lock-phase requests and every 4th hot request carry `profile=true`, the server-reported breakdowns are aggregated per phase into the metrics JSON (`server_profiles`) and a new summary table, and two invariants the client can't see on its own are gated: profiled hot responses must report cache hits on both sides, and a concurrent cold fan-out must report **exactly one** generation per new SHA (the workspace-lock collapse, verified from the server's own accounting instead of log lines). Full quick-profile run: 25 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
