### PR TITLE
ci: run every Rust validation through Bazel, drop cargo

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,14 +54,18 @@ build:release-musl --platforms=//platforms:linux_x86_64_musl
 common --incompatible_strict_action_env
 common --test_env=PATH
 
-# Lint first-party Rust crates with clippy on every build so issues surface
-# immediately instead of waiting for the `cargo clippy` pass in CI. The aspect
-# only attaches to rules_rust targets (required_providers gates it), skips
-# external crates, and turns warnings into errors by default — matching the
-# `cargo clippy -- -D warnings` gate in ci.yaml. Opt a target out with
-# tags = ["no-clippy"].
+# Lint and format-check first-party Rust crates on every build so issues surface
+# immediately. Both aspects only attach to rules_rust targets (required_providers
+# gates them) and skip external crates. Opt a target out with
+# tags = ["no-clippy"] / tags = ["no-rustfmt"].
+#
+# This is local feedback, not the gate: neither aspect propagates along deps, so
+# it only covers the targets a build names. //:rust_clippy_check and
+# //:rust_format_check are the targets CI runs, and they pin the roots.
 build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build --output_groups=+clippy_checks
+build --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
+build --output_groups=+rustfmt_checks
 
 # Coverage runs use the Rust LCOV merger from //tools/coverage instead of
 # Bazel's built-in one. Besides merging each test's raw tracefiles into its

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,11 @@ on:
     branches: [ master ]
 
 jobs:
+  # Every Rust check here runs through Bazel, with no cargo and no host Rust
+  # toolchain: rules_rust downloads the compiler pinned in MODULE.bazel, so CI
+  # and a local `bazel test` agree on the exact rustc. //:rust_clippy_check and
+  # //:rust_format_check below stand in for `cargo clippy -- -D warnings` and
+  # `cargo fmt --all -- --check`.
   rust-candidate:
     name: Rust candidate (Bazel ${{ matrix.bazel }})
     runs-on: ubuntu-latest
@@ -15,10 +20,6 @@ jobs:
       matrix:
         bazel: ['8.x', '9.x']
     steps:
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
       - name: Setup Go environment
         uses: actions/setup-go@v5
         with:
@@ -26,23 +27,16 @@ jobs:
       - name: Setup Bazelisk
         run: go install github.com/bazelbuild/bazelisk@latest
       - uses: actions/checkout@v4
-      - name: Check Cargo build and tests
-        run: |
-          cargo fmt --all -- --check
-          cargo clippy --all-targets --locked -- -D warnings
-          cargo test --lib --bins --locked
       - name: Check Bazel build and tests
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel }}
           CARGO_BAZEL_ISOLATED: 'false'
-        run: ~/go/bin/bazelisk test //:rust_tests //tools:benchmark_test //tools:perf_gate_test --enable_bzlmod=true --enable_workspace=false
+        run: ~/go/bin/bazelisk test //:rust_tests //:rust_clippy_check //:rust_format_check //tools:benchmark_test //tools:perf_gate_test --enable_bzlmod=true --enable_workspace=false
 
   rust-candidate-e2e:
     name: Rust candidate E2E
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
       - name: Setup Java JDK
         uses: actions/setup-java@v4
         with:
@@ -53,24 +47,53 @@ jobs:
         with:
           go-version: ^1.17
       - name: Setup Bazelisk
-        run: go install github.com/bazelbuild/bazelisk@latest
+        # $BAZEL is the nested Bazel //tests:e2e_test spawns for each fixture
+        # workspace. Set explicitly because the fallback -- first `bazel` on
+        # PATH -- resolves to the *outer* Bazel's own binary inside a test,
+        # which ignores USE_BAZEL_VERSION. It reaches the test through the
+        # target's env_inherit.
+        run: |
+          go install github.com/bazelbuild/bazelisk@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          echo "BAZEL=$(go env GOPATH)/bin/bazelisk" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - name: Run native behavioral suite
         env:
+          # Read twice: by the outer bazelisk, and by the nested one.
           USE_BAZEL_VERSION: '8.x'
-        run: cargo test --locked --test e2e -- --test-threads=1
+        run: bazelisk test //tests:e2e_test --enable_bzlmod=true --enable_workspace=false
 
   rust-candidate-msrv:
     name: Rust candidate MSRV
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Rust 1.85
-        uses: dtolnay/rust-toolchain@master
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
         with:
-          toolchain: '1.85.0'
+          go-version: ^1.17
+      - name: Setup Bazelisk
+        run: go install github.com/bazelbuild/bazelisk@latest
       - uses: actions/checkout@v4
+      # Builds the crate with the toolchain pinned to `rust-version` in
+      # Cargo.toml instead of the repo default. --extra_toolchains outranks the
+      # registered toolchains, which is what makes the swap take: the MSRV
+      # toolchain is declared in MODULE.bazel but deliberately not preferred.
+      # Bazel has no `cargo check` equivalent, so this is a full build -- which
+      # is strictly stronger, since it links as well as type-checks.
+      #
+      # The lint output groups are dropped because this job asks one question:
+      # does the crate still compile on the oldest Rust it claims to support.
+      # 1.85's clippy has a different lint set than the pinned toolchain's, so
+      # leaving them on would fail this job for warnings that say nothing about
+      # MSRV. //:rust_clippy_check and //:rust_format_check own that gate.
       - name: Check declared minimum Rust version
-        run: cargo check --locked
+        env:
+          USE_BAZEL_VERSION: '8.x'
+        run: |
+          ~/go/bin/bazelisk build //src:bazel-diff \
+            --extra_toolchains=@rust_toolchains//:rust_msrv__x86_64-unknown-linux-gnu__stable \
+            --output_groups=-clippy_checks,-rustfmt_checks \
+            --enable_bzlmod=true --enable_workspace=false
 
   test-jre21:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/perf-gate.yaml
+++ b/.github/workflows/perf-gate.yaml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+      # No host Rust toolchain: the Rust binary is built by Bazel, which brings
+      # its own rustc pinned in MODULE.bazel.
       - name: Setup Java JDK
         uses: actions/setup-java@v4
         with:

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,6 @@
 load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 load("@rules_license//rules:license.bzl", "license")
+load("@rules_rust//rust:defs.bzl", "rust_clippy_test", "rustfmt_test")
 
 exports_files(
     [
@@ -27,6 +28,37 @@ test_suite(
         "//src:cli_tests",
         "//src:rust_tests",
     ],
+)
+
+# What CI runs in place of `cargo clippy --all-targets -- -D warnings` and
+# `cargo fmt --all -- --check`.
+#
+# The .bazelrc aspects lint whatever a build names, which is the right tradeoff
+# for local feedback but makes coverage a property of the command line: nothing
+# in a build of //src:bazel-diff checks //tools/coverage. These two targets pin
+# the roots instead, so the gate cannot quietly shrink when a CI command changes.
+# `transitive` walks deps/crate from each root; external crates are skipped by
+# the aspects themselves.
+#
+# Adding a first-party Rust crate? Add its root here.
+_RUST_LINT_ROOTS = [
+    "//src:bazel-diff",
+    "//src:bazel_diff_lib",
+    "//tests:e2e_test",
+    "//tools/coverage:lcov_merger",
+    "//tools/coverage:lcov_merger_test",
+]
+
+rust_clippy_test(
+    name = "rust_clippy_check",
+    targets = _RUST_LINT_ROOTS,
+    transitive = True,
+)
+
+rustfmt_test(
+    name = "rust_format_check",
+    targets = _RUST_LINT_ROOTS,
+    transitive = True,
 )
 
 alias(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -68,8 +68,15 @@ go_sdk.download(version = "1.23.1")
 bazel_dep(name = "rules_rust", version = "0.73.0")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+
+# rustfmt_version is pinned to the same release as the toolchain instead of
+# rules_rust's default (a nightly), so the `rustfmt_aspect` gate in .bazelrc
+# checks formatting with the exact rustfmt a contributor gets from `cargo fmt`
+# on a stable toolchain. A nightly rustfmt can change defaults between releases,
+# which would fail CI on code that formats cleanly locally.
 rust.toolchain(
     edition = "2021",
+    rustfmt_version = "1.90.0",
     # Confine the stock toolchains to platforms that use the system libc. They
     # are only constrained by os and cpu -- rules_rust has no musl constraint --
     # so on //platforms:linux_x86_64_musl they would match alongside the musl
@@ -148,6 +155,34 @@ toolchains_musl = use_extension(
     dev_dependency = True,
 )
 toolchains_musl.config(extra_target_compatible_with = ["//platforms:musl"])
+
+# Toolchain pinned to `rust-version` in Cargo.toml, so the MSRV job in ci.yaml
+# can prove the crate still builds on the minimum Rust it advertises. Keep the
+# version in sync with `rust-version` in Cargo.toml.
+#
+# It lands in the same @rust_toolchains hub as everything above, but rules_rust
+# appends `repository_set` toolchains *after* the default ones, so it never wins
+# ordinary toolchain resolution. The MSRV job selects it explicitly with
+# --extra_toolchains, which outranks every registered toolchain. It carries the
+# same system-libc gate as the stock toolchains for the same reason they do: one
+# Rust toolchain should match any given build, never two.
+#
+# Linux/x86_64 only: a `repository_set` tag declares one exec triple, and the
+# MSRV job runs on ubuntu-latest. Building it on another host just falls back to
+# the default toolchain (no MSRV coverage), it does not fail.
+rust.repository_set(
+    name = "rust_msrv",
+    edition = "2021",
+    exec_triple = "x86_64-unknown-linux-gnu",
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+        "//platforms:system_libc",
+    ],
+    target_settings = ["//platforms:is_system_libc"],
+    target_triple = "x86_64-unknown-linux-gnu",
+    versions = ["1.85.0"],
+)
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,13 @@ release_rust_binary_linux:
 build_rust:
 	bazel build //:bazel-diff-rust -c opt
 
+# Both go through Bazel so they use the same formatters CI gates on. `cargo fmt
+# --all` is not equivalent: it only sees the root crate, missing tools/coverage,
+# and it uses whatever rustfmt is on PATH rather than the pinned one.
 .PHONY: format
 format:
 	bazel run //cli/format
-	cargo fmt --all
+	bazel run //cli/format:rustfmt
 
 .PHONY: generate-readme
 generate-readme:

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -462,6 +462,18 @@ filegroup(
     ],
 )
 
+# //tests:e2e_test reads both fixture trees straight off disk (it is not a JVM
+# test, so it cannot pull the zips and goldens off a classpath the way
+# //cli:E2ETest does) and resolves them relative to the runfiles root.
+filegroup(
+    name = "e2e_resources",
+    srcs = [
+        "src/test/resources/fixture",
+        "src/test/resources/workspaces",
+    ],
+    visibility = ["//tests:__pkg__"],
+)
+
 java_binary(
     name = "ktfmt",
     main_class = "com.facebook.ktfmt.cli.Main",

--- a/cli/format/BUILD
+++ b/cli/format/BUILD
@@ -14,3 +14,18 @@ format_multirun(
     starlark = "@buildifier_prebuilt//:buildifier",
     visibility = ["//visibility:public"],
 )
+
+# The fixer for the rustfmt gate. //:rust_format_check only reports (it fails
+# the build, it does not rewrite files), so `bazel run //cli/format:rustfmt` is
+# how you satisfy it. Kept separate from `format` for the same reason
+# `buildifier` is: one language per target, so a cron on one never rewrites
+# another's files.
+#
+# `upstream_wrapper:rustfmt` is plain rustfmt from the registered toolchain --
+# not //tools/rustfmt, which is a Bazel-target-driven wrapper that does not take
+# the file list aspect_rules_lint passes it.
+format_multirun(
+    name = "rustfmt",
+    rust = "@rules_rust//tools/upstream_wrapper:rustfmt",
+    visibility = ["//visibility:public"],
+)

--- a/src/BUILD
+++ b/src/BUILD
@@ -34,6 +34,8 @@ rust_library(
     rustc_env = {
         "CARGO_PKG_VERSION": module_version() if module_version() else "unknown",
     },
+    # //:rust_clippy_check and //:rust_format_check name this crate directly.
+    visibility = ["//:__pkg__"],
     deps = all_crate_deps(
         package_name = "",
         normal = True,

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,0 +1,61 @@
+load("@bazel_diff_crates//:defs.bzl", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_test")
+
+# The Rust behavioral suite, the Bazel equivalent of `cargo test --test e2e`.
+# It drives the real `bazel-diff` binary against real Bazel workspaces, so it is
+# an integration test in the same sense as //cli:E2ETest: it shells out to a
+# nested `bazel` (see `env_inherit` below), copies fixture workspaces into
+# $TEST_TMPDIR, and builds them.
+#
+# `exclusive` + `local` keep it from running alongside other tests; the
+# `--test-threads=1` below is the same serialization cargo ran it with, so
+# nested Bazel servers don't fight over one output base.
+rust_test(
+    name = "e2e_test",
+    size = "enormous",
+    srcs = [
+        "e2e.rs",
+        "e2e/core.rs",
+        "e2e/external.rs",
+        "e2e/regressions.rs",
+        "e2e/support/mod.rs",
+    ],
+    args = ["--test-threads=1"],
+    crate_root = "e2e.rs",
+    data = [
+        "//cli:e2e_resources",
+        "//src:bazel-diff",
+    ],
+    edition = "2021",
+    env = {
+        # Runfiles-relative; support::binary() makes it absolute. `rootpath`
+        # rather than `execpath` because the test reads it at runtime.
+        "BAZEL_DIFF_TEST_BINARY": "$(rootpath //src:bazel-diff)",
+    },
+    env_inherit = [
+        # Which nested Bazel to run, and what it needs to run. Set $BAZEL: the
+        # suite picks it up first (see support::bazel()), and without it the
+        # choice falls to whichever `bazel` PATH happens to yield -- under
+        # `bazel test` that is the outer Bazel's own binary, so the suite would
+        # silently test a different version than .bazelversion or
+        # USE_BAZEL_VERSION names. Several fixtures are version-sensitive.
+        "BAZEL",
+        "HOME",
+        "JAVA_HOME",
+        "PATH",
+        "USE_BAZEL_VERSION",
+    ],
+    # Nested Bazel builds fetch external repos and cannot run under the sandbox.
+    tags = [
+        "exclusive",
+        "external",
+        "local",
+    ],
+    # //:rust_clippy_check and //:rust_format_check name this target directly.
+    visibility = ["//:__pkg__"],
+    deps = all_crate_deps(
+        package_name = "",
+        normal = True,
+        normal_dev = True,
+    ),
+)

--- a/tests/e2e/support/mod.rs
+++ b/tests/e2e/support/mod.rs
@@ -77,8 +77,23 @@ fn top_level_bazel_workspaces(root: &Path) -> Vec<PathBuf> {
     workspaces
 }
 
+/// Root that [`RESOURCES`] is resolved against.
+///
+/// Under Bazel the sources are not on disk at all: the fixtures reach the test
+/// as runfiles, laid out under `$TEST_SRCDIR/$TEST_WORKSPACE` at the same
+/// repo-relative paths. Under `cargo test` there are no runfiles, so fall back
+/// to the crate directory, which is the repo root.
 pub fn repo_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    match runfiles_root() {
+        Some(root) => root,
+        None => PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+    }
+}
+
+fn runfiles_root() -> Option<PathBuf> {
+    let srcdir = std::env::var_os("TEST_SRCDIR")?;
+    let workspace = std::env::var_os("TEST_WORKSPACE")?;
+    Some(PathBuf::from(srcdir).join(workspace))
 }
 
 pub fn bazel() -> PathBuf {
@@ -133,8 +148,22 @@ pub fn supports_mod_show_repo() -> bool {
     version >= (8, 6, 0) && version != (9, 0, 0)
 }
 
+/// The `bazel-diff` binary under test.
+///
+/// `CARGO_BIN_EXE_*` is a cargo-only compile-time variable, so under Bazel the
+/// path comes from `BAZEL_DIFF_TEST_BINARY` (set by the `env` attr of
+/// `//tests:e2e_test` to a runfiles-relative path). Tests run the binary with
+/// `current_dir` set to a temp workspace, so it has to be made absolute here
+/// while the working directory is still the runfiles root.
 pub fn binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_bazel-diff"))
+    let Some(relative) = std::env::var_os("BAZEL_DIFF_TEST_BINARY") else {
+        return PathBuf::from(env!("CARGO_BIN_EXE_bazel-diff"));
+    };
+    let path = match runfiles_root() {
+        Some(root) => root.join(relative),
+        None => PathBuf::from(relative),
+    };
+    fs::canonicalize(&path).unwrap_or(path)
 }
 
 fn which(name: &str) -> Option<PathBuf> {

--- a/tools/coverage/BUILD
+++ b/tools/coverage/BUILD
@@ -34,4 +34,6 @@ coverage_enforced_test(
     coverage_include = ["tools/coverage/src/"],
     crate = ":lcov_merger_lib",
     rule = rust_test,
+    # //:rust_clippy_check and //:rust_format_check name this target directly.
+    visibility = ["//:__pkg__"],
 )

--- a/tools/coverage/src/args.rs
+++ b/tools/coverage/src/args.rs
@@ -78,7 +78,10 @@ mod tests {
         assert_eq!(args.coverage_dir.as_deref(), Some("/tmp/cov"));
         assert_eq!(args.output_file.as_deref(), Some("/tmp/out.dat"));
         assert_eq!(args.filter_sources, vec!["/usr/bin/.+", "/usr/lib/.+"]);
-        assert_eq!(args.source_file_manifest.as_deref(), Some("/tmp/manifest.txt"));
+        assert_eq!(
+            args.source_file_manifest.as_deref(),
+            Some("/tmp/manifest.txt")
+        );
         assert!(args.unknown.is_empty());
     }
 

--- a/tools/coverage/src/enforce.rs
+++ b/tools/coverage/src/enforce.rs
@@ -40,9 +40,10 @@ pub fn config_from_env(env: &BTreeMap<String, String>) -> Result<Option<Config>,
     let Some(raw) = env.get(MIN_LINE_COVERAGE_ENV) else {
         return Ok(None);
     };
-    let min: f64 = raw.trim().parse().map_err(|_| {
-        format!("{MIN_LINE_COVERAGE_ENV}='{raw}' is not a number (expected 0-100)")
-    })?;
+    let min: f64 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("{MIN_LINE_COVERAGE_ENV}='{raw}' is not a number (expected 0-100)"))?;
     if !(0.0..=100.0).contains(&min) {
         return Err(format!(
             "{MIN_LINE_COVERAGE_ENV}={min} is outside the valid range 0-100"

--- a/tools/coverage/src/lcov.rs
+++ b/tools/coverage/src/lcov.rs
@@ -43,9 +43,7 @@ impl FileCoverage {
     /// Fold `other` into `self`, summing hit counts.
     pub fn merge(&mut self, other: &FileCoverage) {
         for (name, line) in &other.function_lines {
-            self.function_lines
-                .entry(name.clone())
-                .or_insert(*line);
+            self.function_lines.entry(name.clone()).or_insert(*line);
         }
         for (name, hits) in &other.function_hits {
             *self.function_hits.entry(name.clone()).or_insert(0) += hits;
@@ -113,8 +111,9 @@ pub fn parse(text: &str) -> (Report, Vec<String>) {
                     Ok(n) => {
                         cov.function_lines.entry(name.to_string()).or_insert(n);
                     }
-                    Err(_) => warnings
-                        .push(format!("line {}: unparseable FN record '{line}'", idx + 1)),
+                    Err(_) => {
+                        warnings.push(format!("line {}: unparseable FN record '{line}'", idx + 1))
+                    }
                 },
                 None => warnings.push(format!("line {}: unparseable FN record '{line}'", idx + 1)),
             }
@@ -122,12 +121,15 @@ pub fn parse(text: &str) -> (Report, Vec<String>) {
             match rest.split_once(',') {
                 Some((hits, name)) => match hits.parse::<u64>() {
                     Ok(h) => *cov.function_hits.entry(name.to_string()).or_insert(0) += h,
-                    Err(_) => warnings
-                        .push(format!("line {}: unparseable FNDA record '{line}'", idx + 1)),
+                    Err(_) => warnings.push(format!(
+                        "line {}: unparseable FNDA record '{line}'",
+                        idx + 1
+                    )),
                 },
-                None => {
-                    warnings.push(format!("line {}: unparseable FNDA record '{line}'", idx + 1))
-                }
+                None => warnings.push(format!(
+                    "line {}: unparseable FNDA record '{line}'",
+                    idx + 1
+                )),
             }
         } else if let Some(rest) = line.strip_prefix("BRDA:") {
             match parse_brda(rest) {
@@ -138,9 +140,10 @@ pub fn parse(text: &str) -> (Report, Vec<String>) {
                         (a, b) => Some(a.unwrap_or(0) + b.unwrap_or(0)),
                     };
                 }
-                None => {
-                    warnings.push(format!("line {}: unparseable BRDA record '{line}'", idx + 1))
-                }
+                None => warnings.push(format!(
+                    "line {}: unparseable BRDA record '{line}'",
+                    idx + 1
+                )),
             }
         }
         // LF/LH/FNF/FNH/BRF/BRH are recomputed on output; TN and anything
@@ -254,8 +257,10 @@ mod tests {
 
     #[test]
     fn merges_hit_counts_across_tracefiles() {
-        let (a, _) = parse("SF:x.rs\nDA:1,1\nDA:2,0\nFNDA:1,f\nFN:1,f\nBRDA:1,0,0,-\nend_of_record\n");
-        let (b, _) = parse("SF:x.rs\nDA:1,3\nDA:5,1\nFNDA:4,f\nFN:1,f\nBRDA:1,0,0,2\nend_of_record\n");
+        let (a, _) =
+            parse("SF:x.rs\nDA:1,1\nDA:2,0\nFNDA:1,f\nFN:1,f\nBRDA:1,0,0,-\nend_of_record\n");
+        let (b, _) =
+            parse("SF:x.rs\nDA:1,3\nDA:5,1\nFNDA:4,f\nFN:1,f\nBRDA:1,0,0,2\nend_of_record\n");
         let mut merged = Report::new();
         merge_reports(&mut merged, a);
         merge_reports(&mut merged, b);
@@ -290,8 +295,9 @@ mod tests {
 
     #[test]
     fn malformed_records_warn_but_do_not_fail() {
-        let (report, warnings) =
-            parse("SF:a.kt\nDA:notanumber,1\nFN:x\nFN:y,f\nFNDA:z,f\nBRDA:1,0\nDA:7,1\nend_of_record\n");
+        let (report, warnings) = parse(
+            "SF:a.kt\nDA:notanumber,1\nFN:x\nFN:y,f\nFNDA:z,f\nBRDA:1,0\nDA:7,1\nend_of_record\n",
+        );
         assert_eq!(report["a.kt"].line_hits, BTreeMap::from([(7, 1)]));
         assert_eq!(warnings.len(), 5);
     }
@@ -319,6 +325,9 @@ mod tests {
     #[test]
     fn emit_skips_function_and_branch_blocks_when_absent() {
         let (report, _) = parse("SF:a.py\nDA:1,0\nend_of_record\n");
-        assert_eq!(emit(&report), "SF:a.py\nDA:1,0\nLH:0\nLF:1\nend_of_record\n");
+        assert_eq!(
+            emit(&report),
+            "SF:a.py\nDA:1,0\nLH:0\nLF:1\nend_of_record\n"
+        );
     }
 }

--- a/tools/coverage/src/lib.rs
+++ b/tools/coverage/src/lib.rs
@@ -229,7 +229,10 @@ mod tests {
         if let Some(manifest_content) = manifest {
             let manifest_path = dir.join("manifest.txt");
             fs::write(&manifest_path, manifest_content).unwrap();
-            argv.push(format!("--source_file_manifest={}", manifest_path.display()));
+            argv.push(format!(
+                "--source_file_manifest={}",
+                manifest_path.display()
+            ));
         }
         argv.extend(extra_args.iter().map(|s| s.to_string()));
         let env: BTreeMap<String, String> = env
@@ -331,7 +334,10 @@ mod tests {
     fn enforcement_passes_and_reports_in_the_log() {
         let result = invoke(
             "enforce_pass",
-            &[("a.dat", "SF:pkg/lib.go\nDA:1,1\nDA:2,1\nDA:3,0\nend_of_record\n")],
+            &[(
+                "a.dat",
+                "SF:pkg/lib.go\nDA:1,1\nDA:2,1\nDA:3,0\nend_of_record\n",
+            )],
             None,
             &[(enforce::MIN_LINE_COVERAGE_ENV, "60")],
             &[],
@@ -345,7 +351,10 @@ mod tests {
     fn enforcement_fails_with_distinct_exit_code() {
         let result = invoke(
             "enforce_fail",
-            &[("a.dat", "SF:pkg/lib.go\nDA:1,1\nDA:2,0\nDA:3,0\nend_of_record\n")],
+            &[(
+                "a.dat",
+                "SF:pkg/lib.go\nDA:1,1\nDA:2,0\nDA:3,0\nend_of_record\n",
+            )],
             None,
             &[
                 (enforce::MIN_LINE_COVERAGE_ENV, "90"),

--- a/tools/coverage/src/pattern.rs
+++ b/tools/coverage/src/pattern.rs
@@ -84,7 +84,9 @@ impl Pattern {
                     Elem::Class(negated, ranges)
                 }
                 '*' | '+' | '?' => {
-                    return Err(format!("quantifier '{c}' with nothing to repeat in '{source}'"))
+                    return Err(format!(
+                        "quantifier '{c}' with nothing to repeat in '{source}'"
+                    ))
                 }
                 '(' | ')' | '|' | '{' | '}' | '^' | '$' => {
                     return Err(format!("unsupported regex syntax '{c}' in '{source}'"))
@@ -153,7 +155,11 @@ fn matches_here(terms: &[(Elem, Quant)], input: &[char], pos: usize) -> bool {
             while end < input.len() && elem_matches(elem, input[end]) {
                 end += 1;
             }
-            let min_end = if *quant == Quant::OneOrMore { pos + 1 } else { pos };
+            let min_end = if *quant == Quant::OneOrMore {
+                pos + 1
+            } else {
+                pos
+            };
             loop {
                 if end < min_end {
                     return false;


### PR DESCRIPTION
CI installed a host Rust toolchain and shelled out to cargo for four checks, plus a second toolchain for MSRV. That is a second build system's worth of setup to maintain, and it pinned the checks to whatever rustc `dtolnay/rust-toolchain@stable` resolved to on the day rather than the compiler `MODULE.bazel` names — so CI and a local `bazel test` could disagree. Every Rust validation now runs through Bazel.

## What replaced what

| Was (cargo) | Now (Bazel) |
| --- | --- |
| `cargo fmt --all -- --check` | `//:rust_format_check` (`rustfmt_test`, transitive) |
| `cargo clippy --all-targets -- -D warnings` | `//:rust_clippy_check` (`rust_clippy_test`, transitive) |
| `cargo test --lib --bins` | `//:rust_tests` (already existed) |
| `cargo test --test e2e` | `//tests:e2e_test` (new `rust_test`) |
| `cargo check` on Rust 1.85 | `bazel build //src:bazel-diff --extra_toolchains=…rust_msrv…` |

`perf-gate.yaml` also loses its `Setup Rust` step — that job already built through Bazel and never used it.

## Notes for review

**The lint gates pin roots rather than relying on the `.bazelrc` aspects.** Neither `rust_clippy_aspect` nor `rustfmt_aspect` propagates along `deps`, so an aspect-only gate covers just the targets a build happens to name. That was already true of the existing clippy setup and meant nothing was checking `tools/coverage` — it turned out to be unformatted. `bazel run //cli/format:rustfmt` is new and fixes it; `make format` now calls it instead of `cargo fmt --all`, which only ever saw the root crate. The aspects stay in `.bazelrc` for fast local feedback.

**The e2e port needed two changes.** Its support helpers read `CARGO_MANIFEST_DIR` and `CARGO_BIN_EXE_*`, which don't exist outside cargo, so they now prefer runfiles and keep the cargo values as a fallback — `cargo test` still works locally. Separately, the nested Bazel each fixture spawns is now chosen by `$BAZEL`: inside a Bazel test the first `bazel` on `PATH` is the *outer* Bazel's own binary, which ignores `USE_BAZEL_VERSION`, and two fixtures are version-sensitive enough that this silently produced wrong results. `find_bazel()` already checked `$BAZEL` first, so this is a config change, not a code one.

**MSRV keeps its own toolchain**, declared in `MODULE.bazel` and registered but deliberately not preferred (rules_rust appends `repository_set` toolchains after the defaults). The job selects it with `--extra_toolchains` and drops the lint output groups, since 1.85's clippy carries a different lint set and would fail that job for reasons unrelated to MSRV. It's Linux/x86_64 only — a `repository_set` tag declares one exec triple, and the job runs on `ubuntu-latest`. On another host the build just falls back to the default toolchain rather than failing.

Rebasing onto #465 conflicted here, and the resolution is worth a look: that PR gated the stock Rust toolchains to `//platforms:is_system_libc` so exactly one toolchain matches any build. The MSRV set carries the same gate and `//platforms:system_libc` in its `target_compatible_with`, so it doesn't reintroduce the ambiguity #465 removed on `//platforms:linux_x86_64_musl`.

## Verification

Locally on macOS: both lint gates, `//:rust_tests`, the tools tests, and a `--config=release` build all pass.

The e2e suite is 32/36. The 4 failures are `external::*` fixtures whose nested Bazel needs a JDK, and this machine has none (`/usr/bin/java` is the macOS stub) — each fails with "Unable to locate a Java Runtime", and I confirmed one fails identically under `cargo test` here. That job installs Temurin 21, so they should pass in CI, but **that is the specific claim I could not verify locally and the thing to watch on the first run.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
