### PR TITLE
ci: lift Bazel test timeouts on release runs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -74,3 +74,14 @@ build --output_groups=+rustfmt_checks
 # Scoped to the `coverage` command, and Bazel only invokes an LCOV merger in
 # coverage mode anyway, so plain `bazel test` runs are never affected.
 coverage --coverage_output_generator=//tools/coverage:lcov_merger
+
+# Releases run the whole suite on one cold runner (see release.yaml), where the
+# long suites -- //tests:e2e_test (size = "enormous") and //cli:E2ETest
+# (timeout = "eternal") -- have no headroom left: v44.0.0 died on
+# "//tests:e2e_test TIMEOUT in 3600.0s" and published nothing. Per-size timeouts
+# are there to catch hangs on PRs, where each suite gets its own runner and an
+# overrun means something is wrong. A release has no such signal to give, so the
+# only bound left is GitHub's 6h job limit; a single value overrides all four
+# size categories. Not named `release`: `test` inherits `build` configs, so
+# --config=release would drag in -c opt and thin LTO and rebuild the world.
+test:no-test-timeouts --test_timeout=21600

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,10 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0
     with:
       release_files: archives/*.*
+      # Same target pattern as the reusable workflow's default (`bazel test
+      # //...`), restated because the only way to add a flag is to replace the
+      # whole command. --config=no-test-timeouts is in .bazelrc.
+      bazel_test_command: "bazel test //... --config=no-test-timeouts"
       prerelease: false
       draft: true
       tag_name: ${{ inputs.tag_name || github.ref_name }}


### PR DESCRIPTION
## Summary
- The Release workflow's reusable `release_ruleset` step runs `bazel test //...` on a single cold runner. On v44.0.0 that killed `//tests:e2e_test` at the `enormous` 3600s cap (`TIMEOUT in 3600.0s`) and skipped attest/publish/binaries.
- Add a `.bazelrc` `test:no-test-timeouts` config (`--test_timeout=21600`, GitHub's 6h job ceiling) and pass it via `bazel_test_command` in `release.yaml`.
- PR CI is unchanged, so per-size timeouts still catch hangs where each suite has its own runner.

## Test plan
- [x] `bazel test //tools:benchmark_test --config=no-test-timeouts --announce_rc` reports `test:no-test-timeouts ... --test_timeout=21600` and the test passes
- [ ] After merge, re-cut (or move) the `v44.0.0` tag so the Release workflow checks out a commit that includes this fix, then confirm `release / build` gets past Test


Made with [Cursor](https://cursor.com)