### PR TITLE
Add GET /dependency_edges for the generate-hashes graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,24 @@ curl 'http://localhost:8080/impacted_targets_with_distances?from=main&to=my-feat
 }
 ```
 
+* `GET /dependency_edges?from=<rev>&to=<rev>` — returns the generate-hashes dependency-edge graph
+  for the **`to` revision**, byte-compatible with `generate-hashes --depEdgesFile`. The body is a JSON
+  object mapping each label to its direct deps — **not** the per-target distance summary from
+  `/impacted_targets_with_distances`, and not wrapped in `from`/`to`/`impactedTargets`. Requires
+  `--trackDeps`; otherwise this endpoint returns `400`. `profile=true` is accepted and ignored so
+  clients can reuse the same query string as the other endpoints. The graph is always the full
+  (unscoped) map; `modifiedFilepaths` on POST does not shrink it.
+
+```bash
+curl 'http://localhost:8080/dependency_edges?from=main&to=my-feature-branch'
+```
+
+```json
+{
+  "//foo:bar": ["//foo:lib", "//bar:baz"]
+}
+```
+
 * `GET /metrics` — returns a JSON snapshot of the instance so callers and monitoring can see its
   identity, liveness, and cache size usage without scraping logs. Unlike the query endpoints it is
   never gated on readiness, so it still responds on an un-ready or lame-ducked instance (the `ready`
@@ -243,7 +261,8 @@ lifecycle policy instead.
 
 Notes and current limitations:
 
-* Distance metrics (`/impacted_targets_with_distances`) require the dependency-edge graph, which is
+* Distance metrics (`/impacted_targets_with_distances`) and the generate-hashes graph
+  (`/dependency_edges`) require the dependency-edge graph, which is
   only tracked when the server is started with `--trackDeps`. Tracking deps grows each cached hash
   entry, so it is opt-in. The flag is folded into the cache key, so enabling or disabling it never
   reuses a previously cached entry of the other kind. This mirrors the `generate-hashes --depEdgesFile`

--- a/cli/src/main/kotlin/com/bazel_diff/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/ServeCommand.kt
@@ -91,7 +91,8 @@ open class ServeCommand : Callable<Int> {
       names = ["--requestTimeout"],
       description =
           [
-              "Maximum seconds an /impacted_targets(_with_distances) request may run before the " +
+              "Maximum seconds an /impacted_targets(_with_distances) or /dependency_edges " +
+                  "request may run before the " +
                   "server abandons it and responds 504. 0 (the default) means no timeout. This " +
                   "bounds the request the client waits on; an in-flight bazel query may keep " +
                   "running in the background and still populate the per-SHA cache."],
@@ -298,7 +299,8 @@ open class ServeCommand : Callable<Int> {
       description =
           [
               "Track dependency edges and persist them per commit SHA so build-graph distance " +
-                  "metrics can be served via /impacted_targets_with_distances. Increases cache " +
+                  "metrics can be served via /impacted_targets_with_distances and the " +
+                  "generate-hashes graph via /dependency_edges. Increases cache " +
                   "size and memory. Defaults to false."])
   var trackDeps = false
 

--- a/cli/src/main/kotlin/com/bazel_diff/server/BazelDiffServer.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/BazelDiffServer.kt
@@ -42,6 +42,11 @@ import org.koin.core.component.inject
  *   form) -- like above but each impacted target is `{"label", "targetDistance",
  *   "packageDistance"}`. Requires the server to have been started with `--trackDeps`; returns `400`
  *   otherwise.
+ * - `GET /dependency_edges?from=<rev>&to=<rev>` (and its `POST` form) -- the generate-hashes
+ *   dependency-edge graph for the `to` revision, byte-compatible with `generate-hashes
+ *   --depEdgesFile`. The body is a JSON object mapping each label to its direct deps -- not wrapped
+ *   in `from`/`to`/`impactedTargets`. Requires `--trackDeps`; returns `400` otherwise.
+ *   `profile=true` is accepted and ignored. `modifiedFilepaths` on POST does not shrink the map.
  * - `GET /metrics` -- a JSON snapshot of the instance (version, uptime, readiness, git engine,
  *   cache size usage, JVM heap) when a [metricsProvider] is wired. Intentionally not gated on
  *   readiness, so a scrape of an un-ready or lame-ducked instance still returns data.
@@ -83,6 +88,7 @@ class BazelDiffServer(
     httpServer.createContext("/impacted_targets", ::handleImpactedTargets)
     httpServer.createContext(
         "/impacted_targets_with_distances", ::handleImpactedTargetsWithDistances)
+    httpServer.createContext("/dependency_edges", ::handleDependencyEdges)
     httpServer.createContext("/metrics", ::handleMetrics)
     httpServer.start()
     server = httpServer
@@ -142,6 +148,11 @@ class BazelDiffServer(
       handleQuery(exchange) { from, to, targetTypes, modifiedFilepaths, profiler ->
         impactedTargetsProvider.getImpactedTargetsWithDistances(
             from, to, targetTypes, modifiedFilepaths, profiler)
+      }
+
+  private fun handleDependencyEdges(exchange: HttpExchange) =
+      handleQuery(exchange) { from, to, _, _, _ ->
+        impactedTargetsProvider.getDependencyEdges(from, to)
       }
 
   /** Normalized inputs for a query, parsed from either a GET query string or a POST JSON body. */
@@ -218,8 +229,8 @@ class BazelDiffServer(
           logger.w { "request exceeded ${requestTimeoutSeconds}s timeout, abandoning" }
           respondJson(
               exchange, 504, mapOf("error" to "request timed out after ${requestTimeoutSeconds}s"))
-        } catch (e: DistancesUnavailableException) {
-          respondJson(exchange, 400, mapOf("error" to (e.message ?: "distances unavailable")))
+        } catch (e: TrackDepsUnavailableException) {
+          respondJson(exchange, 400, mapOf("error" to (e.message ?: "unavailable")))
         } catch (e: GitClientException) {
           logger.e(e) { "git error computing impacted targets" }
           respondJson(exchange, 400, mapOf("error" to "git error: ${e.message}"))

--- a/cli/src/main/kotlin/com/bazel_diff/server/ImpactedTargetsService.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/server/ImpactedTargetsService.kt
@@ -36,10 +36,16 @@ data class ImpactedTargetsWithDistancesResult(
 )
 
 /**
- * Thrown when a distance query arrives but the server was started without `--trackDeps`, so no
- * dependency edges were tracked or cached. The HTTP layer maps this to a `400`.
+ * Thrown when a query that needs the dependency-edge graph arrives but the server was started
+ * without `--trackDeps`. The HTTP layer maps this to a `400`.
  */
-class DistancesUnavailableException(message: String) : Exception(message)
+open class TrackDepsUnavailableException(message: String) : Exception(message)
+
+/** Distances endpoint (`/impacted_targets_with_distances`) requires `--trackDeps`. */
+class DistancesUnavailableException(message: String) : TrackDepsUnavailableException(message)
+
+/** Generate-hashes graph endpoint (`/dependency_edges`) requires `--trackDeps`. */
+class DependencyEdgesUnavailableException(message: String) : TrackDepsUnavailableException(message)
 
 /**
  * Computes the impacted targets between two revisions. Extracted behind an interface so the HTTP
@@ -78,6 +84,16 @@ interface ImpactedTargetsProvider {
       modifiedFilepaths: Set<Path> = emptySet(),
       profiler: QueryProfiler? = null,
   ): ImpactedTargetsWithDistancesResult
+
+  /**
+   * Returns the generate-hashes dependency-edge graph for the **`to` revision** — the same map
+   * `generate-hashes --depEdgesFile` writes. Always the full (unscoped) graph: [modifiedFilepaths]
+   * on the HTTP request must not shrink it. Throws [DependencyEdgesUnavailableException] if the
+   * server was not started with `--trackDeps`.
+   */
+  fun getDependencyEdges(fromRev: String, toRev: String): Map<String, List<String>> {
+    throw UnsupportedOperationException("dependency edges not implemented")
+  }
 }
 
 /**
@@ -170,6 +186,20 @@ class ImpactedTargetsService(
     profiler?.recordDiff(elapsedMillis(diffStartNanos), moduleGraphChanged)
     return ImpactedTargetsWithDistancesResult(
         fromSha, toSha, impacted, profiler?.queryProfile(), profiler?.memoryProfile())
+  }
+
+  override fun getDependencyEdges(fromRev: String, toRev: String): Map<String, List<String>> {
+    if (!depsTracked) {
+      throw DependencyEdgesUnavailableException(
+          "dependency edges unavailable: server started without --trackDeps")
+    }
+    val (_, toSha) = resolveBoth(fromRev, toRev)
+    logger.i { "Fetching dependency-edge graph for $toSha" }
+    // Same graph generate-hashes writes to --depEdgesFile: the end revision's full (unscoped)
+    // dependency map. modifiedFilepaths must not shrink it — clients BFS-walk this file from the
+    // app target and need every edge.
+    val toData = hashProvider.getHashes(toSha, emptySet())
+    return toData.depEdges
   }
 
   /** [resolveBoth], recording its duration (including any on-demand fetches) into [profiler]. */

--- a/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/e2e/E2ETest.kt
@@ -158,8 +158,8 @@ class E2ETest {
   /**
    * End-to-end coverage for the `serve` query service: builds a two-commit git repo from the
    * shell-only `distance_metrics` workspace, runs `bazel-diff serve` (with `--trackDeps`) in a
-   * background thread, then hits `/health`, `/impacted_targets`, and
-   * `/impacted_targets_with_distances` over real HTTP. Exercises the full
+   * background thread, then hits `/health`, `/impacted_targets`,
+   * `/impacted_targets_with_distances`, and `/dependency_edges` over real HTTP. Exercises the full
    * [com.bazel_diff.cli.ServeCommand] path (Koin + hasher wiring, git checkout, real `bazel query`
    * for both revisions, dep-edge tracking, distance computation, and the cache) the same way the
    * other E2E tests cover the CLI commands.
@@ -232,6 +232,17 @@ class E2ETest {
       // Gson decodes JSON numbers as Double.
       assertThat(libEntry["targetDistance"]).isEqualTo(0.0)
       assertThat(libEntry["packageDistance"]).isEqualTo(0.0)
+
+      val (edgesCode, edgesBody) =
+          httpGetServe(
+              "http://localhost:$port/dependency_edges?from=$fromSha&to=$toSha&profile=true")
+      assertThat(edgesCode).isEqualTo(200)
+      val graph: Map<String, Any> =
+          Gson().fromJson(edgesBody, object : TypeToken<Map<String, Any>>() {}.type)
+      assertThat(graph.containsKey("from")).isEqualTo(false)
+      assertThat(graph.containsKey("impactedTargets")).isEqualTo(false)
+      val labels = graph.keys.map { it.removePrefix("@@") }
+      assertThat(labels.any { it == "//:lib" || it.contains(":lib") }).isEqualTo(true)
     } finally {
       serveThread.interrupt()
       serveThread.join(10_000)

--- a/cli/src/test/kotlin/com/bazel_diff/server/BazelDiffServerTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/BazelDiffServerTest.kt
@@ -77,6 +77,8 @@ class BazelDiffServerTest : KoinTest {
       var lastTargetTypes: Set<String>? = null,
       var lastModifiedFilepaths: Set<Path> = emptySet(),
       var lastProfiler: QueryProfiler? = null,
+      var depEdges: Map<String, List<String>> = mapOf("//app:rule" to listOf("//app:source")),
+      var depEdgesError: Exception? = null,
   ) : ImpactedTargetsProvider {
     override fun getImpactedTargets(
         fromRev: String,
@@ -103,6 +105,13 @@ class BazelDiffServerTest : KoinTest {
       distancesError?.let { throw it }
       return distancesResult.copy(
           profile = profiler?.queryProfile(), memoryProfile = profiler?.memoryProfile())
+    }
+
+    override fun getDependencyEdges(fromRev: String, toRev: String): Map<String, List<String>> {
+      lastFrom = fromRev
+      lastTo = toRev
+      depEdgesError?.let { throw it }
+      return depEdges
     }
 
     private fun record(
@@ -152,6 +161,9 @@ class BazelDiffServerTest : KoinTest {
         ) =
             provider.getImpactedTargetsWithDistances(
                 fromRev, toRev, targetTypes, modifiedFilepaths, profiler)
+
+        override fun getDependencyEdges(fromRev: String, toRev: String) =
+            provider.getDependencyEdges(fromRev, toRev)
       }
 
   private data class Response(val code: Int, val body: String)
@@ -598,6 +610,38 @@ class BazelDiffServerTest : KoinTest {
     val response = get("/impacted_targets_with_distances?from=a&to=b")
     assertThat(response.code).isEqualTo(400)
     assertThat(response.body).contains("--trackDeps")
+  }
+
+  @Test
+  fun dependencyEdgesReturnsGenerateHashesGraph() {
+    val fixed = FixedProvider()
+    provider = fixed
+    val response = get("/dependency_edges?from=main&to=feature&profile=true")
+    assertThat(response.code).isEqualTo(200)
+    assertThat(fixed.lastFrom).isEqualTo("main")
+    assertThat(fixed.lastTo).isEqualTo("feature")
+    assertThat(response.body).contains("\"//app:rule\"")
+    assertThat(response.body).contains("\"//app:source\"")
+    assertThat(response.body).doesNotContain("impactedTargets")
+    assertThat(response.body).doesNotContain("\"profile\"")
+  }
+
+  @Test
+  fun dependencyEdgesUnavailableReturns400() {
+    provider =
+        FixedProvider(
+            depEdgesError =
+                DependencyEdgesUnavailableException(
+                    "dependency edges unavailable: server started without --trackDeps"))
+    val response = get("/dependency_edges?from=a&to=b")
+    assertThat(response.code).isEqualTo(400)
+    assertThat(response.body).contains("dependency edges unavailable")
+    assertThat(response.body).contains("--trackDeps")
+  }
+
+  @Test
+  fun dependencyEdgesMissingParamsReturns400() {
+    assertThat(get("/dependency_edges?from=main").code).isEqualTo(400)
   }
 
   @Test

--- a/cli/src/test/kotlin/com/bazel_diff/server/ImpactedTargetsServiceTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/server/ImpactedTargetsServiceTest.kt
@@ -319,6 +319,39 @@ class ImpactedTargetsServiceTest : KoinTest {
   }
 
   @Test
+  fun returnsDepEdgesFromToRevisionWithoutScoping() {
+    val from = HashFileData(mapOf("//:a" to TargetHash("Rule", "h1", "d1")), null)
+    val to =
+        HashFileData(
+            mapOf("//:a" to TargetHash("Rule", "h2", "d2")),
+            null,
+            depEdges = mapOf("//:lib" to listOf("//:dep"), "//:dep" to emptyList()))
+    val provider = FakeHashProvider(mapOf("from-sha" to from, "to-sha" to to))
+    val service = ImpactedTargetsService(IdentityGitClient(), provider, depsTracked = true)
+
+    val graph = service.getDependencyEdges("from-sha", "to-sha")
+
+    assertThat(graph).isEqualTo(mapOf("//:lib" to listOf("//:dep"), "//:dep" to emptyList()))
+    assertThat(provider.modifiedFilepathsByRev.keys).isEqualTo(setOf("to-sha"))
+    assertThat(provider.modifiedFilepathsByRev["to-sha"]).isEqualTo(emptySet())
+  }
+
+  @Test
+  fun dependencyEdgesThrowWhenDepsNotTracked() {
+    val from = HashFileData(mapOf("//:a" to TargetHash("Rule", "h1", "d1")), null)
+    val to = HashFileData(mapOf("//:a" to TargetHash("Rule", "h2", "d2")), null)
+    val service =
+        ImpactedTargetsService(
+            IdentityGitClient(),
+            FakeHashProvider(mapOf("from-sha" to from, "to-sha" to to)),
+            depsTracked = false)
+
+    org.junit.Assert.assertThrows(DependencyEdgesUnavailableException::class.java) {
+      service.getDependencyEdges("from-sha", "to-sha")
+    }
+  }
+
+  @Test
   fun distancesModuleGraphChangePinsWorkspaceToTo() {
     // Same forced live-query path as the non-distance test, but through the distances method.
     val from = HashFileData(mapOf("//:a" to TargetHash("Rule", "h1", "d1")), "graph-v1")

--- a/src/server.rs
+++ b/src/server.rs
@@ -161,6 +161,13 @@ struct QueryInputs {
     profile: bool,
 }
 
+#[derive(Clone, Copy, Debug)]
+enum QueryKind {
+    Labels,
+    Distances,
+    DepEdges,
+}
+
 pub fn parse_duration(value: &str) -> Result<Duration> {
     let normalized = value.trim().to_ascii_lowercase();
     if normalized.is_empty() {
@@ -318,7 +325,7 @@ fn route(mut request: Request, state: &Arc<State>) -> Result<()> {
             }
             respond_json(request, 200, &metrics(state))
         }
-        "/impacted_targets" | "/impacted_targets_with_distances" => {
+        "/impacted_targets" | "/impacted_targets_with_distances" | "/dependency_edges" => {
             if !state.ready.load(Ordering::Acquire) {
                 return respond_json(request, 503, &json!({"error": "service not ready"}));
             }
@@ -335,19 +342,29 @@ fn route(mut request: Request, state: &Arc<State>) -> Result<()> {
                     return respond_json(request, 400, &json!({"error": error.to_string()}))
                 }
             };
-            let distances = path.ends_with("_with_distances");
-            if distances && !state.config.track_deps {
+            let kind = match path {
+                "/dependency_edges" => QueryKind::DepEdges,
+                "/impacted_targets_with_distances" => QueryKind::Distances,
+                _ => QueryKind::Labels,
+            };
+            if matches!(kind, QueryKind::Distances | QueryKind::DepEdges)
+                && !state.config.track_deps
+            {
+                let unavailable = match kind {
+                    QueryKind::DepEdges => "dependency edges unavailable",
+                    _ => "distances unavailable",
+                };
                 return respond_json(
                     request,
                     400,
-                    &json!({"error": "distances unavailable: server started without --trackDeps"}),
+                    &json!({"error": format!("{unavailable}: server started without --trackDeps")}),
                 );
             }
             let timeout = state.config.request_timeout;
             let state_for_compute = Arc::clone(state);
             let (sender, receiver) = mpsc::sync_channel(1);
             std::thread::spawn(move || {
-                let _ = sender.send(compute_query(&state_for_compute, inputs, distances));
+                let _ = sender.send(compute_query(&state_for_compute, inputs, kind));
             });
             let computed = if timeout.is_zero() {
                 receiver
@@ -444,7 +461,7 @@ fn normalized_types(types: Option<Vec<String>>) -> Option<HashSet<String>> {
         .filter(|types| !types.is_empty())
 }
 
-fn compute_query(state: &Arc<State>, inputs: QueryInputs, distances: bool) -> Result<Value> {
+fn compute_query(state: &Arc<State>, inputs: QueryInputs, kind: QueryKind) -> Result<Value> {
     let started = Instant::now();
     let _guard = state
         .workspace_lock
@@ -453,6 +470,14 @@ fn compute_query(state: &Arc<State>, inputs: QueryInputs, distances: bool) -> Re
     let resolve_started = Instant::now();
     let (from_sha, to_sha) = resolve_both(state, &inputs.from, &inputs.to)?;
     let resolve_millis = resolve_started.elapsed().as_millis() as u64;
+    if matches!(kind, QueryKind::DepEdges) {
+        // Same graph generate-hashes writes to --depEdgesFile: the end revision's
+        // full (unscoped) dependency map. modifiedFilepaths must not shrink it —
+        // PRI/CRI BFS-walk this file from the app target and need every edge.
+        let (to, _) = get_hashes_locked(state, &to_sha, &BTreeSet::new())?;
+        prune_cache(state)?;
+        return Ok(serde_json::to_value(&to.dep_edges)?);
+    }
     let from_started = Instant::now();
     let (from, from_hit) = get_hashes_locked(state, &from_sha, &inputs.modified_filepaths)?;
     let from_millis = from_started.elapsed().as_millis() as u64;
@@ -464,7 +489,7 @@ fn compute_query(state: &Arc<State>, inputs: QueryInputs, distances: bool) -> Re
     let exclude_external = state.config.hash_options.bazel.is_bzlmod_enabled();
     let impacted =
         impacted_with_module_changes(&from, &to, Some(&state.config.hash_options.bazel))?;
-    let impacted_value = if distances {
+    let impacted_value = if matches!(kind, QueryKind::Distances) {
         let hash_impacted = impacted_targets(&from.hashes, &to.hashes, None, false)?
             .into_iter()
             .collect::<BTreeSet<_>>();
@@ -1430,7 +1455,7 @@ mod tests {
             modified_filepaths: BTreeSet::new(),
             profile: true,
         };
-        let result = compute_query(&state, inputs, true).unwrap();
+        let result = compute_query(&state, inputs, QueryKind::Distances).unwrap();
         assert_eq!(result["to"], second);
         assert_eq!(result["impactedTargets"].as_array().unwrap().len(), 2);
         assert_eq!(result["profile"]["hashRetrievals"][0]["cacheHit"], true);
@@ -1541,6 +1566,13 @@ mod tests {
         );
         assert!(response.starts_with("HTTP/1.1 400"));
         assert!(response.contains("distances unavailable"));
+
+        let response = request(
+            &state,
+            "GET /dependency_edges?from=a&to=b HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        );
+        assert!(response.starts_with("HTTP/1.1 400"));
+        assert!(response.contains("dependency edges unavailable"));
     }
 
     #[test]
@@ -1595,6 +1627,23 @@ mod tests {
         assert!(response.starts_with("HTTP/1.1 200"), "{response}");
         assert!(response.contains("\"targetDistance\":1"));
         assert!(!response.contains("\"profile\""));
+
+        let response = request(
+            &state,
+            &format!(
+                "GET /dependency_edges?from={first}&to={second}&profile=true HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+            ),
+        );
+        assert!(response.starts_with("HTTP/1.1 200"), "{response}");
+        assert!(response.contains("\"//app:rule\":[\"//app:source\"]"));
+        assert!(
+            !response.contains("\"impactedTargets\""),
+            "body must be the generate-hashes graph, not a wrapped query response: {response}"
+        );
+        assert!(
+            !response.contains("\"profile\""),
+            "profile=true must not wrap the graph body: {response}"
+        );
     }
 
     #[test]

--- a/tests/e2e/core.rs
+++ b/tests/e2e/core.rs
@@ -217,6 +217,25 @@ fn serve_end_to_end() {
         .unwrap()
         .iter()
         .any(|target| target["label"] == "//:lib" && target["targetDistance"] == 0));
+    let (status, body) = server
+        .get(&format!(
+            "/dependency_edges?from={from}&to={to}&profile=true"
+        ))
+        .unwrap();
+    assert_eq!(status, 200);
+    let graph: Value = serde_json::from_str(&body).unwrap();
+    assert!(
+        graph.get("from").is_none() && graph.get("impactedTargets").is_none(),
+        "body must be the generate-hashes graph, got {graph}"
+    );
+    assert!(
+        graph
+            .as_object()
+            .unwrap()
+            .keys()
+            .any(|label| label.trim_start_matches("@@") == "//:lib" || label.contains(":lib")),
+        "expected //:lib in dep-edges graph, got {graph}"
+    );
 }
 
 #[test]

--- a/tools/readme_template.md
+++ b/tools/readme_template.md
@@ -189,6 +189,24 @@ curl 'http://localhost:8080/impacted_targets_with_distances?from=main&to=my-feat
 }
 ```
 
+* `GET /dependency_edges?from=<rev>&to=<rev>` — returns the generate-hashes dependency-edge graph
+  for the **`to` revision**, byte-compatible with `generate-hashes --depEdgesFile`. The body is a JSON
+  object mapping each label to its direct deps — **not** the per-target distance summary from
+  `/impacted_targets_with_distances`, and not wrapped in `from`/`to`/`impactedTargets`. Requires
+  `--trackDeps`; otherwise this endpoint returns `400`. `profile=true` is accepted and ignored so
+  clients can reuse the same query string as the other endpoints. The graph is always the full
+  (unscoped) map; `modifiedFilepaths` on POST does not shrink it.
+
+```bash
+curl 'http://localhost:8080/dependency_edges?from=main&to=my-feature-branch'
+```
+
+```json
+{
+  "//foo:bar": ["//foo:lib", "//bar:baz"]
+}
+```
+
 * `GET /metrics` — returns a JSON snapshot of the instance so callers and monitoring can see its
   identity, liveness, and cache size usage without scraping logs. Unlike the query endpoints it is
   never gated on readiness, so it still responds on an un-ready or lame-ducked instance (the `ready`
@@ -243,7 +261,8 @@ lifecycle policy instead.
 
 Notes and current limitations:
 
-* Distance metrics (`/impacted_targets_with_distances`) require the dependency-edge graph, which is
+* Distance metrics (`/impacted_targets_with_distances`) and the generate-hashes graph
+  (`/dependency_edges`) require the dependency-edge graph, which is
   only tracked when the server is started with `--trackDeps`. Tracking deps grows each cached hash
   entry, so it is opt-in. The flag is folded into the cache key, so enabling or disabling it never
   reuses a previously cached entry of the other kind. This mirrors the `generate-hashes --depEdgesFile`


### PR DESCRIPTION
## Summary
- Add `GET /dependency_edges?from=&to=` returning the generate-hashes dep-edges graph for the `to` revision
- Return 400 when the server was started without `--trackDeps` (same miss contract as distances)
- Body is the raw label → deps map, not wrapped in `from` / `to` / `profile`

## Details
Clients that BFS-walk `target_distance_deps_file.json` cannot reconstruct that graph from `/impacted_targets_with_distances`. This endpoint is the serve-side publisher for that file.

`profile=true` is accepted and ignored so callers can reuse the same query string as the other endpoints. `modifiedFilepaths` does not shrink the map — PRI/CRI need every edge.

Companion Backstage publisher: [TinderApp/backstage#1001](https://github.com/TinderApp/backstage/pull/1001).

## Testing
- [x] `bazelisk test //src:rust_tests //:rust_format_check`
- [x] Library tests for 400 without `--trackDeps` and 200 unwrapped graph body
- [ ] E2E `//tests:e2e_test` (extended `serve_end_to_end`; runs in CI)

## Steps to Test or Reproduce
1. Start `bazel-diff serve --trackDeps` and request `GET /dependency_edges?from=<rev>&to=<rev>&profile=true`
2. Confirm the JSON is `{ "//pkg:target": ["//dep:label", ...] }` with no `impactedTargets` wrapper

### Expected Results
200 with the generate-hashes graph when `--trackDeps` is on; 400 `dependency edges unavailable` without it.

## Jira
[CPP-14661](https://gotinder.atlassian.net/browse/CPP-14661)
