### PR TITLE
DO NOT MERGE: validate release-artifacts status check names

### DIFF
--- a/docs/ci-check-validation-scratch.md
+++ b/docs/ci-check-validation-scratch.md
@@ -1,0 +1,6 @@
+# CI check-name validation (throwaway)
+
+Scratch file for a temporary PR that verifies branch protection matches the
+status checks CI actually emits, after `deploy` was renamed to
+`release-artifacts` in #463. Delete this file and close the PR once the
+three `release-artifacts (<os>)` checks report green.


### PR DESCRIPTION
## Purpose

Throwaway draft PR. It exists only to confirm that the status checks CI emits on a master-based branch match the contexts branch protection requires, after #463 renamed the `deploy` job to `release-artifacts`.

Branch protection was updated to require:

- `release-artifacts (ubuntu-latest)`
- `release-artifacts (macos-latest)`
- `release-artifacts (windows-latest)`

replacing four stale `deploy (…)` contexts — one of which was a truncated UI label (`--legacy_...`) that could never have matched a real check name.

## Pass criteria

- [ ] Exactly three `release-artifacts (<os>)` checks appear and pass
- [ ] No check named `deploy (…)` appears
- [ ] The PR reports mergeable rather than blocked

**Close without merging** once green, and delete `docs/ci-check-validation-scratch.md` along with the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)