### PR TITLE
feat(serve): Alpine 8 GiB real-repo stress cron

### DIFF
--- a/.github/workflows/serve-stress-alpine-real.yml
+++ b/.github/workflows/serve-stress-alpine-real.yml
@@ -1,0 +1,111 @@
+name: Serve Stress (Alpine 8 GiB, real repos)
+
+# Low-resource-node stress + performance profiling for `bazel-diff serve` against REAL repos,
+# complementing the hermetic serve-stress-alpine.yml. Same Alpine (musl) / 8 GiB / small CPU
+# container path as the hermetic alpine cron, but each matrix leg runs tools/serve_stress.py in
+# --real-repo-url mode (via tools/serve_stress_alpine.sh + REAL_* env) so checkout and `bazel
+# query` cost land under the memory/CPU cap -- signals the glibc serve-stress-real.yml runners
+# never produce on large trees.
+#
+# Matrix / targets match serve-stress-real.yml (small / medium / bazel). fail-fast:false so a
+# slow or OOM'd leg still yields comparison data from the others. Each leg gets a 150-min
+# timeout (longer than the glibc real cron: cold query + 2-CPU starvation). If daily runner
+# cost outweighs the trend data, dial the cron below back to weekly (e.g. "30 14 * * 1").
+#
+# Note: scheduled runs execute from the default branch, so this must land on master before the
+# cron fires.
+on:
+  workflow_dispatch:
+    inputs:
+      cpus:
+        description: "Container CPU quota (low-resource profile)"
+        type: string
+        default: "2"
+  schedule:
+    # Daily at 14:30 UTC, offset from serve-stress (30 6), serve-stress-real (30 8),
+    # serve-stress-alpine (30 10), and the format/buildifier crons (0/30 12) so the jobs never
+    # contend for runners. Change to "30 14 * * 1" for a weekly cadence on the heavy legs.
+    - cron: "30 14 * * *"
+
+jobs:
+  ServeStressAlpineReal:
+    strategy:
+      fail-fast: false  # a slow/OOM'd leg must not cancel the others' comparison data
+      matrix:
+        include:
+          - size: small
+            repo: "https://github.com/bazelbuild/bazel-skylib.git"
+            clone_args: "--depth=50"
+          - size: medium
+            repo: "https://github.com/abseil/abseil-cpp.git"
+            clone_args: "--depth=50"
+          - size: bazel
+            repo: "https://github.com/bazelbuild/bazel.git"
+            clone_args: "--depth=50"
+    name: ServeStressAlpineReal (${{ matrix.size }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    env:
+      # Pin the image so a new Alpine release can't silently change what the cron measures.
+      ALPINE_IMAGE: alpine:3.22
+    steps:
+      - name: Compute stage dir
+        run: echo "STAGE=$RUNNER_TEMP/alpine-stage-${{ matrix.size }}" >> "$GITHUB_ENV"
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: ^1.17
+        id: go
+      - name: Setup Bazelisk
+        run: go install github.com/bazelbuild/bazelisk@latest
+      - uses: actions/checkout@v4
+      - name: Build bazel-diff deploy jar (glibc host)
+        run: ~/go/bin/bazelisk build //cli:bazel-diff_deploy.jar
+      - name: Stage container inputs
+        run: |
+          mkdir -p "$STAGE/tools"
+          cp bazel-bin/cli/bazel-diff_deploy.jar "$STAGE/bazel-diff.jar"
+          cp tools/serve_stress.py tools/serve_harness.py tools/serve_stress_alpine.sh "$STAGE/tools/"
+          cp .bazelversion "$STAGE/"
+          BV=$(cat .bazelversion)
+          curl -fsSL -o "$STAGE/bazel-glibc" \
+            "https://github.com/bazelbuild/bazel/releases/download/${BV}/bazel-${BV}-linux-x86_64"
+          chmod +x "$STAGE/bazel-glibc"
+          ls -l "$STAGE"
+      - name: Run serve stress harness (Alpine x86_64, 8 GiB, ${{ matrix.size }})
+        # --memory-swap == --memory disables swap so hitting the cap means real OOM pressure.
+        # Network is left at docker default so the container can clone REAL_REPO_URL.
+        run: >
+          docker run --rm --init --platform linux/amd64
+          --memory 8g --memory-swap 8g
+          --cpus "${{ inputs.cpus || '2' }}"
+          -e OUT_PREFIX=serve-stress-alpine-real-${{ matrix.size }}
+          -e REAL_REPO_URL="${{ matrix.repo }}"
+          -e REAL_FROM=HEAD~1
+          -e REAL_TO=HEAD
+          -e REAL_CLONE_ARGS="${{ matrix.clone_args }}"
+          -v "$STAGE:/stage"
+          "$ALPINE_IMAGE"
+          /bin/sh /stage/tools/serve_stress_alpine.sh
+      - name: Publish step summary
+        if: always()
+        run: |
+          if [ -f "$STAGE/serve-stress-alpine-real-${{ matrix.size }}-summary.md" ]; then
+            cat "$STAGE/serve-stress-alpine-real-${{ matrix.size }}-summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload metrics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: serve-stress-alpine-real-${{ matrix.size }}-8gb-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/alpine-stage-${{ matrix.size }}/serve-stress-alpine-real-${{ matrix.size }}-metrics.json
+            ${{ runner.temp }}/alpine-stage-${{ matrix.size }}/serve-stress-alpine-real-${{ matrix.size }}-summary.md
+            ${{ runner.temp }}/alpine-stage-${{ matrix.size }}/serve-stress-alpine-real-${{ matrix.size }}-footprint.json
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/serve-stress-alpine.yml
+++ b/.github/workflows/serve-stress-alpine.yml
@@ -10,6 +10,7 @@ name: Serve Stress (Alpine 8 GiB)
 # never produce. Alongside the harness's metrics/summary, the run emits a footprint JSON
 # (cgroup memory.peak against the cap + oom/oom_kill counts) as a 90-day artifact so the
 # low-resource numbers can be trended over time and compared against serve-stress.yml's.
+# Real-repo coverage under the same Alpine/8 GiB path lives in serve-stress-alpine-real.yml.
 #
 # Split design (see tools/serve_stress_alpine.sh for the container side): bazel-diff is BUILT
 # on the glibc host -- building it inside Alpine would need the whole Bazel toolchain working
@@ -34,8 +35,9 @@ on:
         type: string
         default: "2"
   schedule:
-    # Daily at 10:30 UTC, offset from serve-stress (30 6), serve-stress-real (30 8), and
-    # serve-harness (0 */12) so the crons never contend for runners.
+    # Daily at 10:30 UTC, offset from serve-stress (30 6), serve-stress-real (30 8),
+    # serve-stress-alpine-real (30 14), and serve-harness (0 */12) so the crons never contend
+    # for runners.
     - cron: "30 10 * * *"
 
 jobs:

--- a/.github/workflows/serve-stress-real.yml
+++ b/.github/workflows/serve-stress-real.yml
@@ -13,7 +13,8 @@ name: Serve Stress (real repos)
 # runs over time*. Runs daily alongside the other serve crons; each leg gets a 90-min timeout and
 # fail-fast:false because the `bazel` leg's full `bazel query` on bazelbuild/bazel is minutes-scale
 # and network-heavy. If a daily run of the large leg is more runner cost than the trend data is
-# worth, dial the cron below back to weekly (e.g. "30 8 * * 1").
+# worth, dial the cron below back to weekly (e.g. "30 8 * * 1"). The Alpine/8 GiB counterpart
+# (same matrix, musl + memory cap) is serve-stress-alpine-real.yml.
 #
 # The targets are wired here, not in code (the harness is preset-free). Swap a repo by editing its
 # matrix row; from/to default to HEAD~1..HEAD so every run tests each repo's latest commit.

--- a/tools/serve_stress_alpine.sh
+++ b/tools/serve_stress_alpine.sh
@@ -1,10 +1,13 @@
 #!/bin/sh
-# Container entry for the serve-stress-alpine cron (.github/workflows/serve-stress-alpine.yml).
+# Container entry for the serve-stress-alpine crons:
+#   .github/workflows/serve-stress-alpine.yml       (hermetic fabricated workspace)
+#   .github/workflows/serve-stress-alpine-real.yml  (real repos via REAL_* env)
 #
-# Runs the hermetic serve stress harness (tools/serve_stress.py) inside an x86_64 Alpine (musl)
-# container hard-capped at 8 GiB / few vCPUs, to surface performance choke points on a
-# low-resource node: JVM startup + heap pressure for serve, `bazel query` server cost, git
-# checkout latency, and OOM behavior that a 4-core/16 GiB glibc runner never shows.
+# Runs tools/serve_stress.py inside an x86_64 Alpine (musl) container hard-capped at 8 GiB /
+# few vCPUs, to surface performance choke points on a low-resource node: JVM startup + heap
+# pressure for serve, `bazel query` server cost, git checkout latency, and OOM behavior that a
+# 4-core/16 GiB glibc runner never shows. Hermetic and real-repo modes share this entry so the
+# musl / cgroup footprint path is identical; only the harness args differ.
 #
 # The host workflow stages everything this script needs into one directory (mounted here,
 # path-independent -- the script locates it from $0):
@@ -28,22 +31,30 @@
 #   2. a musl-native bazel from the Alpine package repos (version may lag; recorded as the
 #      "flavor" in the footprint JSON so runs remain interpretable).
 #
-# Inputs (env): QUICK -- non-empty runs the reduced --quick profile.
-# Outputs (written to <stage>): serve-stress-alpine-metrics.json, serve-stress-alpine-summary.md
-# (harness), plus serve-stress-alpine-footprint.json and a footprint section appended to the
-# summary (cgroup peak memory / OOM-kill counts -- the low-resource signal this pipeline exists
-# to capture). Exit code is the harness's.
+# Inputs (env):
+#   QUICK -- non-empty runs the reduced --quick profile (hermetic only; real-repo ignores it).
+#   REAL_REPO_URL / REAL_FROM / REAL_TO / REAL_CLONE_ARGS -- enable real-repo mode (same flags as
+#     tools/serve_stress.py). REAL_CLONE_ARGS should be a single token like `--depth=50`.
+#   OUT_PREFIX -- basename for metrics/summary/footprint under <stage>
+#     (default: serve-stress-alpine; real cron uses serve-stress-alpine-real-<size>).
+# Outputs (written to <stage>): ${OUT_PREFIX}-metrics.json, ${OUT_PREFIX}-summary.md (harness),
+# plus ${OUT_PREFIX}-footprint.json and a footprint section appended to the summary (cgroup peak
+# memory / OOM-kill counts -- the low-resource signal this pipeline exists to capture). Exit
+# code is the harness's.
 set -eu
 
 STAGE=$(cd "$(dirname "$0")/.." && pwd)
+OUT_PREFIX=${OUT_PREFIX:-serve-stress-alpine}
 echo "== stage: $STAGE"
+echo "== out prefix: $OUT_PREFIX"
 cat /etc/alpine-release
 
 # ------------------------------------------------------------------------------------------
-# Packages: harness deps (python3, git + git daemon), the musl JDK that runs both the serve
-# jar and (redirected) bazel server, and the glibc shim for the official bazel client.
+# Packages: harness deps (python3, git + git daemon), ca-certificates for HTTPS real-repo
+# clones, the musl JDK that runs both the serve jar and (redirected) bazel server, and the
+# glibc shim for the official bazel client.
 # ------------------------------------------------------------------------------------------
-apk add --no-cache python3 git git-daemon openjdk21-jdk gcompat libstdc++ libgcc
+apk add --no-cache python3 git git-daemon ca-certificates openjdk21-jdk gcompat libstdc++ libgcc
 
 JAVA_HOME=/usr/lib/jvm/default-jvm
 if [ ! -x "$JAVA_HOME/bin/java" ]; then
@@ -130,14 +141,45 @@ echo "== bazel flavor: $FLAVOR ($BAZEL)"
 # ------------------------------------------------------------------------------------------
 # Run the harness. set +e so a failing (or OOM-mangled) run still yields the footprint data
 # below -- when memory is the choke point, the failing run is the most interesting one.
+# Real-repo mode is selected by REAL_REPO_URL (same contract as serve-stress-real.yml); the
+# clone happens inside the container so checkout / bazel query cost lands under the 8 GiB cap.
 # ------------------------------------------------------------------------------------------
 set +e
-python3 "$STAGE/tools/serve_stress.py" \
-    --skip-build \
-    --bazel "$BAZEL" \
-    --metrics-out "$STAGE/serve-stress-alpine-metrics.json" \
-    --summary-out "$STAGE/serve-stress-alpine-summary.md" \
-    ${QUICK:+--quick}
+if [ -n "${REAL_REPO_URL:-}" ]; then
+    echo "== real-repo mode: $REAL_REPO_URL (${REAL_FROM:-?}..${REAL_TO:-?})"
+    : "${REAL_FROM:?REAL_FROM required when REAL_REPO_URL is set}"
+    : "${REAL_TO:?REAL_TO required when REAL_REPO_URL is set}"
+    # Keep the `=` spelling for --real-clone-args: its value is itself a flag token
+    # (`--depth=50`), and a space-separated form would be parsed as two options
+    # (see serve-stress-real.yml).
+    if [ -n "${REAL_CLONE_ARGS:-}" ]; then
+        python3 "$STAGE/tools/serve_stress.py" \
+            --skip-build \
+            --bazel "$BAZEL" \
+            --metrics-out "$STAGE/${OUT_PREFIX}-metrics.json" \
+            --summary-out "$STAGE/${OUT_PREFIX}-summary.md" \
+            --real-repo-url "$REAL_REPO_URL" \
+            --real-from "$REAL_FROM" \
+            --real-to "$REAL_TO" \
+            --real-clone-args="${REAL_CLONE_ARGS}"
+    else
+        python3 "$STAGE/tools/serve_stress.py" \
+            --skip-build \
+            --bazel "$BAZEL" \
+            --metrics-out "$STAGE/${OUT_PREFIX}-metrics.json" \
+            --summary-out "$STAGE/${OUT_PREFIX}-summary.md" \
+            --real-repo-url "$REAL_REPO_URL" \
+            --real-from "$REAL_FROM" \
+            --real-to "$REAL_TO"
+    fi
+else
+    python3 "$STAGE/tools/serve_stress.py" \
+        --skip-build \
+        --bazel "$BAZEL" \
+        --metrics-out "$STAGE/${OUT_PREFIX}-metrics.json" \
+        --summary-out "$STAGE/${OUT_PREFIX}-summary.md" \
+        ${QUICK:+--quick}
+fi
 rc=$?
 set -e
 echo "== harness exit code: $rc"
@@ -147,10 +189,10 @@ echo "== harness exit code: $rc"
 # against the 8 GiB cap and the oom/oom_kill counters. memory.peak needs kernel >= 5.19;
 # absent files degrade to null rather than failing the run.
 # ------------------------------------------------------------------------------------------
-python3 - "$STAGE" "$FLAVOR" "$rc" <<'EOF'
+python3 - "$STAGE" "$FLAVOR" "$rc" "$OUT_PREFIX" <<'EOF'
 import json, os, sys
 
-stage, flavor, rc = sys.argv[1], sys.argv[2], int(sys.argv[3])
+stage, flavor, rc, out_prefix = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
 
 def read(name):
     try:
@@ -183,7 +225,7 @@ footprint = {
     "memory_current_bytes": read("memory.current"),
     "memory_events": events,
 }
-with open(os.path.join(stage, "serve-stress-alpine-footprint.json"), "w") as f:
+with open(os.path.join(stage, f"{out_prefix}-footprint.json"), "w") as f:
     json.dump(footprint, f, indent=2)
 
 def gib(v):
@@ -205,7 +247,7 @@ section = [
 ]
 # Append so it lands under the harness's summary; if the harness died before writing one,
 # this creates the file so the CI step summary still shows the environment numbers.
-with open(os.path.join(stage, "serve-stress-alpine-summary.md"), "a") as f:
+with open(os.path.join(stage, f"{out_prefix}-summary.md"), "a") as f:
     f.write("\n".join(section))
 print("\n".join(section))
 EOF


### PR DESCRIPTION
## Summary
- Add `serve-stress-alpine-real.yml`: daily cron (14:30 UTC) running the small/medium/bazel real-repo matrix inside the same Alpine musl / 8 GiB / 2 CPU container as the hermetic alpine stress job
- Teach `serve_stress_alpine.sh` to accept `REAL_*` / `OUT_PREFIX` env so hermetic and real modes share the musl + cgroup footprint path
- Install `ca-certificates` in the container for HTTPS clones; cross-link the sibling hermetic/glibc workflows

## Test plan
- [ ] Dispatch **Serve Stress (Alpine 8 GiB, real repos)** from Actions with the `small` leg (or full matrix) and confirm clone + stress + footprint artifacts upload
- [ ] Confirm hermetic **Serve Stress (Alpine 8 GiB)** still runs unchanged via workflow_dispatch (`quick=true`)
- [ ] Spot-check cron offsets: alpine-real at 14:30 UTC does not overlap serve-stress / real / alpine / format crons


Made with [Cursor](https://cursor.com)