### PR TITLE
Add musl arm64 Rust release binaries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,16 +39,19 @@ build:release --@rules_rust//rust/settings:lto=thin
 # property of the toolchain, which would change every build, not just releases.
 build:release --@rules_rust//rust/settings:extra_rustc_flags=-Cstrip=symbols
 
-# Linux release artifacts: `bazel build //release:bazel-diff-rust --config=release-musl`.
-# Everything --config=release does, but built for a musl platform, which makes
-# the published Linux binary statically linked: it runs on any distribution
-# instead of requiring the glibc of whatever runner built it. //platforms
-# explains the constraint; MODULE.bazel wires up the Rust and C toolchains it
-# selects. Cross-compiles, so this config works on a glibc Linux host and on an
-# Apple Silicon Mac -- the asset name is derived from the target platform, so it
-# is bazel-diff-rust-linux-amd64 either way.
+# Linux release artifacts: `bazel build //release:bazel-diff-rust --config=release-musl`
+# (amd64) or `--config=release-musl-arm64` (arm64). Everything --config=release
+# does, but built for a musl platform, which makes the published Linux binary
+# statically linked: it runs on any distribution instead of requiring the glibc
+# of whatever runner built it. //platforms explains the constraint; MODULE.bazel
+# wires up the Rust and C toolchains it selects. Cross-compiles, so these
+# configs work on a glibc Linux host and on an Apple Silicon Mac -- the asset
+# name is derived from the target platform.
 build:release-musl --config=release
 build:release-musl --platforms=//platforms:linux_x86_64_musl
+
+build:release-musl-arm64 --config=release
+build:release-musl-arm64 --platforms=//platforms:linux_aarch64_musl
 
 # Avoid cache thrashing, but allow integration tests to find "bazel" on the PATH.
 common --incompatible_strict_action_env

--- a/.github/workflows/assert_static_binary.sh
+++ b/.github/workflows/assert_static_binary.sh
@@ -6,9 +6,10 @@
 # in release.yaml (before the asset is uploaded), so a regression cannot reach a
 # release without failing a PR first.
 #
-# The build flag that makes this true is --config=release-musl (see .bazelrc).
-# Losing it does not break the build -- it silently produces a glibc-linked
-# binary -- which is exactly why this is asserted rather than assumed.
+# The build flag that makes this true is --config=release-musl or
+# --config=release-musl-arm64 (see .bazelrc). Losing it does not break the
+# build -- it silently produces a glibc-linked binary -- which is exactly why
+# this is asserted rather than assumed.
 
 set -o errexit -o nounset -o pipefail
 
@@ -48,6 +49,28 @@ if strings -a "$BINARY" | grep -q "GLIBC_"; then
 fi
 
 # Nothing above proves the binary runs, only that it is self-contained.
-"$BINARY" --version
+# Cross-built assets (aarch64 musl on an x86_64 runner) cannot exec here;
+# file/readelf already covered static linking.
+host_arch=$(uname -m)
+elf_machine=$(readelf -h "$BINARY" | sed -n 's/^[[:space:]]*Machine:[[:space:]]*//p')
+can_exec=false
+case "$host_arch" in
+  x86_64|amd64)
+    if [[ "$elf_machine" == *"X86-64"* ]]; then
+      can_exec=true
+    fi
+    ;;
+  aarch64|arm64)
+    if [[ "$elf_machine" == *"AArch64"* ]]; then
+      can_exec=true
+    fi
+    ;;
+esac
+
+if [[ "$can_exec" == true ]]; then
+  "$BINARY" --version
+else
+  echo "Skipping --version: ELF machine '$elf_machine' is not runnable on $host_arch"
+fi
 
 echo "OK: $BINARY is statically linked"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -336,11 +336,14 @@ jobs:
         # librustc_std_workspace_alloc-<hash>.rlib comes to 263 characters and
         # the link fails with LNK1181. C:/b buys back 35.
         #
-        # release_config is `release-musl` on Linux: the published Linux binary
-        # is statically linked against musl so it does not inherit the runner's
-        # glibc as a floor on the systems it runs on. It is a cross-compile, not
-        # a different runner, so it stays in this row. macOS and Windows link
-        # their platform's own libc and use the plain `release` config.
+        # release_config is `release-musl` on Linux: the published Linux amd64
+        # binary is statically linked against musl so it does not inherit the
+        # runner's glibc as a floor. It is a cross-compile, not a different
+        # runner, so it stays in this row. The linux-arm64 musl asset is built
+        # in extra steps on this same job (not a second matrix row) so the
+        # check name stays `release-artifacts (ubuntu-latest)`. macOS and
+        # Windows link their platform's own libc and use the plain `release`
+        # config.
         include:
           - os: ubuntu-latest
             java: '11'
@@ -431,4 +434,19 @@ jobs:
         with:
           name: ${{ matrix.rust_asset }}
           path: bazel-bin/release/${{ matrix.rust_asset }}
+          if-no-files-found: error
+      # Second published Linux asset, built in this same job so the status check
+      # stays `release-artifacts (ubuntu-latest)`. A matrix row with the same
+      # `os` would duplicate that name and break branch protection.
+      - name: Build Rust binary (linux-arm64 musl)
+        if: runner.os == 'Linux'
+        run: bazelisk build //release:bazel-diff-rust --config=release-musl-arm64
+      - name: Assert Linux arm64 binary is statically linked
+        if: runner.os == 'Linux'
+        run: .github/workflows/assert_static_binary.sh bazel-bin/release/bazel-diff-rust-linux-arm64
+      - uses: actions/upload-artifact@v4
+        if: runner.os == 'Linux'
+        with:
+          name: bazel-diff-rust-linux-arm64
+          path: bazel-bin/release/bazel-diff-rust-linux-arm64
           if-no-files-found: error

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,13 +157,20 @@ jobs:
         # stdlib rlib ...\librustc_std_workspace_alloc-<hash>.rlib comes to 263
         # characters and the link fails with LNK1181. Keep in sync with the
         # `release-artifacts` job in ci.yaml, which is where this gets exercised
-        # per-PR -- including release_config, which builds the Linux asset
-        # statically against musl so it runs on any distribution rather than
-        # requiring the runner's glibc or newer.
+        # per-PR -- including release_config, which builds the Linux assets
+        # statically against musl so they run on any distribution rather than
+        # requiring the runner's glibc or newer. linux-arm64 is a second Ubuntu
+        # row here (jobs are named by asset) but extra steps in the same CI job
+        # so that check name does not change.
         include:
           - os: ubuntu-latest
             asset: bazel-diff-rust-linux-amd64
             release_config: release-musl
+            bazel_startup_flags: ""
+            bazel_extra_flags: ""
+          - os: ubuntu-latest
+            asset: bazel-diff-rust-linux-arm64
+            release_config: release-musl-arm64
             bazel_startup_flags: ""
             bazel_extra_flags: ""
           - os: macos-latest

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -40,6 +40,7 @@ http_archive(
 Prebuilt host-native CLIs (attached by the release workflow):
 
 - Linux amd64: https://github.com/Tinder/bazel-diff/releases/download/${TAG}/bazel-diff-rust-linux-amd64
+- Linux arm64: https://github.com/Tinder/bazel-diff/releases/download/${TAG}/bazel-diff-rust-linux-arm64
 - macOS arm64: https://github.com/Tinder/bazel-diff/releases/download/${TAG}/bazel-diff-rust-macos-arm64
 - Windows amd64: https://github.com/Tinder/bazel-diff/releases/download/${TAG}/bazel-diff-rust-windows-amd64.exe
 EOF

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -79,9 +79,9 @@ rust.toolchain(
     rustfmt_version = "1.90.0",
     # Confine the stock toolchains to platforms that use the system libc. They
     # are only constrained by os and cpu -- rules_rust has no musl constraint --
-    # so on //platforms:linux_x86_64_musl they would match alongside the musl
-    # toolchain below and resolution would silently take whichever of the two
-    # was registered first.
+    # so on //platforms:linux_x86_64_musl / linux_aarch64_musl they would match
+    # alongside the musl toolchain below and resolution would silently take
+    # whichever of the two was registered first.
     target_settings = ["//platforms:is_system_libc"],
     versions = ["1.90.0"],
 )
@@ -89,7 +89,7 @@ use_repo(rust, "rust_toolchains")
 
 register_toolchains("@rust_toolchains//:all")
 
-# Rust std for the statically linked musl release binary, cross-compiled from a
+# Rust std for the statically linked musl release binaries, cross-compiled from a
 # glibc Linux host (the release runner) or from an Apple Silicon Mac (so a
 # maintainer can reproduce the published binary locally). rustc itself is the
 # ordinary glibc build: only the target changes, which is what keeps proc-macro
@@ -107,6 +107,20 @@ rust.repository_set(
     target_settings = ["//platforms:is_musl"],
     target_triple = "x86_64-unknown-linux-musl",
     versions = ["1.90.0"],
+)
+
+# Same exec host, second published Linux asset (arm64 musl). Sharing the set
+# name avoids a second auto-emitted glibc x86_64 exec toolchain. exec_triple,
+# edition, versions, and target_settings may only appear on the first tag for a
+# given name.
+rust.repository_set(
+    name = "rust_musl_linux_x86_64",
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+        "//platforms:musl",
+    ],
+    target_triple = "aarch64-unknown-linux-musl",
 )
 
 # rules_rust also emits a toolchain for a set's own exec triple, so the set
@@ -140,6 +154,43 @@ rust.repository_set(
     target_settings = ["//platforms:is_musl"],
     target_triple = "x86_64-unknown-linux-musl",
     versions = ["1.90.0"],
+)
+
+rust.repository_set(
+    name = "rust_musl_macos_aarch64",
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+        "//platforms:musl",
+    ],
+    target_triple = "aarch64-unknown-linux-musl",
+)
+
+# Native ARM Linux host (Graviton, ubuntu-24.04-arm): same musl aarch64 target
+# as the x86_64-hosted set above, with a companion gnu tag so the auto-emitted
+# exec-triple toolchain does not collide with the stock glibc one.
+rust.repository_set(
+    name = "rust_musl_linux_aarch64",
+    edition = "2021",
+    exec_triple = "aarch64-unknown-linux-gnu",
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+        "//platforms:musl",
+    ],
+    target_settings = ["//platforms:is_musl"],
+    target_triple = "aarch64-unknown-linux-musl",
+    versions = ["1.90.0"],
+)
+
+rust.repository_set(
+    name = "rust_musl_linux_aarch64",
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+        "//platforms:system_libc",
+    ],
+    target_triple = "aarch64-unknown-linux-gnu",
 )
 
 # C toolchain for the musl target: a gcc cross-compiler bundled with musl libc,

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,22 @@ release_rust_binary:
 		//release:bazel-diff-rust \
 		--config=release
 
-# The published Linux binary, which is not host-native: it is statically linked
-# against musl so it runs on any distribution, and cross-compiles from a glibc
-# Linux host or an Apple Silicon Mac. Same output path and asset name.
+# The published Linux binaries, which are not host-native: they are statically
+# linked against musl so they run on any distribution, and cross-compile from a
+# glibc Linux host or an Apple Silicon Mac. Same output path and asset name.
 .PHONY: release_rust_binary_linux
 release_rust_binary_linux:
 	bazel \
 		build \
 		//release:bazel-diff-rust \
 		--config=release-musl
+
+.PHONY: release_rust_binary_linux_arm64
+release_rust_binary_linux_arm64:
+	bazel \
+		build \
+		//release:bazel-diff-rust \
+		--config=release-musl-arm64
 
 .PHONY: build_rust
 build_rust:

--- a/README.md
+++ b/README.md
@@ -957,6 +957,10 @@ GitHub Releases also ship prebuilt binaries:
 curl -Lo bazel-diff-rust https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff-rust-linux-amd64
 chmod +x bazel-diff-rust
 
+# Linux arm64 (same musl static linking)
+curl -Lo bazel-diff-rust https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff-rust-linux-arm64
+chmod +x bazel-diff-rust
+
 # macOS arm64
 curl -Lo bazel-diff-rust https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff-rust-macos-arm64
 chmod +x bazel-diff-rust
@@ -971,14 +975,17 @@ whatever lands in `bazel-bin/release/`, so `//release:bazel-diff-rust` names the
 platform it was built for (`bazel-diff-rust-<os>-<arch>`, plus `.exe` on Windows):
 
 ```terminal
-make release_rust_binary         # bazel build //release:bazel-diff-rust --config=release
-make release_rust_binary_linux   # ... --config=release-musl
+make release_rust_binary              # bazel build //release:bazel-diff-rust --config=release
+make release_rust_binary_linux        # ... --config=release-musl
+make release_rust_binary_linux_arm64  # ... --config=release-musl-arm64
 ```
 
-`--config=release-musl` targets `//platforms:linux_x86_64_musl`, which selects a musl Rust std
-and a musl C toolchain, so the Linux asset is statically linked instead of inheriting the build
-runner's glibc as a version floor. It is a cross-compile: the same command produces the same
-`bazel-diff-rust-linux-amd64` on a glibc Linux host and on an Apple Silicon Mac.
+`--config=release-musl` and `--config=release-musl-arm64` target
+`//platforms:linux_x86_64_musl` and `//platforms:linux_aarch64_musl`, which select a musl Rust
+std and a musl C toolchain, so the Linux assets are statically linked instead of inheriting the
+build runner's glibc as a version floor. They are cross-compiles: the same commands produce
+`bazel-diff-rust-linux-amd64` and `bazel-diff-rust-linux-arm64` on a glibc Linux host and on an
+Apple Silicon Mac.
 
 ### Performance gate
 

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -11,7 +11,7 @@
 package(default_visibility = ["//visibility:public"])
 
 # `system_libc` is the default, so @platforms//host and every stock platform
-# satisfies it without declaring anything: only the musl platform below opts out.
+# satisfies it without declaring anything: only the musl platforms below opt out.
 constraint_setting(
     name = "libc",
     default_constraint_value = ":system_libc",
@@ -42,15 +42,25 @@ config_setting(
     constraint_values = [":musl"],
 )
 
-# The platform the published Linux binary is built for:
-# `bazel build //release:bazel-diff-rust --config=release-musl`. Statically
-# linked against musl, so the binary does not depend on the glibc version of the
-# machine that runs it. Reachable from a glibc Linux host and from an Apple
-# Silicon Mac -- both the Rust std and the C toolchain cross-compile.
+# Platforms the published Linux binaries are built for:
+# `bazel build //release:bazel-diff-rust --config=release-musl` (amd64) and
+# `--config=release-musl-arm64` (arm64). Statically linked against musl, so the
+# binary does not depend on the glibc version of the machine that runs it.
+# Reachable from a glibc Linux host and from an Apple Silicon Mac -- both the
+# Rust std and the C toolchain cross-compile.
 platform(
     name = "linux_x86_64_musl",
     constraint_values = [
         "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+        ":musl",
+    ],
+)
+
+platform(
+    name = "linux_aarch64_musl",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
         "@platforms//os:linux",
         ":musl",
     ],

--- a/tools/readme_template.md
+++ b/tools/readme_template.md
@@ -480,6 +480,10 @@ GitHub Releases also ship prebuilt binaries:
 curl -Lo bazel-diff-rust https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff-rust-linux-amd64
 chmod +x bazel-diff-rust
 
+# Linux arm64 (same musl static linking)
+curl -Lo bazel-diff-rust https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff-rust-linux-arm64
+chmod +x bazel-diff-rust
+
 # macOS arm64
 curl -Lo bazel-diff-rust https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff-rust-macos-arm64
 chmod +x bazel-diff-rust
@@ -494,14 +498,17 @@ whatever lands in `bazel-bin/release/`, so `//release:bazel-diff-rust` names the
 platform it was built for (`bazel-diff-rust-<os>-<arch>`, plus `.exe` on Windows):
 
 ```terminal
-make release_rust_binary         # bazel build //release:bazel-diff-rust --config=release
-make release_rust_binary_linux   # ... --config=release-musl
+make release_rust_binary              # bazel build //release:bazel-diff-rust --config=release
+make release_rust_binary_linux        # ... --config=release-musl
+make release_rust_binary_linux_arm64  # ... --config=release-musl-arm64
 ```
 
-`--config=release-musl` targets `//platforms:linux_x86_64_musl`, which selects a musl Rust std
-and a musl C toolchain, so the Linux asset is statically linked instead of inheriting the build
-runner's glibc as a version floor. It is a cross-compile: the same command produces the same
-`bazel-diff-rust-linux-amd64` on a glibc Linux host and on an Apple Silicon Mac.
+`--config=release-musl` and `--config=release-musl-arm64` target
+`//platforms:linux_x86_64_musl` and `//platforms:linux_aarch64_musl`, which select a musl Rust
+std and a musl C toolchain, so the Linux assets are statically linked instead of inheriting the
+build runner's glibc as a version floor. They are cross-compiles: the same commands produce
+`bazel-diff-rust-linux-amd64` and `bazel-diff-rust-linux-arm64` on a glibc Linux host and on an
+Apple Silicon Mac.
 
 ### Performance gate
 


### PR DESCRIPTION
## Summary
- Publish `bazel-diff-rust-linux-arm64`, a statically linked musl CLI built with `--config=release-musl-arm64` (`//platforms:linux_aarch64_musl`), alongside the existing amd64 musl asset.
- Wire Rust std for `aarch64-unknown-linux-musl` from Linux x86_64 CI, Apple Silicon, and native ARM Linux hosts; PR CI builds the new asset in the existing Ubuntu job so the `release-artifacts (ubuntu-latest)` check name stays stable.
- Skip `--version` in the static-link assert when the ELF cannot run on the runner (cross-built aarch64 on x86_64).

## Test plan
- [ ] Confirm `make release_rust_binary_linux_arm64` produces `bazel-bin/release/bazel-diff-rust-linux-arm64` as a static aarch64 ELF (`file` reports ARM aarch64, statically linked).
- [ ] Confirm `release-artifacts (ubuntu-latest)` still builds, asserts, and uploads both `bazel-diff-rust-linux-amd64` and `bazel-diff-rust-linux-arm64`.
- [ ] After merge, confirm the next GitHub Release attaches `bazel-diff-rust-linux-arm64` and lists it in the release notes.


Made with [Cursor](https://cursor.com)