### PR TITLE
Ship multi-platform Rust CLI binaries on GitHub Releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 # Cut a release whenever a new tag is pushed or via workflow_dispatch.
 # Uses bazel-contrib release ruleset: build, attest, and publish to GitHub Releases.
+# A separate matrix job attaches host-native Rust CLI binaries to the draft release.
 name: Release
 on:
   workflow_dispatch:
@@ -35,8 +36,73 @@ jobs:
       tag_name: ${{ inputs.tag_name || github.ref_name }}
     secrets:
       BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+  rust-binaries:
+    needs: release
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset: bazel-diff-rust-linux-amd64
+            bazel_extra_flags: ""
+          - os: macos-latest
+            asset: bazel-diff-rust-macos-arm64
+            bazel_extra_flags: ""
+          - os: windows-latest
+            asset: bazel-diff-rust-windows-amd64.exe
+            bazel_extra_flags: "--legacy_external_runfiles"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name || github.ref_name }}
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: ^1.17
+      - name: Setup Bazelisk (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: |
+          go install github.com/bazelbuild/bazelisk@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Setup Bazelisk (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          go install github.com/bazelbuild/bazelisk@latest
+          echo "$(go env GOPATH)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Build Rust binary
+        shell: bash
+        run: |
+          bazelisk build //:bazel-diff-rust -c opt \
+            --cxxopt=-std=c++17 \
+            --host_cxxopt=-std=c++17 \
+            ${{ matrix.bazel_extra_flags }}
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            src="bazel-bin/src/bazel-diff.exe"
+          else
+            src="bazel-bin/src/bazel-diff"
+          fi
+          cp "$src" "${{ matrix.asset }}"
+      - name: Upload release asset
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag_name || github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$TAG" "${{ matrix.asset }}" \
+            --clobber \
+            --repo "$GITHUB_REPOSITORY"
   finalize:
-    needs: publish
+    needs: [publish, rust-binaries]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -12,10 +12,6 @@ make release_deploy_jar &> /dev/null
 
 cp bazel-bin/cli/bazel-diff_deploy.jar archives/bazel-diff_deploy.jar
 
-make release_rust_binary &> /dev/null
-
-cp bazel-bin/src/bazel-diff archives/bazel-diff-rust
-
 SHA=$(shasum -a 256 archives/release.tar.gz | awk '{print $1}')
 
 cat << EOF
@@ -38,4 +34,12 @@ http_archive(
   url = "https://github.com/Tinder/bazel-diff/releases/download/${TAG}/release.tar.gz",
 )
 \`\`\`
+
+## Experimental Rust binary
+
+Prebuilt host-native CLIs (attached by the release workflow):
+
+- Linux amd64: https://github.com/Tinder/bazel-diff/releases/download/${TAG}/bazel-diff-rust-linux-amd64
+- macOS arm64: https://github.com/Tinder/bazel-diff/releases/download/${TAG}/bazel-diff-rust-macos-arm64
+- Windows amd64: https://github.com/Tinder/bazel-diff/releases/download/${TAG}/bazel-diff-rust-windows-amd64.exe
 EOF

--- a/README.md
+++ b/README.md
@@ -913,6 +913,22 @@ implementation remains the default `//:bazel-diff` target and the released JAR.
 bazel run //:bazel-diff-rust -- --help
 ```
 
+GitHub Releases also ship prebuilt host-native binaries:
+
+```terminal
+# Linux amd64
+curl -Lo bazel-diff-rust https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff-rust-linux-amd64
+chmod +x bazel-diff-rust
+
+# macOS arm64
+curl -Lo bazel-diff-rust https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff-rust-macos-arm64
+chmod +x bazel-diff-rust
+```
+
+Windows amd64: download
+`bazel-diff-rust-windows-amd64.exe` from the
+[latest release](https://github.com/Tinder/bazel-diff/releases/latest).
+
 ## Code coverage
 
 CI enforces a minimum **90% line coverage** on production sources. Kotlin

--- a/tools/readme_template.md
+++ b/tools/readme_template.md
@@ -453,6 +453,22 @@ implementation remains the default `//:bazel-diff` target and the released JAR.
 bazel run //:bazel-diff-rust -- --help
 ```
 
+GitHub Releases also ship prebuilt host-native binaries:
+
+```terminal
+# Linux amd64
+curl -Lo bazel-diff-rust https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff-rust-linux-amd64
+chmod +x bazel-diff-rust
+
+# macOS arm64
+curl -Lo bazel-diff-rust https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff-rust-macos-arm64
+chmod +x bazel-diff-rust
+```
+
+Windows amd64: download
+`bazel-diff-rust-windows-amd64.exe` from the
+[latest release](https://github.com/Tinder/bazel-diff/releases/latest).
+
 ## Code coverage
 
 CI enforces a minimum **90% line coverage** on production sources. Kotlin


### PR DESCRIPTION
## Summary
- Add a release-matrix job that builds and uploads host-native Rust CLIs for Linux amd64, macOS arm64, and Windows amd64 onto the draft GitHub Release
- Stop building the unused single-host `archives/bazel-diff-rust` in release prep; document the new download URLs in release notes and the README

## Test plan
- [ ] Confirm Release workflow YAML is valid (Actions UI parses / workflow runs on this PR if any path filters allow)
- [ ] After merge, cut a test tag (or `workflow_dispatch`) and verify the draft release receives:
  - `bazel-diff-rust-linux-amd64`
  - `bazel-diff-rust-macos-arm64`
  - `bazel-diff-rust-windows-amd64.exe`
- [ ] Confirm `finalize` waits for both BCR publish and rust-binaries before undrafting
- [ ] Spot-check that each binary runs `--help` on its platform


Made with [Cursor](https://cursor.com)