### PR TITLE
feat(serve): per-phase profile breakdown so slow queries are attributable

### DIFF
--- a/cli/src/main/kotlin/com/bazel_diff/hash/BuildGraphHasher.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/hash/BuildGraphHasher.kt
@@ -21,6 +21,17 @@ import kotlinx.coroutines.runBlocking
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
+/**
+ * Mutable per-run phase timings, filled in by [BuildGraphHasher.hashAllBazelTargetsAndSourcefiles]
+ * when the caller passes one. The phases run sequentially, in field order; [targetHashMillis] also
+ * covers deriving the seed and per-package `.bzl` seeds that target hashing consumes.
+ */
+class HasherPhaseTimings {
+  var bazelQueryMillis: Long = 0
+  var sourceHashMillis: Long = 0
+  var targetHashMillis: Long = 0
+}
+
 class BuildGraphHasher(private val bazelClient: BazelClient) : KoinComponent {
   private val targetHasher: TargetHasher by inject()
   private val sourceFileHasher: SourceFileHasher by inject()
@@ -30,12 +41,15 @@ class BuildGraphHasher(private val bazelClient: BazelClient) : KoinComponent {
   fun hashAllBazelTargetsAndSourcefiles(
       seedFilepaths: Set<Path> = emptySet(),
       ignoredAttrs: Set<String> = emptySet(),
-      modifiedFilepaths: Set<Path> = emptySet()
+      modifiedFilepaths: Set<Path> = emptySet(),
+      timings: HasherPhaseTimings? = null
   ): Map<String, TargetHash> {
     val (sourceDigests, allTargets) =
         runBlocking {
+          val queryStartNanos = System.nanoTime()
           val targetsTask = async(Dispatchers.IO) { bazelClient.queryAllTargets() }
           val allTargets = targetsTask.await()
+          timings?.bazelQueryMillis = (System.nanoTime() - queryStartNanos) / 1_000_000
           val sourceTargets =
               allTargets
                   .filter { it is BazelTarget.SourceFile }
@@ -47,25 +61,30 @@ class BuildGraphHasher(private val bazelClient: BazelClient) : KoinComponent {
                 val sourceFileTargets = hashSourcefiles(sourceTargets, modifiedFilepaths)
                 val sourceHashDuration =
                     Calendar.getInstance().getTimeInMillis() - sourceHashDurationEpoch
+                timings?.sourceHashMillis = sourceHashDuration
                 logger.i { "Source file hashes calculated in $sourceHashDuration" }
                 sourceFileTargets
               }
 
           Pair(sourceDigestsFuture.await(), allTargets)
         }
+    val targetHashStartNanos = System.nanoTime()
     val seedForFilepaths = runBlocking(Dispatchers.IO) { createSeedForFilepaths(seedFilepaths) }
     // Attribute each BUILD file's loaded `.bzl` digests to the package that loads them, so a
     // `.bzl` edit only re-hashes targets in packages that actually `load()` it -- not every
     // target in the workspace (issue #365). A package that loads no tracked `.bzl` gets nothing
     // mixed in, keeping its targets' hashes byte-for-byte stable.
     val packageBzlSeeds = createPackageBzlSeeds(allTargets, modifiedFilepaths)
-    return hashAllTargets(
-        seedForFilepaths,
-        packageBzlSeeds,
-        sourceDigests,
-        allTargets,
-        ignoredAttrs,
-        modifiedFilepaths)
+    val result =
+        hashAllTargets(
+            seedForFilepaths,
+            packageBzlSeeds,
+            sourceDigests,
+            allTargets,
+            ignoredAttrs,
+            modifiedFilepaths)
+    timings?.targetHashMillis = (System.nanoTime() - targetHashStartNanos) / 1_000_000
+    return result
   }
 
   private fun hashSourcefiles(

--- a/cli/src/main/kotlin/com/bazel_diff/server/HashService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/HashService.kt
@@ -3,6 +3,7 @@ package com.bazel_diff.server
 import com.bazel_diff.bazel.BazelModService
 import com.bazel_diff.extensions.toHexString
 import com.bazel_diff.hash.BuildGraphHasher
+import com.bazel_diff.hash.HasherPhaseTimings
 import com.bazel_diff.hash.TargetHash
 import com.bazel_diff.hash.sha256
 import com.bazel_diff.interactor.DeserialiseHashesInteractor
@@ -102,15 +103,34 @@ class HashService(
     return "$base.$digest"
   }
 
+  /**
+   * Outcome of one [retrieve]: the data, whether it was a cache hit, and where the time went --
+   * everything [getHashes] needs to assemble a [HashRetrievalProfile] except the total duration.
+   */
+  private data class Retrieval(
+      val data: HashFileData,
+      val cacheHit: Boolean,
+      val lockWaitMillis: Long? = null,
+      val cacheReadMillis: Long? = null,
+      val generation: HashGenerationBreakdown? = null,
+  )
+
   override fun getHashes(
       sha: String,
       modifiedFilepaths: Set<Path>,
       profiler: QueryProfiler?
   ): HashFileData {
     val startNanos = System.nanoTime()
-    val (data, cacheHit) = retrieve(sha, modifiedFilepaths)
-    profiler?.recordHashRetrieval(sha, cacheHit, (System.nanoTime() - startNanos) / 1_000_000)
-    return data
+    val retrieval = retrieve(sha, modifiedFilepaths)
+    profiler?.recordHashRetrieval(
+        HashRetrievalProfile(
+            sha = sha,
+            cacheHit = retrieval.cacheHit,
+            durationMillis = (System.nanoTime() - startNanos) / 1_000_000,
+            lockWaitMillis = retrieval.lockWaitMillis,
+            cacheReadMillis = retrieval.cacheReadMillis,
+            generation = retrieval.generation))
+    return retrieval.data
   }
 
   /**
@@ -118,12 +138,16 @@ class HashService(
    * waited-behind-another-generation case (the after-lock re-check): this request itself ran no
    * checkout/query, though its duration then includes the lock wait.
    */
-  private fun retrieve(sha: String, modifiedFilepaths: Set<Path>): Pair<HashFileData, Boolean> {
+  private fun retrieve(sha: String, modifiedFilepaths: Set<Path>): Retrieval {
     val key = cacheKey(sha, modifiedFilepaths)
+    val readStartNanos = System.nanoTime()
     storage.get(key)?.let { bytes ->
-      logger.i { "Hash cache hit for $sha" }
-      return deserialiser.executeTargetHashWithMetadataFromString(
-          String(bytes, StandardCharsets.UTF_8)) to true
+      val data =
+          deserialiser.executeTargetHashWithMetadataFromString(
+              String(bytes, StandardCharsets.UTF_8))
+      val readMillis = elapsedMillis(readStartNanos)
+      logger.i { "Hash cache hit for $sha (read+deserialize ${readMillis}ms)" }
+      return Retrieval(data, cacheHit = true, cacheReadMillis = readMillis)
     }
     return generate(sha, modifiedFilepaths, key)
   }
@@ -134,29 +158,74 @@ class HashService(
         block()
       }
 
-  private fun generate(
-      sha: String,
-      modifiedFilepaths: Set<Path>,
-      key: String
-  ): Pair<HashFileData, Boolean> =
-      synchronized(generationLock) {
-        // Re-check under the lock: another thread may have generated this revision while we waited.
-        storage.get(key)?.let {
-          logger.i { "Hash cache hit for $sha (after lock)" }
-          return deserialiser.executeTargetHashWithMetadataFromString(
-              String(it, StandardCharsets.UTF_8)) to true
+  private fun generate(sha: String, modifiedFilepaths: Set<Path>, key: String): Retrieval {
+    val lockStartNanos = System.nanoTime()
+    synchronized(generationLock) {
+      val lockWaitMillis = elapsedMillis(lockStartNanos)
+      // Re-check under the lock: another thread may have generated this revision while we waited.
+      val readStartNanos = System.nanoTime()
+      storage.get(key)?.let {
+        val data =
+            deserialiser.executeTargetHashWithMetadataFromString(String(it, StandardCharsets.UTF_8))
+        val readMillis = elapsedMillis(readStartNanos)
+        logger.i {
+          "Hash cache hit for $sha (after ${lockWaitMillis}ms lock wait, " +
+              "read+deserialize ${readMillis}ms)"
         }
-        logger.i { "Hash cache miss for $sha - generating hashes" }
-        gitClient.checkout(sha)
-        val hashes =
-            buildGraphHasher.hashAllBazelTargetsAndSourcefiles(
-                seedFilepaths, ignoredRuleHashingAttributes, modifiedFilepaths)
-        val moduleGraphJson = runBlocking { bazelModService.getModuleGraphJson() }
-        val depEdges = depEdgesOf(hashes)
-        storage.put(
-            key, serialize(hashes, moduleGraphJson, depEdges).toByteArray(StandardCharsets.UTF_8))
-        HashFileData(hashes, moduleGraphJson, depEdges) to false
+        return Retrieval(
+            data, cacheHit = true, lockWaitMillis = lockWaitMillis, cacheReadMillis = readMillis)
       }
+      logger.i { "Hash cache miss for $sha - generating hashes" }
+
+      val checkoutStartNanos = System.nanoTime()
+      gitClient.checkout(sha)
+      val checkoutMillis = elapsedMillis(checkoutStartNanos)
+
+      val hasherTimings = HasherPhaseTimings()
+      val hashes =
+          buildGraphHasher.hashAllBazelTargetsAndSourcefiles(
+              seedFilepaths, ignoredRuleHashingAttributes, modifiedFilepaths, hasherTimings)
+
+      val moduleGraphStartNanos = System.nanoTime()
+      val moduleGraphJson = runBlocking { bazelModService.getModuleGraphJson() }
+      val moduleGraphMillis = elapsedMillis(moduleGraphStartNanos)
+
+      val writeStartNanos = System.nanoTime()
+      val depEdges = depEdgesOf(hashes)
+      storage.put(
+          key, serialize(hashes, moduleGraphJson, depEdges).toByteArray(StandardCharsets.UTF_8))
+      val cacheWriteMillis = elapsedMillis(writeStartNanos)
+
+      val breakdown =
+          HashGenerationBreakdown(
+              checkoutMillis = checkoutMillis,
+              bazelQueryMillis = hasherTimings.bazelQueryMillis,
+              sourceHashMillis = hasherTimings.sourceHashMillis,
+              targetHashMillis = hasherTimings.targetHashMillis,
+              moduleGraphMillis = moduleGraphMillis,
+              cacheWriteMillis = cacheWriteMillis,
+              targetCount = hashes.size,
+          )
+      // Always logged (not just when the request opted into profile=true) so slow generations are
+      // attributable to a phase straight from the server logs.
+      logger.i {
+        "Hash generation for $sha took ${elapsedMillis(lockStartNanos)}ms: " +
+            "lockWait=${lockWaitMillis}ms checkout=${checkoutMillis}ms " +
+            "bazelQuery=${hasherTimings.bazelQueryMillis}ms " +
+            "sourceHash=${hasherTimings.sourceHashMillis}ms " +
+            "targetHash=${hasherTimings.targetHashMillis}ms " +
+            "moduleGraph=${moduleGraphMillis}ms cacheWrite=${cacheWriteMillis}ms " +
+            "targets=${hashes.size}"
+      }
+      return Retrieval(
+          HashFileData(hashes, moduleGraphJson, depEdges),
+          cacheHit = false,
+          lockWaitMillis = lockWaitMillis,
+          generation = breakdown)
+    }
+  }
+
+  private fun elapsedMillis(startNanos: Long): Long = (System.nanoTime() - startNanos) / 1_000_000
 
   /**
    * The dependency-edge adjacency list (label -> direct dep labels) when [trackDeps] is on, else

--- a/cli/src/main/kotlin/com/bazel_diff/server/ImpactedTargetsService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/ImpactedTargetsService.kt
@@ -116,7 +116,8 @@ class ImpactedTargetsService(
     val writer = StringWriter()
     val interactor = CalculateImpactedTargetsInteractor()
     val diffStartNanos = System.nanoTime()
-    runOnGraph(fromData.moduleGraphJson, toData.moduleGraphJson, toSha) {
+    val moduleGraphChanged = fromData.moduleGraphJson != toData.moduleGraphJson
+    runOnGraph(moduleGraphChanged, toSha) {
       interactor.execute(
           fromData.hashes,
           toData.hashes,
@@ -126,7 +127,7 @@ class ImpactedTargetsService(
           toData.moduleGraphJson,
           excludeExternalTargets())
     }
-    profiler?.recordDiff(elapsedMillis(diffStartNanos))
+    profiler?.recordDiff(elapsedMillis(diffStartNanos), moduleGraphChanged)
 
     val impacted = writer.toString().split("\n").filter { it.isNotBlank() }
     return ImpactedTargetsResult(
@@ -152,8 +153,9 @@ class ImpactedTargetsService(
 
     val interactor = CalculateImpactedTargetsInteractor()
     val diffStartNanos = System.nanoTime()
+    val moduleGraphChanged = fromData.moduleGraphJson != toData.moduleGraphJson
     val impacted =
-        runOnGraph(fromData.moduleGraphJson, toData.moduleGraphJson, toSha) {
+        runOnGraph(moduleGraphChanged, toSha) {
           // Use the `to` revision's dependency edges: distances are measured by traversing the
           // impacted labels through the final build graph (matches the CLI's depEdgesFile usage).
           interactor.computeImpactedTargetsWithDistances(
@@ -165,7 +167,7 @@ class ImpactedTargetsService(
               toData.moduleGraphJson,
               excludeExternalTargets())
         }
-    profiler?.recordDiff(elapsedMillis(diffStartNanos))
+    profiler?.recordDiff(elapsedMillis(diffStartNanos), moduleGraphChanged)
     return ImpactedTargetsWithDistancesResult(
         fromSha, toSha, impacted, profiler?.queryProfile(), profiler?.memoryProfile())
   }
@@ -255,18 +257,16 @@ class ImpactedTargetsService(
   private fun excludeExternalTargets(): Boolean = bazelModService.isBzlmodEnabled
 
   /**
-   * Runs [block], holding the workspace at [toSha] only when the module graph changed. In that case
-   * the interactor issues a live `rdeps` query against the working tree, so it must be checked out
-   * at `to` and held there while the query runs. The common (pure hash-diff) path touches no
-   * workspace state, so it runs without the lock.
+   * Runs [block], holding the workspace at [toSha] only when [moduleGraphChanged]. In that case the
+   * interactor issues a live `rdeps` query against the working tree, so it must be checked out at
+   * `to` and held there while the query runs. The common (pure hash-diff) path touches no workspace
+   * state, so it runs without the lock.
    */
-  private fun <T> runOnGraph(
-      fromModuleGraphJson: String?,
-      toModuleGraphJson: String?,
-      toSha: String,
-      block: () -> T
-  ): T =
-      if (fromModuleGraphJson != toModuleGraphJson) {
+  private fun <T> runOnGraph(moduleGraphChanged: Boolean, toSha: String, block: () -> T): T =
+      if (moduleGraphChanged) {
+        logger.i {
+          "Module graph changed between revisions; diff includes a live rdeps query at $toSha"
+        }
         hashProvider.withWorkspaceAt(toSha) { block() }
       } else {
         block()

--- a/cli/src/main/kotlin/com/bazel_diff/server/QueryProfiler.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/QueryProfiler.kt
@@ -8,11 +8,40 @@ import java.util.Collections
  * served from the per-SHA cache -- including when this request waited behind another request that
  * generated them -- and false when this request ran the checkout + `bazel query` itself, which is
  * why a miss is typically orders of magnitude slower than a hit.
+ *
+ * The optional fields break the duration down so a slow retrieval is attributable to a specific
+ * phase (all are omitted from the JSON when absent):
+ * - [lockWaitMillis]: time blocked behind another request's checkout/query on the workspace lock.
+ *   Present whenever the retrieval had to take the lock -- both misses and waited-behind hits.
+ * - [cacheReadMillis]: hit only -- reading the cached entry and deserialising its JSON, which for a
+ *   large graph is the entire cost of a hit.
+ * - [generation]: miss only -- the per-phase cost of generating the hashes.
  */
 data class HashRetrievalProfile(
     val sha: String,
     val cacheHit: Boolean,
     val durationMillis: Long,
+    val lockWaitMillis: Long? = null,
+    val cacheReadMillis: Long? = null,
+    val generation: HashGenerationBreakdown? = null,
+)
+
+/**
+ * Wall-clock breakdown of one cache-miss hash generation, in pipeline order. [checkoutMillis] is
+ * the `git checkout`; [bazelQueryMillis] the `bazel query` for all targets (including proto
+ * parsing); [sourceHashMillis] content-hashing the source files; [targetHashMillis] seeding and
+ * hashing every target; [moduleGraphMillis] the `bazel mod graph --output=json` call (0 when Bzlmod
+ * is off); [cacheWriteMillis] serialising the result and writing it to the cache. [targetCount]
+ * sizes the graph the above phases operated on.
+ */
+data class HashGenerationBreakdown(
+    val checkoutMillis: Long,
+    val bazelQueryMillis: Long,
+    val sourceHashMillis: Long,
+    val targetHashMillis: Long,
+    val moduleGraphMillis: Long,
+    val cacheWriteMillis: Long,
+    val targetCount: Int,
 )
 
 /**
@@ -24,13 +53,16 @@ data class HashRetrievalProfile(
  * the workspace lock, so it can exceed the sum of the individual phases.
  * [resolveRevisionsDurationMillis] covers git revision resolution including any on-demand fetches.
  * [diffDurationMillis] covers the hash diff itself and, when the module graph changed between the
- * revisions, the live `rdeps` query that path issues.
+ * revisions, the live `rdeps` query that path issues -- [diffModuleGraphChanged] is true exactly
+ * when that happened, so an unexpectedly slow diff between two cache-hit revisions is attributable
+ * to the live query rather than the in-memory diff.
  */
 data class QueryProfile(
     val totalDurationMillis: Long,
     val resolveRevisionsDurationMillis: Long,
     val hashRetrievals: List<HashRetrievalProfile>,
     val diffDurationMillis: Long,
+    val diffModuleGraphChanged: Boolean = false,
 )
 
 /**
@@ -85,18 +117,20 @@ class QueryProfiler(
 
   @Volatile private var resolveRevisionsMillis = 0L
   @Volatile private var diffMillis = 0L
+  @Volatile private var diffModuleGraphChanged = false
   private val hashRetrievals = Collections.synchronizedList(mutableListOf<HashRetrievalProfile>())
 
   fun recordResolveRevisions(durationMillis: Long) {
     resolveRevisionsMillis += durationMillis
   }
 
-  fun recordHashRetrieval(sha: String, cacheHit: Boolean, durationMillis: Long) {
-    hashRetrievals.add(HashRetrievalProfile(sha, cacheHit, durationMillis))
+  fun recordHashRetrieval(retrieval: HashRetrievalProfile) {
+    hashRetrievals.add(retrieval)
   }
 
-  fun recordDiff(durationMillis: Long) {
+  fun recordDiff(durationMillis: Long, moduleGraphChanged: Boolean = false) {
     diffMillis += durationMillis
+    if (moduleGraphChanged) diffModuleGraphChanged = true
   }
 
   /** Snapshot of the recorded phases; total spans construction to this call. */
@@ -106,6 +140,7 @@ class QueryProfiler(
           resolveRevisionsDurationMillis = resolveRevisionsMillis,
           hashRetrievals = synchronized(hashRetrievals) { hashRetrievals.toList() },
           diffDurationMillis = diffMillis,
+          diffModuleGraphChanged = diffModuleGraphChanged,
       )
 
   /** Heap/GC movement between construction and this call. */

--- a/cli/src/test/kotlin/com/bazel_diff/server/HashServiceTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/HashServiceTest.kt
@@ -25,6 +25,8 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnit
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -81,7 +83,7 @@ class HashServiceTest : KoinTest {
 
   @Test
   fun cacheMissGeneratesAndStores() {
-    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any()))
+    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any(), anyOrNull()))
         .thenReturn(sampleHashes)
     runBlocking { whenever(bazelModService.getModuleGraphJson()).thenReturn(null) }
     val git = RecordingGitClient()
@@ -99,7 +101,7 @@ class HashServiceTest : KoinTest {
 
   @Test
   fun scopedRequestUsesADistinctCacheKeyAndPassesTheSetToTheHasher() {
-    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any()))
+    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any(), anyOrNull()))
         .thenReturn(sampleHashes)
     runBlocking { whenever(bazelModService.getModuleGraphJson()).thenReturn(null) }
     val storage = InMemoryStorage()
@@ -113,7 +115,9 @@ class HashServiceTest : KoinTest {
     assertThat(key).startsWith("sha1.fp.")
     assertThat(key).isNotEqualTo("sha1.fp")
     // The scope reaches the hasher (3rd arg) so unchanged files skip content reads.
-    verify(buildGraphHasher).hashAllBazelTargetsAndSourcefiles(emptySet(), emptySet(), modified)
+    verify(buildGraphHasher)
+        .hashAllBazelTargetsAndSourcefiles(
+            eq(emptySet()), eq(emptySet()), eq(modified), anyOrNull())
   }
 
   @Test
@@ -131,7 +135,7 @@ class HashServiceTest : KoinTest {
 
   @Test
   fun secondCallIsServedFromCacheWithoutRegenerating() {
-    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any()))
+    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any(), anyOrNull()))
         .thenReturn(sampleHashes)
     runBlocking { whenever(bazelModService.getModuleGraphJson()).thenReturn(null) }
     val git = RecordingGitClient()
@@ -144,12 +148,13 @@ class HashServiceTest : KoinTest {
     assertThat(second.hashes).isEqualTo(sampleHashes)
     // Only the first call touches the workspace / runs the hasher.
     assertThat(git.checkouts).isEqualTo(listOf("sha1"))
-    verify(buildGraphHasher, times(1)).hashAllBazelTargetsAndSourcefiles(any(), any(), any())
+    verify(buildGraphHasher, times(1))
+        .hashAllBazelTargetsAndSourcefiles(any(), any(), any(), anyOrNull())
   }
 
   @Test
   fun profilerRecordsCacheMissThenHit() {
-    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any()))
+    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any(), anyOrNull()))
         .thenReturn(sampleHashes)
     runBlocking { whenever(bazelModService.getModuleGraphJson()).thenReturn(null) }
     val service = newService(RecordingGitClient(), InMemoryStorage())
@@ -163,9 +168,18 @@ class HashServiceTest : KoinTest {
     assertThat(miss.sha).isEqualTo("sha1")
     assertThat(miss.cacheHit).isEqualTo(false)
     assertThat(miss.durationMillis >= 0).isEqualTo(true)
+    // A miss carries the per-phase generation breakdown (and no cache-read time).
+    assertThat(miss.cacheReadMillis).isNull()
+    val generation = miss.generation!!
+    assertThat(generation.targetCount).isEqualTo(sampleHashes.size)
+    assertThat(generation.checkoutMillis >= 0).isEqualTo(true)
+    assertThat(miss.lockWaitMillis!! >= 0).isEqualTo(true)
     val hit = hitProfiler.queryProfile().hashRetrievals.single()
     assertThat(hit.sha).isEqualTo("sha1")
     assertThat(hit.cacheHit).isEqualTo(true)
+    // A hit carries the read+deserialize time and no generation breakdown.
+    assertThat(hit.cacheReadMillis!! >= 0).isEqualTo(true)
+    assertThat(hit.generation).isNull()
   }
 
   @Test
@@ -181,7 +195,7 @@ class HashServiceTest : KoinTest {
 
   @Test
   fun cachePreservesModuleGraphJson() {
-    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any()))
+    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any(), anyOrNull()))
         .thenReturn(sampleHashes)
     runBlocking { whenever(bazelModService.getModuleGraphJson()).thenReturn("""{"graph":1}""") }
     val storage = InMemoryStorage()
@@ -196,7 +210,7 @@ class HashServiceTest : KoinTest {
 
   @Test
   fun trackDepsPersistsAndRoundTripsDepEdges() {
-    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any()))
+    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any(), anyOrNull()))
         .thenReturn(sampleHashesWithDeps)
     runBlocking { whenever(bazelModService.getModuleGraphJson()).thenReturn(null) }
     val storage = InMemoryStorage()
@@ -214,7 +228,7 @@ class HashServiceTest : KoinTest {
 
   @Test
   fun withoutTrackDepsCacheHasNoDepEdges() {
-    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any()))
+    whenever(buildGraphHasher.hashAllBazelTargetsAndSourcefiles(any(), any(), any(), anyOrNull()))
         .thenReturn(sampleHashesWithDeps)
     runBlocking { whenever(bazelModService.getModuleGraphJson()).thenReturn(null) }
     val storage = InMemoryStorage()

--- a/cli/src/test/kotlin/com/bazel_diff/server/ImpactedTargetsServiceTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/ImpactedTargetsServiceTest.kt
@@ -159,7 +159,8 @@ class ImpactedTargetsServiceTest : KoinTest {
     ): HashFileData {
       modifiedFilepathsByRev[sha] = modifiedFilepaths
       // Mirror HashService: each retrieval reports itself to the profiler (canned data = a "hit").
-      profiler?.recordHashRetrieval(sha, cacheHit = true, durationMillis = 1)
+      profiler?.recordHashRetrieval(
+          HashRetrievalProfile(sha, cacheHit = true, durationMillis = 1, cacheReadMillis = 1))
       return byRev[sha] ?: error("no canned hashes for $sha")
     }
 
@@ -330,10 +331,14 @@ class ImpactedTargetsServiceTest : KoinTest {
         FakeHashProvider(mapOf("from-sha" to from, "to-sha" to to), allowWorkspaceAt = true)
     val service = ImpactedTargetsService(IdentityGitClient(), provider, depsTracked = true)
 
-    val result = service.getImpactedTargetsWithDistances("from-sha", "to-sha", null)
+    val result =
+        service.getImpactedTargetsWithDistances(
+            "from-sha", "to-sha", null, profiler = QueryProfiler())
 
     assertThat(result.impactedTargets).containsExactly(ImpactedTargetWithDistance("//:a", 0, 0))
     assertThat(provider.workspaceAtCalls).isEqualTo(listOf("to-sha"))
+    // The live-rdeps diff path is called out in the profile so a slow diff is attributable to it.
+    assertThat(result.profile!!.diffModuleGraphChanged).isEqualTo(true)
   }
 
   @Test
@@ -353,6 +358,8 @@ class ImpactedTargetsServiceTest : KoinTest {
     assertThat(profile.totalDurationMillis).isGreaterThanOrEqualTo(0)
     assertThat(profile.resolveRevisionsDurationMillis).isGreaterThanOrEqualTo(0)
     assertThat(profile.diffDurationMillis).isGreaterThanOrEqualTo(0)
+    // Identical (null) module graphs on both sides: the pure hash-diff path ran.
+    assertThat(profile.diffModuleGraphChanged).isEqualTo(false)
     val memory = result.memoryProfile!!
     assertThat(memory.heapMaxBytes).isGreaterThan(0)
     assertThat(memory.heapUsedAfterBytes - memory.heapUsedBeforeBytes)

--- a/cli/src/test/kotlin/com/bazel_diff/server/QueryProfilerTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/QueryProfilerTest.kt
@@ -18,9 +18,25 @@ class QueryProfilerTest {
             heapMax = { 1 },
             gcStats = { GcStats(0, 0) })
 
+    val generation =
+        HashGenerationBreakdown(
+            checkoutMillis = 20,
+            bazelQueryMillis = 150,
+            sourceHashMillis = 30,
+            targetHashMillis = 25,
+            moduleGraphMillis = 15,
+            cacheWriteMillis = 5,
+            targetCount = 1234)
     profiler.recordResolveRevisions(3)
-    profiler.recordHashRetrieval("from-sha", cacheHit = true, durationMillis = 10)
-    profiler.recordHashRetrieval("to-sha", cacheHit = false, durationMillis = 250)
+    profiler.recordHashRetrieval(
+        HashRetrievalProfile("from-sha", cacheHit = true, durationMillis = 10, cacheReadMillis = 9))
+    profiler.recordHashRetrieval(
+        HashRetrievalProfile(
+            "to-sha",
+            cacheHit = false,
+            durationMillis = 250,
+            lockWaitMillis = 2,
+            generation = generation))
     profiler.recordDiff(7)
     nowNanos = 321_000_000 // 321ms since construction
 
@@ -29,11 +45,28 @@ class QueryProfilerTest {
     assertThat(profile.totalDurationMillis).isEqualTo(321)
     assertThat(profile.resolveRevisionsDurationMillis).isEqualTo(3)
     assertThat(profile.diffDurationMillis).isEqualTo(7)
+    assertThat(profile.diffModuleGraphChanged).isEqualTo(false)
     assertThat(profile.hashRetrievals)
         .isEqualTo(
             listOf(
-                HashRetrievalProfile("from-sha", true, 10),
-                HashRetrievalProfile("to-sha", false, 250)))
+                HashRetrievalProfile("from-sha", true, 10, cacheReadMillis = 9),
+                HashRetrievalProfile(
+                    "to-sha", false, 250, lockWaitMillis = 2, generation = generation)))
+  }
+
+  @Test
+  fun diffModuleGraphChangedLatchesAcrossRecordings() {
+    val profiler =
+        QueryProfiler(
+            nanoClock = { 0 }, heapUsed = { 0 }, heapMax = { 1 }, gcStats = { GcStats(0, 0) })
+
+    profiler.recordDiff(5, moduleGraphChanged = true)
+    // A later recording without the flag must not clear it.
+    profiler.recordDiff(2)
+
+    val profile = profiler.queryProfile()
+    assertThat(profile.diffDurationMillis).isEqualTo(7)
+    assertThat(profile.diffModuleGraphChanged).isEqualTo(true)
   }
 
   @Test

--- a/tools/serve_harness.py
+++ b/tools/serve_harness.py
@@ -498,7 +498,7 @@ def _impacted(s: Serve, frm: str, to: str, target_type: str | None = None, timeo
 
 
 def _impacted_post(s: Serve, frm: str, to: str, modified: list[str] | None = None,
-                   target_type: str | None = None, timeout: float = 300.0):
+                   target_type: str | None = None, profile: bool = False, timeout: float = 300.0):
     """POST /impacted_targets with an optional `modifiedFilepaths` scope (the content-hashing
     optimization). `modified` is a list of workspace-relative paths; None omits it (full hash)."""
     payload: dict = {"from": frm, "to": to}
@@ -506,6 +506,8 @@ def _impacted_post(s: Serve, frm: str, to: str, modified: list[str] | None = Non
         payload["modifiedFilepaths"] = modified
     if target_type:
         payload["targetType"] = target_type.split(",")
+    if profile:
+        payload["profile"] = True
     code, body = http(s.port, "/impacted_targets", method="POST", body=json.dumps(payload), timeout=timeout)
     try:
         data = json.loads(body)
@@ -653,6 +655,15 @@ def _full_extras(rep: Report, case: str, s: Serve, remote: Remote, track_deps: b
                         f"hits={[r.get('cacheHit') for r in retrievals]}",
               fail_detail=f"code={code} body={body[:300]}")
 
+    # A cache hit's cost is the cache read + JSON deserialize, so that -- and only that -- phase
+    # rides on each retrieval; the per-phase generation breakdown is a miss-only field.
+    rep.check(case, "hit retrievals carry cacheReadMillis, no generation breakdown",
+              len(retrievals) == 2
+              and all(r.get("cacheReadMillis", -1) >= 0 for r in retrievals)
+              and not any("generation" in r for r in retrievals),
+              ok_detail=f"reads={[r.get('cacheReadMillis') for r in retrievals]}ms",
+              fail_detail=f"retrievals={retrievals}")
+
     # Without the flag the response shape is unchanged (no profile keys leak in).
     code, body, _ = _impacted(s, sh["C1"], sh["C2"])
     rep.check(case, "no profile keys without profile=true",
@@ -764,12 +775,27 @@ def case_scoped(remote: Remote, clone: Path, root: Path, rep: Report) -> None:
         full = _stable(gdata)
 
         # (1) Scope to the actually-changed file -> identical impacted set as the full hash.
-        pc, pbody, pdata = _impacted_post(s, sh["C1"], sh["C2"], modified=["core.txt"])
+        # profile=true rides along: the scoped cache key is fresh, so both sides are cache misses
+        # and must carry the per-phase generation breakdown.
+        pc, pbody, pdata = _impacted_post(s, sh["C1"], sh["C2"], modified=["core.txt"], profile=True)
         rep.check(case, "scope to changed file == full set",
                   pc == 200 and _stable(pdata) == full == core_edit,
                   ok_detail=str(sorted(_stable(pdata))),
                   fail_detail=f"code={pc} scoped={sorted(_stable(pdata))} "
                               f"full={sorted(full)} body={pbody[:160]}")
+
+        sretr = (pdata or {}).get("profile", {}).get("hashRetrievals", [])
+        gens = [r.get("generation") or {} for r in sretr]
+        rep.check(case, "miss retrievals carry per-phase generation breakdown",
+                  len(sretr) == 2
+                  and not any(r.get("cacheHit") for r in sretr)
+                  and all(g.get("bazelQueryMillis", -1) >= 0 for g in gens)
+                  and all(g.get("checkoutMillis", -1) >= 0 for g in gens)
+                  and all(g.get("cacheWriteMillis", -1) >= 0 for g in gens)
+                  and all(g.get("targetCount", 0) > 0 for g in gens),
+                  ok_detail=f"bazelQuery={[g.get('bazelQueryMillis') for g in gens]}ms "
+                            f"targets={[g.get('targetCount') for g in gens]}",
+                  fail_detail=f"retrievals={sretr}")
 
         # (2) Negative control: omit the changed file. It is content-skipped on both revisions, so
         # the change is invisible and its targets are missed -- proving the scope really gates


### PR DESCRIPTION
## Why

Serve requests that miss the per-SHA cache were taking 60s+, and the `profile=true` data added in #429 could not say why: a cache-miss `hashRetrievals` entry was one opaque duration that lumped together the workspace lock wait, `git checkout`, the `bazel query`, source/target hashing, the `bazel mod graph --output=json` call, and the cache serialize+write. Two other costs were completely invisible: a cache *hit* still pays a JSON deserialize of the whole hash file, and the diff phase silently runs a live `rdeps` bazel query whenever the module graph changed between the revisions.

## What

- `HashRetrievalProfile` gains `lockWaitMillis`, `cacheReadMillis` (hit: the read+deserialize cost, i.e. the entire cost of a hit), and a miss-only `generation` breakdown: `checkoutMillis`, `bazelQueryMillis`, `sourceHashMillis`, `targetHashMillis`, `moduleGraphMillis`, `cacheWriteMillis`, `targetCount`. All omitted from the JSON when absent, so the response shape only grows when the data exists.
- `QueryProfile.diffModuleGraphChanged` flags when the diff took the live-rdeps path, so a slow diff between two fully-cached revisions is attributable.
- Every hash generation now logs a one-line per-phase summary at INFO (`lockWait=… checkout=… bazelQuery=… sourceHash=… targetHash=… moduleGraph=… cacheWrite=… targets=…`), so slow requests are diagnosable straight from server logs without the caller opting into `profile=true`.
- `BuildGraphHasher` accepts an optional `HasherPhaseTimings` holder (default null — the `generate-hashes` CLI path is unchanged).

## Validation

- Unit tests updated/extended: `QueryProfilerTest`, `HashServiceTest` (miss carries generation + lock wait, hit carries cacheReadMillis only), `ImpactedTargetsServiceTest` (`diffModuleGraphChanged` latches on the live-rdeps path, stays false on the pure hash-diff path).
- `tools/serve_harness.py` now asserts both shapes end to end: hit retrievals carry `cacheReadMillis` and no `generation`; the scoped-POST case (fresh cache key → miss on both sides) carries the full generation breakdown. All 34 checks pass locally, plus the scoped case.
- Full `bazel test //cli/...` green except 4 pre-existing local-only E2E failures (cquery/external-repo/Android cases) that fail identically on the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)