### PR TITLE
Cache external repository resolution and parallelize query decode (#457)

### DIFF
--- a/src/bazel.rs
+++ b/src/bazel.rs
@@ -4,10 +4,11 @@ use crate::proto::blaze_query::{
 };
 use anyhow::{anyhow, bail, Context, Result};
 use buffa::Message;
+use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tempfile::NamedTempFile;
@@ -475,20 +476,107 @@ pub fn decode_delimited<M: Message>(path: &Path) -> Result<Vec<M>> {
     Ok(messages)
 }
 
+/// Upper bounds on one decode batch. Batching keeps peak memory proportional to
+/// the batch rather than to the whole query output, which for a large workspace
+/// is gigabytes.
+const DECODE_BATCH_MESSAGES: usize = 8192;
+const DECODE_BATCH_BYTES: usize = 32 * 1024 * 1024;
+
+/// Raw, still-encoded messages read off the stream, kept in one contiguous
+/// buffer so a batch costs one allocation rather than one per message.
+#[derive(Default)]
+struct RawBatch {
+    buffer: Vec<u8>,
+    bounds: Vec<(usize, usize)>,
+}
+
+impl RawBatch {
+    fn clear(&mut self) {
+        self.buffer.clear();
+        self.bounds.clear();
+    }
+
+    fn slices(&self) -> impl IndexedParallelIterator<Item = &[u8]> {
+        self.bounds
+            .par_iter()
+            .map(|(start, end)| &self.buffer[*start..*end])
+    }
+}
+
+/// Reads a length-delimited varint prefix, returning `None` at end of stream.
+fn read_message_length(reader: &mut impl BufRead) -> Result<Option<usize>> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let available = reader.fill_buf()?;
+        let Some(byte) = available.first().copied() else {
+            if shift == 0 {
+                return Ok(None);
+            }
+            bail!("truncated length prefix in Bazel query output");
+        };
+        reader.consume(1);
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return usize::try_from(value)
+                .map(Some)
+                .map_err(|_| anyhow!("length prefix {value} does not fit in usize"));
+        }
+        shift += 7;
+        if shift >= 64 {
+            bail!("length prefix in Bazel query output overflows a u64");
+        }
+    }
+}
+
+/// Fills `batch` with up to the batch limits worth of encoded messages,
+/// returning false once the stream is exhausted.
+fn read_raw_batch(reader: &mut impl BufRead, batch: &mut RawBatch) -> Result<bool> {
+    batch.clear();
+    while batch.bounds.len() < DECODE_BATCH_MESSAGES && batch.buffer.len() < DECODE_BATCH_BYTES {
+        let Some(length) = read_message_length(reader)? else {
+            break;
+        };
+        let start = batch.buffer.len();
+        batch.buffer.reserve(length);
+        let copied = std::io::copy(
+            &mut reader.take(length as u64),
+            &mut &mut batch.buffer as &mut dyn std::io::Write,
+        )?;
+        if copied != length as u64 {
+            bail!("truncated message in Bazel query output");
+        }
+        batch.bounds.push((start, batch.buffer.len()));
+    }
+    Ok(!batch.bounds.is_empty())
+}
+
 fn decode_target_stream(
     path: &Path,
     transform: &mut impl FnMut(&mut Target),
 ) -> Result<Vec<Target>> {
-    let mut reader = BufReader::new(File::open(path)?);
+    let mut reader = BufReader::with_capacity(1 << 20, File::open(path)?);
     let mut targets = Vec::new();
-    loop {
-        if reader.fill_buf()?.is_empty() {
-            break;
-        }
-        let target = buffa::DecodeOptions::new().decode_length_delimited_reader(&mut reader)?;
-        if let Some(mut target) = lower_target(target) {
-            transform(&mut target);
-            targets.push(target);
+    let mut batch = RawBatch::default();
+    // Decoding dominates this phase and is independent per message, so each
+    // batch is decoded in parallel. `transform` stays sequential: callers use it
+    // to accumulate into shared state, and it is the cheaper half.
+    let mut decoded = Vec::new();
+    while read_raw_batch(&mut reader, &mut batch)? {
+        batch
+            .slices()
+            .map(|bytes| {
+                <Target as Message>::decode_from_slice(bytes)
+                    .map_err(anyhow::Error::from)
+                    .map(lower_target)
+            })
+            .collect_into_vec(&mut decoded);
+        targets.reserve(decoded.len());
+        for lowered in decoded.drain(..) {
+            if let Some(mut target) = lowered? {
+                transform(&mut target);
+                targets.push(target);
+            }
         }
     }
     Ok(targets)
@@ -1036,6 +1124,59 @@ mod tests {
             target_name(&decode_cquery_stream(&non_streamed, false, &mut |_| {}).unwrap()[0]),
             Some("//c:c")
         );
+    }
+
+    #[test]
+    fn read_message_length_parses_varints_and_rejects_bad_prefixes() {
+        assert_eq!(read_message_length(&mut [].as_slice()).unwrap(), None);
+        assert_eq!(read_message_length(&mut [0x05].as_slice()).unwrap(), Some(5));
+        // 300 encodes as two continuation-flagged bytes.
+        assert_eq!(
+            read_message_length(&mut [0xAC, 0x02].as_slice()).unwrap(),
+            Some(300)
+        );
+        // Continuation bit set with nothing following.
+        assert!(read_message_length(&mut [0x80].as_slice()).is_err());
+        // Never-terminating prefix overflows the shift.
+        assert!(read_message_length(&mut [0x80; 10].as_slice()).is_err());
+    }
+
+    #[test]
+    fn decode_target_stream_preserves_order_across_batches() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("query.pb");
+        let written = (0..DECODE_BATCH_MESSAGES + 5)
+            .map(|index| rule_target(&format!("//pkg:target{index}")))
+            .collect::<Vec<_>>();
+        write_delimited(&path, &written);
+        let mut seen = Vec::new();
+        let decoded = decode_target_stream(&path, &mut |target| {
+            seen.push(target_name(target).unwrap().to_owned())
+        })
+        .unwrap();
+        assert_eq!(decoded.len(), written.len());
+        // Order must survive the batch boundary in both the returned targets and
+        // the sequence `transform` observes.
+        let expected = (0..written.len())
+            .map(|index| format!("//pkg:target{index}"))
+            .collect::<Vec<_>>();
+        assert_eq!(seen, expected);
+        assert_eq!(
+            decoded
+                .iter()
+                .map(|target| target_name(target).unwrap().to_owned())
+                .collect::<Vec<_>>(),
+            expected
+        );
+    }
+
+    #[test]
+    fn decode_target_stream_rejects_truncated_message() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("truncated.pb");
+        // A length prefix of 16 followed by only two bytes of payload.
+        fs::write(&path, [0x10u8, 0x00, 0x00]).unwrap();
+        assert!(decode_target_stream(&path, &mut |_| {}).is_err());
     }
 
     #[test]

--- a/src/bazel.rs
+++ b/src/bazel.rs
@@ -1129,7 +1129,10 @@ mod tests {
     #[test]
     fn read_message_length_parses_varints_and_rejects_bad_prefixes() {
         assert_eq!(read_message_length(&mut [].as_slice()).unwrap(), None);
-        assert_eq!(read_message_length(&mut [0x05].as_slice()).unwrap(), Some(5));
+        assert_eq!(
+            read_message_length(&mut [0x05].as_slice()).unwrap(),
+            Some(5)
+        );
         // 300 encodes as two continuation-flagged bytes.
         assert_eq!(
             read_message_length(&mut [0xAC, 0x02].as_slice()).unwrap(),

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -14,7 +14,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::rc::Rc;
-use std::sync::OnceLock;
+use std::sync::{Arc, Mutex, OnceLock};
 
 const CONFIGURED_INPUT_SEPARATOR: char = '|';
 type DigestBytes = [u8; 32];
@@ -837,11 +837,20 @@ fn owner_executable(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct ExternalRepoResolver {
     workspace: PathBuf,
     bazel: PathBuf,
     output_base: PathBuf,
+    startup_options: Vec<String>,
+    no_bazelrc: bool,
+    /// Memoizes resolution per apparent repository name. `resolve` is called once
+    /// per external source file and can shell out to Bazel, so without this a
+    /// repository with N source files costs N Bazel invocations, all of which
+    /// serialize on the Bazel server lock.
+    resolved: Arc<Mutex<HashMap<String, PathBuf>>>,
+    /// Lazily populated apparent -> canonical repository name mapping.
+    repo_mapping: Arc<OnceLock<HashMap<String, String>>>,
 }
 
 impl ExternalRepoResolver {
@@ -863,18 +872,63 @@ impl ExternalRepoResolver {
             workspace: options.workspace.clone(),
             bazel: options.bazel.clone(),
             output_base: PathBuf::from(String::from_utf8_lossy(&output.stdout).trim()),
+            startup_options: options.startup_options.clone(),
+            no_bazelrc: options.no_bazelrc,
+            ..Default::default()
         })
     }
 
+    /// Builds a Bazel command carrying the same startup options `new` used, so
+    /// follow-up invocations reach the same server and output base.
+    fn command(&self) -> Command {
+        let mut command = Command::new(&self.bazel);
+        command.current_dir(&self.workspace);
+        if self.no_bazelrc {
+            command.arg(if cfg!(windows) {
+                "--bazelrc=NUL"
+            } else {
+                "--bazelrc=/dev/null"
+            });
+        }
+        command.args(&self.startup_options);
+        command
+    }
+
     fn resolve(&self, repo: &str) -> Result<PathBuf> {
+        // The lock is held across resolution so that concurrent hashing threads
+        // missing the same repository do not each shell out to Bazel.
+        let mut resolved = self
+            .resolved
+            .lock()
+            .map_err(|_| anyhow!("external repository cache was poisoned"))?;
+        if let Some(root) = resolved.get(repo) {
+            return Ok(root.clone());
+        }
+        let root = self.resolve_uncached(repo)?;
+        resolved.insert(repo.to_owned(), root.clone());
+        Ok(root)
+    }
+
+    fn resolve_uncached(&self, repo: &str) -> Result<PathBuf> {
         let external = self.output_base.join("external");
         for candidate in [external.join(repo), external.join(format!("{repo}+"))] {
             if candidate.exists() {
                 return Ok(candidate);
             }
         }
-        let output = Command::new(&self.bazel)
-            .current_dir(&self.workspace)
+        // Under Bzlmod the directory is named after the canonical repository name
+        // (`rules_req_compile++requirements+pip_deps`), which neither candidate
+        // above guesses. `bazel mod dump_repo_mapping` reports that name directly
+        // and is one invocation for every repository, so prefer it over the
+        // `bazel query` fallback below.
+        if let Some(canonical) = self.repo_mapping().get(repo) {
+            let candidate = external.join(canonical);
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+        let output = self
+            .command()
             .arg("query")
             .arg(format!("@{repo}//..."))
             .arg("--keep_going")
@@ -898,6 +952,50 @@ impl ExternalRepoResolver {
         }
         Ok(external.join(repo))
     }
+
+    /// Returns the main repository's apparent -> canonical repository mapping,
+    /// fetching it at most once. An empty map means the mapping was unavailable
+    /// (for example a WORKSPACE-only build), leaving the `bazel query` fallback.
+    fn repo_mapping(&self) -> &HashMap<String, String> {
+        self.repo_mapping.get_or_init(|| {
+            let output = self
+                .command()
+                .arg("mod")
+                .arg("dump_repo_mapping")
+                .arg("")
+                .stdin(Stdio::null())
+                .output();
+            match output {
+                Ok(output) if output.status.success() => {
+                    parse_apparent_repo_mapping(&String::from_utf8_lossy(&output.stdout))
+                }
+                _ => HashMap::new(),
+            }
+        })
+    }
+}
+
+/// Parses `bazel mod dump_repo_mapping` output, one JSON object of apparent ->
+/// canonical repository names per line, into a flat map.
+fn parse_apparent_repo_mapping(text: &str) -> HashMap<String, String> {
+    let mut mapping = HashMap::new();
+    for line in text.lines() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+            continue;
+        };
+        let Some(entries) = value.as_object() else {
+            continue;
+        };
+        for (apparent, canonical) in entries {
+            let Some(canonical) = canonical.as_str() else {
+                continue;
+            };
+            if !apparent.is_empty() && !canonical.is_empty() {
+                mapping.insert(apparent.clone(), canonical.to_owned());
+            }
+        }
+    }
+    mapping
 }
 
 trait HashingCommand {
@@ -972,6 +1070,7 @@ mod tests {
                 workspace: options.bazel.workspace.clone(),
                 bazel: options.bazel.bazel.clone(),
                 output_base: output_base.to_path_buf(),
+                ..Default::default()
             },
             Some(r#"{"name":"root"}"#.to_owned()),
         )
@@ -1505,10 +1604,115 @@ mod tests {
             workspace: workspace.path().to_path_buf(),
             bazel: PathBuf::from("bazel"),
             output_base,
+            ..Default::default()
         };
         assert_eq!(
             resolver.resolve("existing").unwrap(),
             external.join("existing+")
+        );
+    }
+
+    /// A stub `bazel` that appends its argv to `log` and prints `stdout`.
+    #[cfg(unix)]
+    fn stub_bazel(directory: &Path, log: &Path, stdout: &str) -> PathBuf {
+        let script = directory.join("stub-bazel");
+        fs::write(
+            &script,
+            format!(
+                "#!/bin/sh\necho \"$@\" >> {log}\ncat <<'STUB_EOF'\n{stdout}\nSTUB_EOF\n",
+                log = log.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+        script
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_repo_resolver_uses_repo_mapping_and_resolves_once() {
+        let workspace = tempfile::tempdir().unwrap();
+        let output_base = workspace.path().join("output");
+        let external = output_base.join("external");
+        // Only the canonical directory exists, as under Bzlmod.
+        let canonical = external.join("rules_req_compile++requirements+pip_deps");
+        fs::create_dir_all(&canonical).unwrap();
+        let log = workspace.path().join("bazel.log");
+        let bazel = stub_bazel(
+            workspace.path(),
+            &log,
+            r#"{"pip_deps": "rules_req_compile++requirements+pip_deps"}"#,
+        );
+        let resolver = ExternalRepoResolver {
+            workspace: workspace.path().to_path_buf(),
+            bazel,
+            output_base,
+            ..Default::default()
+        };
+
+        for _ in 0..5 {
+            assert_eq!(resolver.resolve("pip_deps").unwrap(), canonical);
+        }
+
+        // One `mod dump_repo_mapping`, and no `query` fallback, for five lookups.
+        let invocations = fs::read_to_string(&log).unwrap();
+        assert_eq!(
+            invocations.lines().collect::<Vec<_>>(),
+            ["mod dump_repo_mapping "]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_repo_resolver_falls_back_to_query_and_caches_misses() {
+        let workspace = tempfile::tempdir().unwrap();
+        let output_base = workspace.path().join("output");
+        let external = output_base.join("external");
+        fs::create_dir_all(external.join("queried+1.0")).unwrap();
+        let log = workspace.path().join("bazel.log");
+        // The mapping has no entry for `queried`, so resolution falls through to
+        // `bazel query`; the stub answers both with the same location line.
+        let bazel = stub_bazel(
+            workspace.path(),
+            &log,
+            &format!(
+                "{}/queried+1.0/pkg/BUILD:1:1: source file @queried//pkg:BUILD",
+                external.display()
+            ),
+        );
+        let resolver = ExternalRepoResolver {
+            workspace: workspace.path().to_path_buf(),
+            bazel,
+            output_base,
+            startup_options: vec!["--max_idle_secs=17".to_owned()],
+            ..Default::default()
+        };
+
+        for _ in 0..3 {
+            assert_eq!(
+                resolver.resolve("queried").unwrap(),
+                external.join("queried+1.0")
+            );
+        }
+
+        let invocations = fs::read_to_string(&log).unwrap();
+        assert_eq!(
+            invocations.lines().collect::<Vec<_>>(),
+            [
+                "--max_idle_secs=17 mod dump_repo_mapping ",
+                "--max_idle_secs=17 query @queried//... --keep_going --output location",
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_apparent_repo_mapping_skips_unusable_entries() {
+        let mapping = parse_apparent_repo_mapping(
+            "not json\n{\"apparent\": \"canonical+1.0\", \"\": \"skipped\", \"empty\": \"\", \"wrong_type\": 7}\n[\"not an object\"]\n",
+        );
+        assert_eq!(
+            mapping,
+            HashMap::from([("apparent".to_owned(), "canonical+1.0".to_owned())])
         );
     }
 
@@ -1523,6 +1727,7 @@ mod tests {
             workspace: workspace.path().to_path_buf(),
             bazel: PathBuf::from("bazel"),
             output_base: workspace.path().join("output"),
+            ..Default::default()
         };
         let modified = BTreeSet::new();
         let hasher = SourceHasher {
@@ -1562,6 +1767,7 @@ mod tests {
             workspace: workspace.path().to_path_buf(),
             bazel: PathBuf::from("bazel"),
             output_base: workspace.path().join("output"),
+            ..Default::default()
         };
         let modified = BTreeSet::new();
         let hasher = SourceHasher {
@@ -1615,6 +1821,7 @@ mod tests {
             workspace: workspace.path().to_path_buf(),
             bazel: PathBuf::from("bazel"),
             output_base: workspace.path().join("output"),
+            ..Default::default()
         };
         let modified = BTreeSet::new();
         let hasher = SourceHasher {
@@ -1665,6 +1872,7 @@ mod tests {
             workspace: workspace.path().to_path_buf(),
             bazel: PathBuf::from("bazel"),
             output_base: workspace.path().join("output"),
+            ..Default::default()
         };
         let modified = BTreeSet::new();
         let hasher = SourceHasher {


### PR DESCRIPTION
Applies the two fixes proposed in #457, validated independently with the performance harness from #459 (baseline binary in the reference slot, patched binary in the candidate slot, so the gate's output-parity check doubles as proof the fixes do not change emitted hashes).

## Cache external repository resolution (`src/hash.rs`)

`ExternalRepoResolver::resolve` had no memoization and guessed only `external/<repo>` and `external/<repo>+`, which both miss under Bzlmod where the directory carries the canonical repository name (e.g. `rules_req_compile++requirements+pip_deps`). Every miss shelled out to `bazel query @<repo>//... --output location` — once per external source file, serialized on the Bazel server lock — and that fallback ran a bare `bazel` without the configured startup options, so under `--bazelStartupOptions=--output_base=...` it queried a different output base than the one it resolved paths against.

This change memoizes resolution per apparent repository name, answers canonical names from a single `bazel mod dump_repo_mapping` invocation, keeps the `bazel query` fallback for WORKSPACE-only builds, and gives that fallback the startup options the resolver was constructed with.

Measured on a hermetic fixture with 400 `@pip_deps//` source files living only under the canonical directory (replay `bazel` shim logging every invocation):

| | before | after |
|---|---|---|
| nested `query ... --output location` invocations | 400 (one per file) | **0** |
| `mod dump_repo_mapping` invocations | 0 | 1 |
| fallback queries carrying `--output_base` | 0 of 400 | n/a |
| wall time (free stub bazel) | 0.358 s | 0.033 s |
| wall time (50 ms per nested invocation) | 5.61 s | 0.034 s |
| emitted hashes | — | identical |

The invocation counts reproduce #457's mechanism exactly (709 nested queries → 0 in the reporter's repository); with real per-invocation Bazel cost the before-time scales linearly with external source files, consistent with the reported 300 s → 2.4 s.

## Decode Bazel query output in parallel (`src/bazel.rs`)

`decode_target_stream` decoded one message at a time off a default 8 KiB `BufReader`, entirely on one thread. This change reads length-delimited messages into bounded batches (8192 messages / 32 MB), decodes each batch across the Rayon pool, walks the decoded batch in stream order (`transform` stays sequential because callers accumulate into shared state), and raises the reader buffer to 1 MiB.

Measured with the #459 gate (4 CPUs, 7 interleaved rounds, ~48k-target graph): 1.04–1.08x end-to-end on generate-hashes with hashes identical in every round, peak RSS unchanged within 4% (115 MB → 119 MB), and no movement outside noise on the diff workloads the change does not touch. #457 reports 1.4x on the query-parse phase alone for a 1.05 GB / 576k-target stream.

## Tests

Both patches ship unit tests (repo-mapping resolution and caching, fallback startup options, mapping parser, varint edge cases, order preservation across batch boundaries, truncated-input rejection). Full lib suite: 81 passed.

Credit to @BarrettStephen for the diagnosis and both patches in #457.

Closes #457


