### PR TITLE
ci: turn the orphaned deploy job into a release-artifacts check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,13 +259,23 @@ jobs:
           $prevRev = git rev-parse HEAD~1
           $currRev = git rev-parse HEAD
           .\bazel-diff-example.ps1 -WorkspacePath "$env:GITHUB_WORKSPACE" -BazelPath "$env:USERPROFILE\go\bin\bazelisk.exe" -PreviousRevision $prevRev -FinalRevision $currRev
-  deploy:
+  # Verifies per-PR that everything a release ships still builds, on every
+  # platform it ships for. It publishes nothing: release.yaml owns that, via
+  # release_prep.sh (JAR + source archive) and its rust-binaries matrix. This
+  # job predates that flow -- it used to *be* the deploy -- so its uploads are
+  # a build check whose output happens to be downloadable, nothing more.
+  release-artifacts:
+    # Explicit name so the status check is stable. Left implicit, GitHub derives
+    # it from every matrix value -- which is how branch protection ended up
+    # requiring `deploy (11)`, a check that stopped existing the moment this job
+    # grew an os/rust_asset matrix. Adding a matrix key must not rename a check.
+    name: release-artifacts (${{ matrix.os }})
     needs: [test-jre21]
     runs-on: ${{ matrix.os }}
     permissions:
+      # Read-only: nothing here attests or publishes. The id-token/attestations
+      # writes this job used to request were left over from the old deploy.
       contents: read
-      id-token: write
-      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -332,9 +342,13 @@ jobs:
           name: bazel-diff_deploy.jar
           path: bazel-bin/cli/bazel-diff_deploy.jar
           if-no-files-found: error
+      # The same script release_prep.sh packs the shipped archive with, so this
+      # check can't pass on an archive the release would not produce. It used to
+      # call `make release_source_archive`, a second tar recipe that had already
+      # drifted (no __pycache__/*.pyc excludes).
       - name: Build release source archive
         if: matrix.upload_jar_and_archive
-        run: make release_source_archive
+        run: .github/workflows/pack_release_archive.sh archives/release.tar.gz
       - uses: actions/upload-artifact@v4
         if: matrix.upload_jar_and_archive
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
+# Delegates rather than repeating the tar invocation: release_prep.sh (release),
+# bcr_consumer.yaml and ci.yaml all pack through this one script, so the archive
+# you get locally is byte-for-byte the recipe that ships. The inlined copy that
+# used to live here had already drifted from it.
+# Note: the script lives under .github/, which the archive itself excludes, so
+# this target only works in a git checkout -- not inside an extracted release.
 .PHONY: release_source_archive
 release_source_archive:
-	mkdir -p archives
-	tar --exclude-vcs \
-		--exclude=bazel-* \
-		--exclude=target \
-		--exclude=.github \
-		--exclude=archives \
-		-zcf "archives/release.tar.gz" .
+	.github/workflows/pack_release_archive.sh archives/release.tar.gz
 
 .PHONY: release_deploy_jar
 release_deploy_jar:


### PR DESCRIPTION
## Summary

The `deploy` job in `ci.yaml` dates from #123, long before #319 moved releasing to the bazel-contrib release ruleset. Since then it has published nothing — no workflow downloads its `bazel-diff_deploy.jar` or `release.tar.gz` (zero `download-artifact` references in `.github/`), and `release_prep.sh` builds the real ones at tag time. This makes the job honest about being a per-PR build check.

- Rename `deploy` → `release-artifacts`, with a comment on what actually owns publishing.
- Drop `id-token: write` / `attestations: write`. Nothing in the job attests; leftovers from when it really was the deploy.
- Pack the source archive with `pack_release_archive.sh` — the same script `release_prep.sh` and `bcr_consumer.yaml` use — instead of `make release_source_archive`. The Makefile copy had **drifted** (no `__pycache__` / `*.pyc` excludes), so the job was verifying an archive releases never produce. `make release_source_archive` now delegates to the script, leaving one tar recipe.
- Give the job an explicit `name:` so its status check is stable.

The multi-platform Rust matrix added in #462 stays as-is: it is what surfaced the Windows `MAX_PATH` failure that `release.yaml` would otherwise have hit at tag time.

## ⚠️ Requires a branch-protection update

`master` currently requires the status check **`deploy (11)`**, which stopped existing the moment #462 gave that job an os matrix — GitHub derives implicit job names from *every* matrix value. That is why this PR adds an explicit name: adding a matrix key should never rename a required check.

After merge, replace `deploy (11)` with:

- `release-artifacts (ubuntu-latest)`
- `release-artifacts (macos-latest)`
- `release-artifacts (windows-latest)`

## Test plan

- [ ] `release-artifacts (ubuntu-latest)` uploads `bazel-diff_deploy.jar` + `release.tar.gz`
- [ ] All three legs still build `//release:bazel-diff-rust` and upload their asset
- [ ] Archive from `pack_release_archive.sh` excludes `__pycache__` / `*.pyc` (verified locally: 3,900 entries, no `.github`)
- [ ] `make release_source_archive` works via the delegated script (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)