### PR TITLE
Run clippy on every Bazel build via the rules_rust aspect

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,15 @@ build:windows --host_cxxopt=/std:c++17
 common --incompatible_strict_action_env
 common --test_env=PATH
 
+# Lint first-party Rust crates with clippy on every build so issues surface
+# immediately instead of waiting for the `cargo clippy` pass in CI. The aspect
+# only attaches to rules_rust targets (required_providers gates it), skips
+# external crates, and turns warnings into errors by default — matching the
+# `cargo clippy -- -D warnings` gate in ci.yaml. Opt a target out with
+# tags = ["no-clippy"].
+build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
+build --output_groups=+clippy_checks
+
 # Coverage runs use the Rust LCOV merger from //tools/coverage instead of
 # Bazel's built-in one. Besides merging each test's raw tracefiles into its
 # coverage.dat, it enforces the per-target line-coverage minimums declared

--- a/tools/coverage/src/enforce.rs
+++ b/tools/coverage/src/enforce.rs
@@ -103,7 +103,7 @@ pub fn check(report: &Report, config: &Config) -> Outcome {
 
     let mut text = String::new();
     let _ = writeln!(text, "{:>8}  {:>17}  FILE", "COV%", "LINES (hit/total)");
-    rows.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap().then(a.3.cmp(&b.3)));
+    rows.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap().then(a.3.cmp(b.3)));
     for (pct, hit, found, path) in &rows {
         let _ = writeln!(text, "{pct:>7.2}%  {hit:>7} / {found:<7}  {path}");
     }


### PR DESCRIPTION
## What changed

- `.bazelrc` now applies `@rules_rust//rust:defs.bzl%rust_clippy_aspect` (plus the `clippy_checks` output group) on the `build` command, so every `bazel build`/`test`/`run`/`coverage` invocation lints first-party Rust crates immediately.
- Fixed the one lint the aspect surfaced on its first run: a `needless_borrow` in `tools/coverage/src/enforce.rs`.

## Why

Clippy previously only ran as a `cargo clippy --all-targets -- -D warnings` step in CI, so lint issues weren't caught during local Bazel development — and crates outside the Cargo workspace were never linted at all. The `enforce.rs` fix in this PR is a live example: `tools/coverage` is Bazel-only, so the cargo pass never saw it.

The aspect matches the existing CI bar: it denies warnings by default (`-Dwarnings`), only attaches to rules_rust targets via `required_providers`, and skips external crate_universe crates. A target can opt out with `tags = ["no-clippy"]`. CI's Bazel jobs pick this up automatically through `.bazelrc`, so no workflow changes are needed. The cargo clippy CI step stays, since it covers things Bazel doesn't build (`tests/e2e`, `build.rs` via cargo).

## Verification

- `bazel build //src:all //tools/coverage:all` passes with `.clippy.ok` markers produced for all seven first-party crates (libs, bins, and test targets).
- A seeded `clone_on_copy` warning fails the build immediately (then reverted).
- Non-Rust targets (`//:license`), `bazel run --script_path //:bazel-diff-rust`, and `cquery` — the paths `bazel-diff-example.sh` exercises — are unaffected.
- The aspect loads and analyzes cleanly under Bazel 7.x and 9.x (`build --nobuild`); everything else ran on the pinned 8.5.1. `MODULE.bazel.lock` stays clean under the pinned version.
- `//tools/coverage:lcov_merger_test` passes after the lint fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)