### PR TITLE
ci: stage target-repo Bazel for Alpine real-repo stress

### DIFF
--- a/.github/workflows/serve-stress-alpine-real.yml
+++ b/.github/workflows/serve-stress-alpine-real.yml
@@ -7,6 +7,12 @@ name: Serve Stress (Alpine 8 GiB, real repos)
 # query` cost land under the memory/CPU cap -- signals the glibc serve-stress-real.yml runners
 # never produce on large trees.
 #
+# Bazel binary staging: peek the matrix repo's .bazelversion on the host. A concrete X.Y.Z pin
+# (e.g. bazelbuild/bazel.git -> 9.2.0) is downloaded as bazel-glibc so `bazel query` can parse
+# that tree's BUILD files -- matching serve-stress-real.yml's bazelisk-honors-clone-.bazelversion
+# intent. Floating pins (skylib's "8.x") or a missing file fall back to bazel-diff's
+# .bazelversion so those legs keep today's known-good binary without needing bazelisk under musl.
+#
 # Matrix / targets match serve-stress-real.yml (small / medium / bazel). fail-fast:false so a
 # slow or OOM'd leg still yields comparison data from the others. Each leg gets a 150-min
 # timeout (longer than the glibc real cron: cold query + 2-CPU starvation). If daily runner
@@ -72,7 +78,31 @@ jobs:
           cp bazel-bin/cli/bazel-diff_deploy.jar "$STAGE/bazel-diff.jar"
           cp tools/serve_stress.py tools/serve_harness.py tools/serve_stress_alpine.sh "$STAGE/tools/"
           cp .bazelversion "$STAGE/"
-          BV=$(cat .bazelversion)
+          FALLBACK_BV=$(tr -d '[:space:]' < .bazelversion)
+
+          # Sparse-peek the target repo's .bazelversion so we can stage a Bazel that can parse
+          # its BUILD files (bazel.git HEAD needs 9.x). Download stays on the glibc host so the
+          # 8 GiB Alpine cgroup does not pay for the release fetch.
+          PEEK=$(mktemp -d)
+          TARGET_BV=""
+          if git clone --depth=1 --filter=blob:none --sparse "${{ matrix.repo }}" "$PEEK"; then
+            git -C "$PEEK" sparse-checkout set .bazelversion || true
+            if [ -f "$PEEK/.bazelversion" ]; then
+              TARGET_BV=$(tr -d '[:space:]' < "$PEEK/.bazelversion")
+            fi
+          else
+            echo "WARN: could not peek ${{ matrix.repo }}; using fallback Bazel $FALLBACK_BV"
+          fi
+          rm -rf "$PEEK"
+
+          # Concrete X.Y.Z only — floating pins (e.g. skylib's "8.x") keep the fallback.
+          if echo "$TARGET_BV" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            BV="$TARGET_BV"
+            echo "Staging target-repo Bazel $BV (from ${{ matrix.repo }} .bazelversion)"
+          else
+            BV="$FALLBACK_BV"
+            echo "Staging fallback Bazel $BV (target .bazelversion=${TARGET_BV:-missing})"
+          fi
           curl -fsSL -o "$STAGE/bazel-glibc" \
             "https://github.com/bazelbuild/bazel/releases/download/${BV}/bazel-${BV}-linux-x86_64"
           chmod +x "$STAGE/bazel-glibc"

--- a/tools/serve_stress_alpine.sh
+++ b/tools/serve_stress_alpine.sh
@@ -13,10 +13,16 @@
 # path-independent -- the script locates it from $0):
 #
 #   <stage>/bazel-diff.jar            the //cli:bazel-diff_deploy.jar built on the glibc host
-#   <stage>/bazel-glibc               the official bazel release binary matching .bazelversion
+#   <stage>/bazel-glibc               the official bazel release binary (see version note below)
 #   <stage>/.bazelversion             copied into fabricated workspaces (harness expects it)
 #   <stage>/tools/serve_stress.py     the harness + its shared plumbing + this script
 #   <stage>/tools/serve_harness.py
+#
+# bazel-glibc version: hermetic serve-stress-alpine.yml stages bazel-diff's .bazelversion so
+# numbers compare cleanly across hermetic pipelines. serve-stress-alpine-real.yml may instead
+# stage the *target repo's* concrete X.Y.Z pin (peeked on the host) when that repo needs a
+# newer Bazel to parse its BUILD files; floating/missing pins still fall back to bazel-diff's
+# pin. Either way this script just probes and runs whatever binary was staged.
 #
 # Building bazel-diff *inside* Alpine would require a full glibc Bazel toolchain to work under
 # musl -- the most fragile possible path -- so the jar is built on the host and only *run* here,
@@ -26,8 +32,9 @@
 # query before the 30+ minute harness commits to it:
 #
 #   1. the official release binary under gcompat (glibc shim), with the server JVM redirected to
-#      the musl OpenJDK via a system bazelrc (`startup --server_javabase=...`) -- this keeps the
-#      bazel *version* identical to the other stress pipelines, so numbers compare cleanly;
+#      the musl OpenJDK via a system bazelrc (`startup --server_javabase=...`) -- hermetic runs
+#      keep this version identical to the other stress pipelines; real-repo runs may use the
+#      target's concrete pin (still under the same gcompat + server_javabase path);
 #   2. a musl-native bazel from the Alpine package repos (version may lag; recorded as the
 #      "flavor" in the footprint JSON so runs remain interpretable).
 #


### PR DESCRIPTION
## Summary
- Alpine real-repo stress was staging bazel-diff's Bazel 8.5.1 for every matrix leg, so the `bazelbuild/bazel.git` leg failed `bazel query` on BUILD files that need Bazel 9+ (`exec_group_compatible_with` → exit 7 / HTTP 500).
- Peek the matrix repo's `.bazelversion` on the host and download a concrete `X.Y.Z` release when present (bazel.git → 9.2.0); floating pins (skylib `8.x`) or missing files still fall back to bazel-diff's pin.
- Aligns Alpine real-repo staging with `serve-stress-real.yml`'s bazelisk-honors-clone-`.bazelversion` intent without pulling bazelisk into the musl container.

## Test plan
- [ ] `workflow_dispatch` **Serve Stress (Alpine 8 GiB, real repos)** after merge (or on this branch if the workflow runs from PRs)
- [ ] Confirm bazel leg stages target-repo Bazel 9.x and cold/hot/lock-heal impacted requests return 200
- [ ] Confirm small (skylib `8.x`) and medium (abseil, no pin) still stage the fallback and stay green


Made with [Cursor](https://cursor.com)