### PR TITLE
fix(serve): stop treating S3 hash-cache misses as errors in the Rust serve path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ buffa = "0.9.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 hex = "0.4"
 rayon = "1.10"
-rust-s3 = { version = "=0.36.0", default-features = false, features = ["sync-rustls-tls", "fail-on-err"] }
+rust-s3 = { version = "=0.36.0", default-features = false, features = ["sync-rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -247,7 +247,8 @@ crate.from_cargo(
     # crate_universe refuses to run from_cargo in a non-root module without a
     # checked-in cargo-bazel lockfile (repinning can't cross module boundaries),
     # so BCR consumers need this file shipped in the release archive.
-    # Regenerate with: CARGO_BAZEL_REPIN=1 bazel sync --only=bazel_diff_crates
+    # Regenerate with: CARGO_BAZEL_REPIN=1 bazel build //:bazel-diff-rust
+    # (`bazel sync` is WORKSPACE-only and this module is bzlmod-only).
     lockfile = "//:cargo-bazel-lock.json",
     manifests = ["//:Cargo.toml"],
 )

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "81383baeb244c49e4bacf82cb1027f19a216a6c594fe793722976320fa46e4aa",
+  "checksum": "706ee75673bec5e4d514fe0bc1ea91301131838f7d2e0c76e4dac7644a73a68f",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -6502,7 +6502,6 @@
         "crate_features": {
           "common": [
             "attohttpc",
-            "fail-on-err",
             "sync",
             "sync-rustls-tls"
           ],

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,7 @@ use crate::model::{
 use crate::module_graph::impacted_with_module_changes;
 use anyhow::{anyhow, bail, Context, Result};
 use s3::creds::Credentials;
-use s3::error::S3Error;
+use s3::request::ResponseData;
 use s3::{Bucket, Region};
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -92,39 +92,51 @@ impl RemoteCache {
 
     /// Reads an entry, degrading to a miss on any failure.
     ///
-    /// Deliberately a bare `GetObject` with no `HeadObject` probe in front of it. Besides costing a
-    /// second round trip on every hit, `head_object` is unusable with this client stack: S3 answers
-    /// a HEAD miss with `404`, `Transfer-Encoding: chunked` and no body, and `rust-s3`'s
-    /// `fail-on-err` feature builds its error by *reading* that body -- so the 404 surfaces as
-    /// `attohttpc: Io Error: unexpected end of file` instead of [`S3Error::HttpFailWithBody`], and
-    /// every miss logs a warning. A GET miss carries a real `NoSuchKey` body, so it classifies.
+    /// Deliberately a bare `GetObject` with no `HeadObject` probe in front of it: besides costing a
+    /// second round trip on every hit, `head_object` cannot report a miss here. S3 answers a HEAD
+    /// miss with `404`, `Transfer-Encoding: chunked` and no body, and every HTTP client on this
+    /// stack fails reading that absent body -- `attohttpc: Io Error: unexpected end of file`. A GET
+    /// miss carries a real `NoSuchKey` body, so it reads back cleanly.
     fn get(&self, key: &str) -> Option<Vec<u8>> {
-        match self.bucket.get_object(self.object_key(key)) {
-            Ok(response) if response.status_code() == 200 => Some(response.to_vec()),
-            Ok(_) => None,
-            Err(error) if is_s3_not_found(&error) => None,
-            Err(error) => {
-                eprintln!(
-                    "[Warn] S3 cache read of {} failed (treating as a miss): {error}",
-                    self.object_key(key)
-                );
-                None
-            }
-        }
+        let failure = match self.bucket.get_object(self.object_key(key)) {
+            Ok(response) if response.status_code() == 200 => return Some(response.to_vec()),
+            Ok(response) if response.status_code() == 404 => return None,
+            Ok(response) => http_failure(&response),
+            Err(error) => error.to_string(),
+        };
+        eprintln!(
+            "[Warn] S3 cache read of {} failed (treating as a miss): {failure}",
+            self.object_key(key)
+        );
+        None
     }
 
     fn put(&self, key: &str, data: &[u8]) {
-        if let Err(error) = self.bucket.put_object(self.object_key(key), data) {
-            eprintln!(
-                "[Warn] S3 cache write of {} failed (entry not shared): {error}",
-                self.object_key(key)
-            );
-        }
+        let failure = match self.bucket.put_object(self.object_key(key), data) {
+            Ok(response) if (200..300).contains(&response.status_code()) => return,
+            Ok(response) => http_failure(&response),
+            Err(error) => error.to_string(),
+        };
+        eprintln!(
+            "[Warn] S3 cache write of {} failed (entry not shared): {failure}",
+            self.object_key(key)
+        );
     }
 }
 
-fn is_s3_not_found(error: &S3Error) -> bool {
-    matches!(error, S3Error::HttpFailWithBody(404, _))
+/// Renders a non-2xx response for a warning, matching how `S3Error::HttpFailWithBody` reads.
+///
+/// Statuses are classified here rather than by `rust-s3`'s `fail-on-err` feature, which is
+/// deliberately off: it turns every non-2xx into an error *after* reading the body, and the read
+/// happens inside `rust-s3`'s `retry!`, so a plain 404 miss cost a duplicate request and a
+/// one-second backoff sleep before being recognized as a miss. `retry!` still covers transport
+/// errors, which are the ones worth retrying.
+fn http_failure(response: &ResponseData) -> String {
+    format!(
+        "Got HTTP {} with content '{}'",
+        response.status_code(),
+        response.as_str().unwrap_or("<non-utf8 body>").trim()
+    )
 }
 
 fn normalize_s3_prefix(prefix: &str) -> String {
@@ -1140,14 +1152,6 @@ mod tests {
         assert_eq!(normalize_s3_prefix(""), "");
         assert_eq!(normalize_s3_prefix("/"), "");
         assert_eq!(normalize_s3_prefix("/team/cache/"), "team/cache/");
-        assert!(is_s3_not_found(&S3Error::HttpFailWithBody(
-            404,
-            "missing".into()
-        )));
-        assert!(!is_s3_not_found(&S3Error::HttpFailWithBody(
-            500,
-            "failure".into()
-        )));
         assert!(RemoteCache::new(&test_config()).unwrap().is_none());
     }
 
@@ -1169,7 +1173,7 @@ mod tests {
             .all(|request| request.url.contains("/bucket/team/repo/sha.fp.json")));
         // A read is a single GET: a HeadObject probe in front of it would double the round trips
         // and, worse, cannot report a miss -- S3 frames a HEAD 404 as chunked with no body, which
-        // `rust-s3` surfaces as `attohttpc: Io Error: unexpected end of file`.
+        // the client surfaces as `attohttpc: Io Error: unexpected end of file`.
         assert_eq!(
             captured
                 .iter()
@@ -1181,27 +1185,34 @@ mod tests {
 
     #[test]
     fn remote_cache_misses_and_errors_degrade_without_failing() {
-        // `rust-s3` wraps each request in its `retry!` macro and, with the `fail-on-err` feature,
-        // treats any non-2xx as an error -- so every failing call here is attempted twice.
-        let missing = b"<Error><Code>NoSuchKey</Code></Error>".to_vec();
         let (remote, requests, handle) = remote_cache_with_responses(
             "",
             vec![
-                (404, missing.clone()),
-                (404, missing),
+                (404, b"<Error><Code>NoSuchKey</Code></Error>".to_vec()),
                 (500, b"failure".to_vec()),
-                (500, b"failure".to_vec()),
-                (500, Vec::new()),
                 (500, Vec::new()),
             ],
         );
         assert_eq!(remote.get("missing"), None);
         assert_eq!(remote.get("failure"), None);
         remote.put("failure", b"data");
-        for _ in 0..6 {
+        // Exactly one request per call. `rust-s3`'s `fail-on-err` feature is off precisely so a
+        // non-2xx stays a response: as an error it would enter the crate's `retry!`, and every
+        // miss would cost a second request and a one-second backoff sleep.
+        for _ in 0..3 {
             requests.recv_timeout(Duration::from_secs(5)).unwrap();
         }
+        assert!(requests.recv_timeout(Duration::from_millis(200)).is_err());
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn remote_cache_reports_unexpected_statuses_with_their_body() {
+        let response = ResponseData::new("denied".into(), 403, std::collections::HashMap::new());
+        assert_eq!(
+            http_failure(&response),
+            "Got HTTP 403 with content 'denied'"
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -90,6 +90,14 @@ impl RemoteCache {
         format!("{}{key}.json", self.prefix)
     }
 
+    /// Reads an entry, degrading to a miss on any failure.
+    ///
+    /// Deliberately a bare `GetObject` with no `HeadObject` probe in front of it. Besides costing a
+    /// second round trip on every hit, `head_object` is unusable with this client stack: S3 answers
+    /// a HEAD miss with `404`, `Transfer-Encoding: chunked` and no body, and `rust-s3`'s
+    /// `fail-on-err` feature builds its error by *reading* that body -- so the 404 surfaces as
+    /// `attohttpc: Io Error: unexpected end of file` instead of [`S3Error::HttpFailWithBody`], and
+    /// every miss logs a warning. A GET miss carries a real `NoSuchKey` body, so it classifies.
     fn get(&self, key: &str) -> Option<Vec<u8>> {
         match self.bucket.get_object(self.object_key(key)) {
             Ok(response) if response.status_code() == 200 => Some(response.to_vec()),
@@ -111,20 +119,6 @@ impl RemoteCache {
                 "[Warn] S3 cache write of {} failed (entry not shared): {error}",
                 self.object_key(key)
             );
-        }
-    }
-
-    fn contains(&self, key: &str) -> bool {
-        match self.bucket.head_object(self.object_key(key)) {
-            Ok((_, status)) => status == 200,
-            Err(error) if is_s3_not_found(&error) => false,
-            Err(error) => {
-                eprintln!(
-                    "[Warn] S3 cache check of {} failed (treating as a miss): {error}",
-                    self.object_key(key)
-                );
-                false
-            }
         }
     }
 }
@@ -573,12 +567,10 @@ fn get_hashes_locked(
         return Ok((data, true));
     }
     if let Some(remote) = &state.remote {
-        if remote.contains(&key) {
-            if let Some(bytes) = remote.get(&key) {
-                let data = HashFileData::from_slice(&bytes)?;
-                fs::write(&path, &bytes)?;
-                return Ok((data, true));
-            }
+        if let Some(bytes) = remote.get(&key) {
+            let data = HashFileData::from_slice(&bytes)?;
+            fs::write(&path, &bytes)?;
+            return Ok((data, true));
         }
     }
     checkout(state, sha)?;
@@ -1048,6 +1040,7 @@ mod tests {
     }
 
     struct CapturedS3Request {
+        method: String,
         url: String,
     }
 
@@ -1067,6 +1060,7 @@ mod tests {
                 let request = server.recv().unwrap();
                 sender
                     .send(CapturedS3Request {
+                        method: request.method().as_str().to_owned(),
                         url: request.url().to_owned(),
                     })
                     .unwrap();
@@ -1161,43 +1155,50 @@ mod tests {
     fn remote_cache_operations_use_normalized_key_and_succeed() {
         let (remote, requests, handle) = remote_cache_with_responses(
             "/team/repo/",
-            vec![
-                (200, b"hello".to_vec()),
-                (200, Vec::new()),
-                (200, Vec::new()),
-            ],
+            vec![(200, b"hello".to_vec()), (200, Vec::new())],
         );
         assert_eq!(remote.object_key("sha.fp"), "team/repo/sha.fp.json");
         assert_eq!(remote.get("sha.fp"), Some(b"hello".to_vec()));
         remote.put("sha.fp", b"data");
-        assert!(remote.contains("sha.fp"));
-        let captured = (0..3)
+        let captured = (0..2)
             .map(|_| requests.recv_timeout(Duration::from_secs(5)).unwrap())
             .collect::<Vec<_>>();
         handle.join().unwrap();
         assert!(captured
             .iter()
             .all(|request| request.url.contains("/bucket/team/repo/sha.fp.json")));
+        // A read is a single GET: a HeadObject probe in front of it would double the round trips
+        // and, worse, cannot report a miss -- S3 frames a HEAD 404 as chunked with no body, which
+        // `rust-s3` surfaces as `attohttpc: Io Error: unexpected end of file`.
+        assert_eq!(
+            captured
+                .iter()
+                .map(|request| request.method.as_str())
+                .collect::<Vec<_>>(),
+            vec!["GET", "PUT"]
+        );
     }
 
     #[test]
     fn remote_cache_misses_and_errors_degrade_without_failing() {
+        // `rust-s3` wraps each request in its `retry!` macro and, with the `fail-on-err` feature,
+        // treats any non-2xx as an error -- so every failing call here is attempted twice.
+        let missing = b"<Error><Code>NoSuchKey</Code></Error>".to_vec();
         let (remote, requests, handle) = remote_cache_with_responses(
             "",
             vec![
-                (404, b"missing".to_vec()),
+                (404, missing.clone()),
+                (404, missing),
                 (500, b"failure".to_vec()),
-                (404, Vec::new()),
+                (500, b"failure".to_vec()),
                 (500, Vec::new()),
                 (500, Vec::new()),
             ],
         );
         assert_eq!(remote.get("missing"), None);
         assert_eq!(remote.get("failure"), None);
-        assert!(!remote.contains("missing"));
-        assert!(!remote.contains("failure"));
         remote.put("failure", b"data");
-        for _ in 0..5 {
+        for _ in 0..6 {
             requests.recv_timeout(Duration::from_secs(5)).unwrap();
         }
         handle.join().unwrap();
@@ -1386,8 +1387,8 @@ mod tests {
             ..Default::default()
         };
         let bytes = serde_json::to_vec(&data.serialized(true, false)).unwrap();
-        let (remote, requests, handle) =
-            remote_cache_with_responses("", vec![(200, Vec::new()), (200, bytes)]);
+        // One GET serves the whole lookup; the second read is answered by the local backfill.
+        let (remote, requests, handle) = remote_cache_with_responses("", vec![(200, bytes)]);
         let mut config = test_config();
         config.hash_options.bazel.workspace = repo.path().to_path_buf();
         config.git_path = PathBuf::from("git");
@@ -1411,9 +1412,8 @@ mod tests {
         assert!(second_hit);
         assert_eq!(second.hashes["//app:lib"].hash, "overall");
 
-        for _ in 0..2 {
-            requests.recv_timeout(Duration::from_secs(5)).unwrap();
-        }
+        requests.recv_timeout(Duration::from_secs(5)).unwrap();
+        assert!(requests.recv_timeout(Duration::from_millis(200)).is_err());
         handle.join().unwrap();
     }
 


### PR DESCRIPTION
## What

`bazel-diff serve` (Rust) logged this on **every** remote cache miss:

```
[Warn] S3 cache check of bazel-diff/<team>/<sha>.<fingerprint>.json failed (treating as a miss): attohttpc: Io Error: unexpected end of file
```

Two commits, both about the same underlying mistake — a cache miss was being handled as a failure:

1. **Drop the `HeadObject` probe.** `get_hashes_locked` ran `RemoteCache::contains` (a HEAD) before the `GetObject`; the read is now a bare `GetObject`.
2. **Drop `rust-s3`'s `fail-on-err` feature** and classify HTTP statuses in `RemoteCache` directly.

## Why

### The warning

S3 answers a HEAD on a missing key like this — confirmed with a live `curl -X HEAD` against S3:

```
HTTP/1.1 404 Not Found
Content-Type: application/xml
Transfer-Encoding: chunked
Server: AmazonS3
```

Chunked framing, but no body — a HEAD response must not carry one. Under `fail-on-err`, `rust-s3` builds its error for a non-2xx by *reading* that body; attohttpc's chunked reader hits EOF on the first chunk-size line and returns `S3Error::Atto(Io ...)` instead of `HttpFailWithBody(404, _)`. `is_s3_not_found` matched only the latter, so a plain miss was never classified and warned instead.

The lookup still degraded correctly — an unclassified error is treated as a miss — so this was noise rather than a wrong answer. But it made the log useless for spotting real S3 trouble, and with this client stack `head_object` cannot distinguish a genuine failure from a miss at all: every non-2xx HEAD fails the same opaque way. Dropping the probe also halves the S3 round trips on a cache hit (was HEAD + GET).

### The retry tax

`fail-on-err` turns every non-2xx into an error, and that error is produced *inside* `rust-s3`'s `retry!` macro. So a 404 miss was retried. Measured against a loopback S3 before the change: one `get` of a missing key issued **2 requests over 1.008s** — a duplicate request plus a one-second backoff sleep on every miss. The unit suite drops from 3.02s to 0.44s with the feature off, which is those sleeps disappearing.

With the feature off, `RemoteCache` classifies statuses itself: `200` is a hit, `404` is a miss, anything else warns with the status and body. The warning text is rendered exactly the way `S3Error::HttpFailWithBody` displayed it (`Got HTTP 500 with content '...'`), so existing log greps still match. `retry!` still wraps transport errors, which are the ones actually worth retrying.

`put` also gains a real check: it now requires a 2xx, where previously a non-2xx write was silently accepted as a successful publish (only a transport error was reported).

## Notes for the reviewer

- `cargo-bazel-lock.json` is repinned for the feature change — the diff is the checksum plus one removed `crate_features` entry.
- Repinning turned up that the regeneration command recorded in `MODULE.bazel` no longer works: `bazel sync` is WORKSPACE-only and this module is bzlmod-only. Corrected in place to `CARGO_BAZEL_REPIN=1 bazel build //:bazel-diff-rust`.
- `RemoteCache::contains` had exactly one caller and is deleted; the Kotlin `S3HashCacheStorage.contains` is untouched (the AWS SDK maps the bare 404 itself, and it backs the `HashCacheStorage` interface there).
- The reasoning is captured in doc comments on `RemoteCache::get` and `http_failure`, and in the test comments, so neither the HEAD probe nor `fail-on-err` gets reintroduced by accident.
- Tests: the read-path test asserts the request methods are exactly `["GET", "PUT"]`; the error-path test asserts exactly one request per call (a reintroduced `retry!` would double them); the backfill test asserts a single S3 request serves both lookups; and a new test pins the warning rendering for an unexpected status.

## Test plan

- `cargo test --lib` — 83/83 pass
- `bazel test //src:rust_tests` — passes
- `cargo clippy --all-targets` clean, `cargo fmt --check` clean, `bazel run //cli/format:buildifier` no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)