### PR TITLE
ci: bump E2ETest timeout to eternal

### DIFF
--- a/cli/BUILD
+++ b/cli/BUILD
@@ -212,7 +212,9 @@ kt_jvm_test(
 
 kt_jvm_test(
     name = "E2ETest",
-    timeout = "long",
+    # "eternal": the suite runs ~1150s on CI's macos-latest x bazel 8.x cell,
+    # right at the "long" ceiling, so slow-runner jitter was timing it out.
+    timeout = "eternal",
     data = [":workspaces"],
     test_class = "com.bazel_diff.e2e.E2ETest",
     runtime_deps = [":cli-test-lib"],


### PR DESCRIPTION
## Summary
- Bump `//cli:E2ETest` Bazel timeout from `long` (15m) to `eternal` (60m)
- Stops flakes on CI's macos-latest × bazel 8.x cell where the suite runs ~1150s and slow-runner jitter hits the 1200s ceiling

## Test plan
- [ ] Confirm CI `test-jre21` matrix (especially macos-latest × bazel 8.x) no longer times out `E2ETest`
- [ ] Spot-check that other matrix cells still pass with the longer budget


Made with [Cursor](https://cursor.com)