### PR TITLE
fix: hash external repos when WORKSPACE and Bzlmod are both enabled

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelClient.kt
@@ -39,13 +39,14 @@ class BazelClient(
   suspend fun queryAllTargets(): List<BazelTarget> {
     val queryEpoch = Calendar.getInstance().getTimeInMillis()
 
-    // Skip //external:all-targets when explicitly excluded, when Bzlmod is enabled (//external not
-    // available), or when an earlier query already proved //external is unavailable here (the
-    // Bzlmod probe false-negatived -- see [externalPackageUnavailable]).
+    // Skip //external:all-targets when explicitly excluded, or when an earlier query already proved
+    // //external is unavailable here (see [externalPackageUnavailable]).
+    //
+    // Bzlmod being enabled does not retire //external: a workspace can run both, and //external
+    // still holds the only version-bearing hash for every WORKSPACE repo. Ask for it and let the
+    // ExternalPackageUnavailableException path below drop it when it really is gone.
     val repoTargetsQuery =
-        if (excludeExternalTargets ||
-            bazelModService.isBzlmodEnabled ||
-            externalPackageUnavailable) {
+        if (excludeExternalTargets || externalPackageUnavailable) {
           emptyList()
         } else {
           listOf("//external:all-targets")

--- a/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/bazel/BazelQueryService.kt
@@ -310,7 +310,17 @@ class BazelQueryService(
     }
 
     // Step 2: Fetch repo definitions via `mod show_repo @@<canonical>... --output=streamed_proto`.
-    val canonicalNames = canonicalToApparent.keys.map { "@@$it" }
+    //
+    // Ask only for repos `bazel mod` can resolve. A workspace running Bzlmod alongside WORKSPACE
+    // maps its WORKSPACE repos into the root repo mapping too, and show_repo fails the whole batch
+    // on the first one it does not know -- leaving every Bzlmod repo unhashed. A Bzlmod canonical
+    // name carries the module separator ('+', or '~' before Bazel 7.1); //external covers the rest.
+    val canonicalNames =
+        canonicalToApparent.keys.filter { it.contains('+') || it.contains('~') }.map { "@@$it" }
+    if (canonicalNames.isEmpty()) {
+      logger.w { "No bzlmod-canonical repos in the repo mapping, skipping mod show_repo" }
+      return emptyList()
+    }
     val outputFile = Files.createTempFile(null, ".bin").toFile()
     outputFile.deleteOnExit()
 

--- a/cli/src/test/kotlin/com/bazel_diff/bazel/BazelClientTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/bazel/BazelClientTest.kt
@@ -49,7 +49,8 @@ class BazelClientTest : KoinTest {
 
       whenever(modService.isBzlmodEnabled).thenReturn(true)
       whenever(queryService.canUseBzlmodShowRepo).thenReturn(true)
-      whenever(queryService.query("'//...:all-targets'")).thenReturn(listOf(mainTarget))
+      whenever(queryService.query("'//external:all-targets' + '//...:all-targets'"))
+          .thenReturn(listOf(mainTarget))
       whenever(queryService.queryBzlmodRepos()).thenReturn(listOf(bzlmodTarget))
 
       val client =
@@ -68,6 +69,40 @@ class BazelClientTest : KoinTest {
     }
   }
 
+  /**
+   * Enabling Bzlmod does not retire //external: a workspace can run both, and then //external still
+   * carries the repo-generation target -- the only version-bearing hash -- for every WORKSPACE
+   * repo. Skipping it there hashes those repos to nothing, so a WORKSPACE dependency bump reports
+   * no impacted target at all.
+   */
+  @Test
+  fun queryAllTargets_bzlmodEnabled_hybridWorkspace_includesExternalAndBzlmodRepos() {
+    runBlocking {
+      val mainTarget = mockRuleTarget("//src:lib")
+      val workspaceRepoTarget = mockRuleTarget("//external:guava")
+      val bzlmodTarget = mockRuleTarget("//external:rules_java~")
+
+      whenever(modService.isBzlmodEnabled).thenReturn(true)
+      whenever(queryService.canUseBzlmodShowRepo).thenReturn(true)
+      whenever(queryService.query("'//external:all-targets' + '//...:all-targets'"))
+          .thenReturn(listOf(mainTarget, workspaceRepoTarget))
+      whenever(queryService.queryBzlmodRepos()).thenReturn(listOf(bzlmodTarget))
+
+      val client =
+          BazelClient(
+              useCquery = false,
+              cqueryExpression = null,
+              fineGrainedHashExternalRepos = emptySet(),
+              excludeExternalTargets = false,
+              excludeTargetsQuery = null)
+
+      val targets = client.queryAllTargets()
+
+      assertThat(targets.map { it.name })
+          .containsOnly("//src:lib", "//external:guava", "//external:rules_java~")
+    }
+  }
+
   @Test
   fun queryAllTargets_bzlmodEnabled_oldBazel_skipsBzlmodRepos() {
     runBlocking {
@@ -75,7 +110,8 @@ class BazelClientTest : KoinTest {
 
       whenever(modService.isBzlmodEnabled).thenReturn(true)
       whenever(queryService.canUseBzlmodShowRepo).thenReturn(false)
-      whenever(queryService.query("'//...:all-targets'")).thenReturn(listOf(mainTarget))
+      whenever(queryService.query("'//external:all-targets' + '//...:all-targets'"))
+          .thenReturn(listOf(mainTarget))
 
       val client =
           BazelClient(
@@ -127,6 +163,7 @@ class BazelClientTest : KoinTest {
       whenever(queryService.canUseBzlmodShowRepo).thenReturn(true)
       whenever(queryService.query("deps(//...:all-targets)", useCquery = true))
           .thenReturn(listOf(mainTarget))
+      whenever(queryService.query("'//external:all-targets'")).thenReturn(emptyList())
       whenever(queryService.queryBzlmodRepos()).thenReturn(listOf(bzlmodTarget))
 
       val client =
@@ -153,7 +190,8 @@ class BazelClientTest : KoinTest {
 
       whenever(modService.isBzlmodEnabled).thenReturn(true)
       whenever(queryService.canUseBzlmodShowRepo).thenReturn(true)
-      whenever(queryService.query("'//...:all-targets'")).thenReturn(listOf(mainTarget))
+      whenever(queryService.query("'//external:all-targets' + '//...:all-targets'"))
+          .thenReturn(listOf(mainTarget))
       whenever(queryService.queryBzlmodRepos()).thenReturn(listOf(bzlmodTarget))
 
       val client =
@@ -286,6 +324,7 @@ class BazelClientTest : KoinTest {
       whenever(modService.isBzlmodEnabled).thenReturn(true)
       whenever(queryService.canUseBzlmodShowRepo).thenReturn(false)
       whenever(queryService.query(wrapped, useCquery = true)).thenReturn(listOf(mainTarget))
+      whenever(queryService.query("'//external:all-targets'")).thenReturn(emptyList())
 
       val client =
           BazelClient(


### PR DESCRIPTION
## The bug

An external repo is hashed through its repo-generation target, whose attributes carry the version — a url, a sha256, a commit. There are two sources for those, and `isBzlmodEnabled` picks between them:

- `//external:all-targets` — the WORKSPACE repos
- `bazel mod show_repo` — the Bzlmod repos

A workspace can run **both** systems at once. There, each source covers only half the graph, and each is switched off by the half it doesn't cover:

1. `BazelClient.queryAllTargets` drops `//external` the moment `isBzlmodEnabled` is true. A hybrid workspace still has a live `//external` package holding the only version-bearing hash for every WORKSPACE repo, so those repos hash to nothing.

2. `BazelQueryService.queryBzlmodRepos` asks `mod show_repo` for **every** repo in the root repo mapping. A hybrid workspace maps its WORKSPACE repos into that mapping too; `bazel mod` cannot resolve them, so the batch exits non-zero, the `resultCode != 0` branch returns `emptyList()`, and the Bzlmod repos hash to nothing either.

It takes both sources to cover the graph, so on a hybrid workspace current `master` hashes **no external repo at all**: bumping any dependency, WORKSPACE or Bzlmod, moves no hash and reports no impacted target, and CI silently tests nothing.

## The fix

- Gate `//external` on **availability** rather than on Bzlmod being enabled. The `ExternalPackageUnavailableException` self-heal from #420 already drops it when the package really is gone, which is the Bzlmod-only case.
- Ask `show_repo` only for the **Bzlmod-canonical** repos — a canonical name carries the module separator (`+`, or `~` before Bazel 7.1). Those are the ones it can answer for; `//external` covers the rest.

Both repo systems hash again, and the impacted set stays precise: the bump above now selects the generated parser and the targets that build it, and nothing else. `//external:*` pseudo-targets still do not leak into the impacted output, so #326 / #334 continue to hold.

Removing the `isBzlmodEnabled` short-circuit means a Bzlmod-only workspace now attempts the `//external` query once and self-heals via the #420 catch, rather than skipping it. That cost lands on Bzlmod-only workspaces — increasingly the common case — to correctly support hybrid ones, which are rarer. It's one cheap, load-phase query that fails fast and is caught, and it buys correctness: the gate's "skip when Bzlmod is on" was silently wrong whenever both systems were in use. This is the simple, definitely-correct version; there's likely a faster way to detect the hybrid case without the extra query, and I'd defer to you on whether it's worth the complexity.

## Tests

New `queryAllTargets_bzlmodEnabled_hybridWorkspace_includesExternalAndBzlmodRepos`, covering a Bzlmod-enabled workspace whose `//external` is still live.

The existing Bzlmod-enabled cases asserted the either/or directly — their expected query strings excluded `//external` — so they are updated to expect it.

The unit suite passes. `//cli:E2ETest` fails three tests for me — `testBzlmodShowRepoDetectsModuleBazelChanges`, `testBzlmodTransitiveDepsCquery`, `testExcludeExternalTargetsFiltersBzlmodSyntheticLabels` — but it fails those same three on pristine `master` (they look tied to the Bazel version resolved locally: the golden output expects the `+` canonical separator and the runtime emits `~`). Unaffected by this change.
