### PR TITLE
feat(explain): attribute an impacted target to its root-cause targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,90 @@ This will produce an impacted targets json list with target label, target distan
 ]
 ```
 
+## Explaining Why a Target Was Impacted
+
+`get-impacted-targets` tells you *that* `//service/a:app` needs rebuilding. It does not tell you
+*why* — and a service can be impacted for several reasons at once: it changed itself, a shared
+module it depends on changed, or both. `explain` answers that question by attributing the target's
+hash change to the upstream target(s) actually responsible, and by showing the dependency path the
+change travelled along. See [issue #479](https://github.com/Tinder/bazel-diff/issues/479).
+
+It reads the same three files `get-impacted-targets` consumes — it runs no `bazel query` and needs
+no workspace — so it is cheap to run after the fact on a CI machine that only kept the artifacts:
+
+```bash
+bazel-diff generate-hashes -w /path/to/workspace -b bazel --depEdgesFile deps.json final_hashes.json
+
+bazel-diff explain \
+  -sh starting_hashes.json \
+  -fh final_hashes.json \
+  -d deps.json \
+  --target //service/a:app
+```
+
+```text
+//service/a:app  [Rule]
+IMPACTED (directly -- this target changed on its own)
+
+Root causes: 3
+
+  1. //service/a:app  [Rule]
+     the rule's own definition or attributes changed
+     0 hops -- this is the queried target itself
+     //service/a:app
+
+  2. //service/a:main.py  [SourceFile]
+     source file content changed
+     1 hop (0 package boundaries crossed)
+     //service/a:main.py -> //service/a:app
+
+  3. //common/data:util.py  [SourceFile]
+     source file content changed
+     3 hops (2 package boundaries crossed)
+     //common/data:util.py -> //common:gen_srcs -> //common:lib -> //service/a:app
+```
+
+A **root cause** is a target whose *own* hash changed — its `directHash` moved, or it is new in the
+final revision. Everything between a root cause and the queried target merely carried the change
+downstream. This is the same DIRECT/INDIRECT classification that backs the distance metrics above,
+so `explain` and `--depEdgesFile` always agree on which targets are roots.
+
+`--depEdgesFile` is required: attribution is a walk over those edges. Generate it with
+`generate-hashes --depEdgesFile` (or, on the query service, fetch it from `GET /dependency_edges`).
+
+### Visualizing the blame graph
+
+`--format dot` and `--format mermaid` emit the blame subgraph — the queried target, the root causes,
+and the targets that carried the change between them. Only that subgraph is rendered, never the
+whole impacted set, which is what keeps the output readable on a monorepo.
+
+```bash
+bazel-diff explain -sh starting_hashes.json -fh final_hashes.json -d deps.json \
+  --target //service/a:app --format dot -o why.dot
+dot -Tsvg why.dot -o why.svg
+```
+
+Edges point in **impact-propagation** direction — root cause at the top, queried target at the
+bottom — so reading downward follows the change as it flows in. (This is the reverse of the
+`--depEdgesFile` orientation, which maps a label to the deps it consumes.)
+
+`--format mermaid` emits a `flowchart TD` that renders inline in a GitHub comment or PR description,
+which is handy for posting "here is why your PR rebuilt these targets" from CI. Each role has its
+own border color *and* node shape *and* an explicit role label, so the graph stays readable in
+monochrome and for viewers who cannot separate the two hues.
+
+`--format json` gives the same data structurally (root causes, paths, nodes, edges) for feeding
+another tool.
+
+### Bounding the output
+
+A target deep in a monorepo can have a great many root causes. Two knobs bound the work, and
+neither ever truncates silently — the full count is always reported:
+
+* `--maxRootCauses` (default `25`) reports only the nearest N root causes. `0` means all of them.
+* `--maxDepth` (default `-1`, unbounded) stops the search N dependency hops above the queried
+  target. When a bound cuts the search short, a warning says so.
+
 ## Query Service (experimental)
 
 Instead of running `generate-hashes` from scratch on every CI invocation, you can run `bazel-diff` as
@@ -314,6 +398,10 @@ Commands:
                           Target in the provided workspace.
   get-impacted-targets  Command-line utility to analyze the state of the bazel
                           build graph
+  explain               Explains why a target was impacted: the upstream target
+                          (s) whose own hash changed, and the dependency path
+                          from each down to the queried target. Renders as
+                          text, JSON, Graphviz DOT, or a Mermaid flowchart.
   warmup                Record-side entrypoint for Firecracker snapshots: runs
                           generate-hashes for the base revision, writes base
                           hashes + fingerprint to known paths, and exits 0 only
@@ -549,6 +637,51 @@ Command-line utility to analyze the state of the bazel build graph
   -w, --workspacePath=<workspacePath>
                          Path to Bazel workspace directory. Required for module
                            change detection.
+```
+
+### `explain` command
+
+```terminal
+Usage: bazel-diff explain [-hvV] -d=<depEdgesJSONPath> [-f=<format>]
+                          -fh=<finalHashesJSONPath> [--maxDepth=<maxDepth>]
+                          [--maxRootCauses=<maxRootCauses>] [-o=<outputPath>]
+                          -sh=<startingHashesJSONPath> -t=<target>
+Explains why a target was impacted: the upstream target(s) whose own hash
+changed, and the dependency path from each down to the queried target. Renders
+as text, JSON, Graphviz DOT, or a Mermaid flowchart.
+  -d, --depEdgesFile=<depEdgesJSONPath>
+                          Path to the dependency-edges file written by
+                            'generate-hashes --depEdgesFile'. Required:
+                            attribution is a walk over these edges.
+  -f, --format=<format>   Output format: TEXT, JSON, DOT, MERMAID. 'dot' and
+                            'mermaid' emit a node-link graph of the blame
+                            subgraph, with edges pointing from root cause to
+                            queried target.
+      -fh, --finalHashes=<finalHashesJSONPath>
+                          The path to the JSON file of target hashes for the
+                            final revision. Run 'generate-hashes' to get this
+                            value.
+  -h, --help              Show this help message and exit.
+      --maxDepth=<maxDepth>
+                          Stop searching this many dependency hops above the
+                            queried target. Root causes further upstream are
+                            then not reported (a warning is logged). -1 means
+                            no bound. Default: -1.
+      --maxRootCauses=<maxRootCauses>
+                          Report at most this many root causes, nearest first.
+                            The full count is always reported alongside. 0
+                            means no limit. Default: 25.
+  -o, --output=<outputPath>
+                          Filepath to write the explanation to. Defaults to
+                            STDOUT.
+      -sh, --startingHashes=<startingHashesJSONPath>
+                          The path to the JSON file of target hashes for the
+                            initial revision. Run 'generate-hashes' to get this
+                            value.
+  -t, --target=<target>   The impacted Bazel label to explain, e.g.
+                            '//service/a:app'.
+  -v, --verbose           Display query string, missing files and elapsed time
+  -V, --version           Print version information and exit.
 ```
 
 ### `serve` command

--- a/cli/BUILD
+++ b/cli/BUILD
@@ -110,6 +110,33 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "ExplainImpactInteractorTest",
+    env = coverage_minimum_env(
+        coverage_include = ["cli/src/main/kotlin/com/bazel_diff/interactor/ExplainImpactInteractor.kt"],
+    ),
+    test_class = "com.bazel_diff.interactor.ExplainImpactInteractorTest",
+    runtime_deps = [":cli-test-lib"],
+)
+
+kt_jvm_test(
+    name = "ImpactGraphRendererTest",
+    env = coverage_minimum_env(
+        coverage_include = ["cli/src/main/kotlin/com/bazel_diff/interactor/ImpactGraphRenderer.kt"],
+    ),
+    test_class = "com.bazel_diff.interactor.ImpactGraphRendererTest",
+    runtime_deps = [":cli-test-lib"],
+)
+
+kt_jvm_test(
+    name = "ExplainCommandTest",
+    env = coverage_minimum_env(
+        coverage_include = ["cli/src/main/kotlin/com/bazel_diff/cli/ExplainCommand.kt"],
+    ),
+    test_class = "com.bazel_diff.cli.ExplainCommandTest",
+    runtime_deps = [":cli-test-lib"],
+)
+
+kt_jvm_test(
     name = "CalculateImpactedTargetsInteractorTest",
     env = coverage_minimum_env(
         coverage_include = ["cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt"],
@@ -136,6 +163,15 @@ kt_jvm_test(
         coverage_include = ["cli/src/main/kotlin/com/bazel_diff/cli/converter/NormalisingPathConverter.kt"],
     ),
     test_class = "com.bazel_diff.cli.converter.NormalisingPathConverterTest",
+    runtime_deps = [":cli-test-lib"],
+)
+
+kt_jvm_test(
+    name = "ExplainFormatConverterTest",
+    env = coverage_minimum_env(
+        coverage_include = ["cli/src/main/kotlin/com/bazel_diff/cli/converter/ExplainFormatConverter.kt"],
+    ),
+    test_class = "com.bazel_diff.cli.converter.ExplainFormatConverterTest",
     runtime_deps = [":cli-test-lib"],
 )
 

--- a/cli/src/main/kotlin/com/bazel_diff/cli/BazelDiff.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/BazelDiff.kt
@@ -11,6 +11,7 @@ import picocli.CommandLine.Spec
         [
             GenerateHashesCommand::class,
             GetImpactedTargetsCommand::class,
+            ExplainCommand::class,
             WarmupCommand::class,
             FingerprintCommand::class,
             ServeCommand::class],

--- a/cli/src/main/kotlin/com/bazel_diff/cli/ExplainCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/ExplainCommand.kt
@@ -1,0 +1,169 @@
+package com.bazel_diff.cli
+
+import com.bazel_diff.cli.converter.ExplainFormatConverter
+import com.bazel_diff.di.loggingModule
+import com.bazel_diff.di.serialisationModule
+import com.bazel_diff.interactor.DeserialiseHashesInteractor
+import com.bazel_diff.interactor.ExplainFormat
+import com.bazel_diff.interactor.ExplainImpactInteractor
+import com.bazel_diff.interactor.ImpactGraphRenderer
+import com.bazel_diff.interactor.UnknownTargetException
+import com.google.gson.Gson
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileDescriptor
+import java.io.FileWriter
+import java.io.IOException
+import java.util.concurrent.Callable
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.java.KoinJavaComponent
+import picocli.CommandLine
+
+/**
+ * Explains *why* a single target was impacted: which upstream target(s) actually changed, and along
+ * which dependency path the change reached it.
+ *
+ * Answers [issue #479](https://github.com/Tinder/bazel-diff/issues/479). Pure post-processing over
+ * the same three files `get-impacted-targets` consumes -- it runs no Bazel query and needs no
+ * workspace, so it is cheap enough to run on a CI failure after the fact.
+ */
+@CommandLine.Command(
+    name = "explain",
+    mixinStandardHelpOptions = true,
+    description =
+        [
+            "Explains why a target was impacted: the upstream target(s) whose own hash changed, " +
+                "and the dependency path from each down to the queried target. Renders as text, " +
+                "JSON, Graphviz DOT, or a Mermaid flowchart."],
+    versionProvider = VersionProvider::class)
+class ExplainCommand : Callable<Int> {
+  @CommandLine.ParentCommand private lateinit var parent: BazelDiff
+
+  @CommandLine.Option(
+      names = ["-sh", "--startingHashes"],
+      scope = CommandLine.ScopeType.LOCAL,
+      description =
+          [
+              "The path to the JSON file of target hashes for the initial revision. Run 'generate-hashes' to get this value."],
+      required = true)
+  lateinit var startingHashesJSONPath: File
+
+  @CommandLine.Option(
+      names = ["-fh", "--finalHashes"],
+      scope = CommandLine.ScopeType.LOCAL,
+      description =
+          [
+              "The path to the JSON file of target hashes for the final revision. Run 'generate-hashes' to get this value."],
+      required = true)
+  lateinit var finalHashesJSONPath: File
+
+  @CommandLine.Option(
+      names = ["-d", "--depEdgesFile"],
+      scope = CommandLine.ScopeType.LOCAL,
+      description =
+          [
+              "Path to the dependency-edges file written by 'generate-hashes --depEdgesFile'. " +
+                  "Required: attribution is a walk over these edges."],
+      required = true)
+  lateinit var depEdgesJSONPath: File
+
+  @CommandLine.Option(
+      names = ["-t", "--target"],
+      scope = CommandLine.ScopeType.LOCAL,
+      description = ["The impacted Bazel label to explain, e.g. '//service/a:app'."],
+      required = true)
+  lateinit var target: String
+
+  @CommandLine.Option(
+      names = ["-f", "--format"],
+      scope = CommandLine.ScopeType.LOCAL,
+      description =
+          [
+              "Output format: \${COMPLETION-CANDIDATES}. 'dot' and 'mermaid' emit a node-link " +
+                  "graph of the blame subgraph, with edges pointing from root cause to queried " +
+                  "target."],
+      converter = [ExplainFormatConverter::class],
+      defaultValue = "TEXT")
+  var format: ExplainFormat = ExplainFormat.TEXT
+
+  @CommandLine.Option(
+      names = ["-o", "--output"],
+      scope = CommandLine.ScopeType.LOCAL,
+      description = ["Filepath to write the explanation to. Defaults to STDOUT."])
+  var outputPath: File? = null
+
+  @CommandLine.Option(
+      names = ["--maxRootCauses"],
+      scope = CommandLine.ScopeType.LOCAL,
+      description =
+          [
+              "Report at most this many root causes, nearest first. The full count is always " +
+                  "reported alongside. 0 means no limit. Default: \${DEFAULT-VALUE}."],
+      defaultValue = "25")
+  var maxRootCauses: Int = 25
+
+  @CommandLine.Option(
+      names = ["--maxDepth"],
+      scope = CommandLine.ScopeType.LOCAL,
+      description =
+          [
+              "Stop searching this many dependency hops above the queried target. Root causes " +
+                  "further upstream are then not reported (a warning is logged). -1 means no " +
+                  "bound. Default: \${DEFAULT-VALUE}."],
+      defaultValue = "-1")
+  var maxDepth: Int = -1
+
+  @CommandLine.Spec lateinit var spec: CommandLine.Model.CommandSpec
+
+  override fun call(): Int {
+    org.koin.core.context.GlobalContext.stopKoin()
+    startKoin { modules(serialisationModule(), loggingModule(parent.isVerbose())) }
+
+    return try {
+      validate()
+      val deserialiser = DeserialiseHashesInteractor()
+      val from = deserialiser.executeTargetHash(startingHashesJSONPath)
+      val to = deserialiser.executeTargetHash(finalHashesJSONPath)
+      val depEdges = deserialiser.deserializeDeps(depEdgesJSONPath)
+
+      val explanation =
+          ExplainImpactInteractor()
+              .explain(from, to, depEdges, target, maxDepth = maxDepth, maxRoots = maxRootCauses)
+
+      val gson = KoinJavaComponent.get<Gson>(Gson::class.java)
+      val rendered = ImpactGraphRenderer(gson).render(explanation, format)
+
+      try {
+        BufferedWriter(
+                when (val path = outputPath) {
+                  null -> FileWriter(FileDescriptor.out)
+                  else -> FileWriter(path)
+                })
+            .use { it.write(rendered) }
+        CommandLine.ExitCode.OK
+      } catch (e: IOException) {
+        CommandLine.ExitCode.SOFTWARE
+      }
+    } catch (e: UnknownTargetException) {
+      throw CommandLine.ParameterException(spec.commandLine(), e.message)
+    } finally {
+      stopKoin()
+    }
+  }
+
+  private fun validate() {
+    if (!startingHashesJSONPath.canRead()) {
+      throw CommandLine.ParameterException(
+          spec.commandLine(), "Incorrect starting hashes: file doesn't exist or can't be read.")
+    }
+    if (!finalHashesJSONPath.canRead()) {
+      throw CommandLine.ParameterException(
+          spec.commandLine(), "Incorrect final hashes: file doesn't exist or can't be read.")
+    }
+    if (!depEdgesJSONPath.canRead()) {
+      throw CommandLine.ParameterException(
+          spec.commandLine(), "Incorrect dep edges file: file doesn't exist or can't be read.")
+    }
+  }
+}

--- a/cli/src/main/kotlin/com/bazel_diff/cli/converter/ExplainFormatConverter.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/converter/ExplainFormatConverter.kt
@@ -1,0 +1,21 @@
+package com.bazel_diff.cli.converter
+
+import com.bazel_diff.interactor.ExplainFormat
+import picocli.CommandLine.ITypeConverter
+import picocli.CommandLine.TypeConversionException
+
+/**
+ * Parses `explain --format` case-insensitively, so `--format dot` works as well as `--format DOT`.
+ *
+ * picocli's built-in enum conversion is case-sensitive, which would reject the lower-case spelling
+ * everyone actually types (and the one used throughout the docs) for a Kotlin enum whose constants
+ * are conventionally upper-case.
+ */
+class ExplainFormatConverter : ITypeConverter<ExplainFormat> {
+  override fun convert(value: String): ExplainFormat =
+      ExplainFormat.entries.firstOrNull { it.name.equals(value.trim(), ignoreCase = true) }
+          ?: throw TypeConversionException(
+              "invalid format '$value' (expected one of ${
+                ExplainFormat.entries.joinToString(", ") { it.name.lowercase() }
+              })")
+}

--- a/cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/interactor/CalculateImpactedTargetsInteractor.kt
@@ -198,27 +198,43 @@ class CalculateImpactedTargetsInteractor : KoinComponent {
     return compareBy<String>({ kindRank(it) }, { it })
   }
 
-  fun computeAllDistances(
+  /**
+   * Partitions the impacted labels between [from] and [to] into [ImpactType.DIRECT] (the target's
+   * own [TargetHash.directHash] changed, or the target is new -- i.e. the target is itself a root
+   * cause of the change) and [ImpactType.INDIRECT] (only its transitive hash moved, so the cause
+   * lies upstream in its deps).
+   *
+   * Shared by the distance path ([computeAllDistances]) and the attribution path
+   * ([ExplainImpactInteractor]) so both agree on exactly which targets count as root causes.
+   *
+   * Diffs by hash identity, not the full [TargetHash] -- see [hashIdentities]. The returned keys
+   * still index the original [from]/[to] maps for the `directHash` check.
+   */
+  fun classifyImpactedLabels(
       from: Map<String, TargetHash>,
-      to: Map<String, TargetHash>,
-      depEdges: Map<String, List<String>>
-  ): Map<String, TargetDistanceMetrics> {
-    // Diff by hash identity, not the full TargetHash -- see [hashIdentities]. The keys still index
-    // the original `from`/`to` maps below for the directHash (DIRECT vs INDIRECT) check.
+      to: Map<String, TargetHash>
+  ): Map<String, ImpactType> {
     val difference = Maps.difference(hashIdentities(to), hashIdentities(from))
 
     val newLabels = difference.entriesOnlyOnLeft().keys
     val existingImpactedLabels = difference.entriesDiffering().keys
 
-    val impactedLabels =
-        HashMap<String, ImpactType>().apply {
-          newLabels.forEach { this[it] = ImpactType.DIRECT }
-          existingImpactedLabels.forEach {
-            this[it] =
-                if (from[it]!!.directHash != to[it]!!.directHash) ImpactType.DIRECT
-                else ImpactType.INDIRECT
-          }
-        }
+    return HashMap<String, ImpactType>().apply {
+      newLabels.forEach { this[it] = ImpactType.DIRECT }
+      existingImpactedLabels.forEach {
+        this[it] =
+            if (from[it]!!.directHash != to[it]!!.directHash) ImpactType.DIRECT
+            else ImpactType.INDIRECT
+      }
+    }
+  }
+
+  fun computeAllDistances(
+      from: Map<String, TargetHash>,
+      to: Map<String, TargetHash>,
+      depEdges: Map<String, List<String>>
+  ): Map<String, TargetDistanceMetrics> {
+    val impactedLabels = classifyImpactedLabels(from, to)
 
     val computedResult: ConcurrentMap<String, TargetDistanceMetrics> = ConcurrentHashMap()
 

--- a/cli/src/main/kotlin/com/bazel_diff/interactor/ExplainImpactInteractor.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/interactor/ExplainImpactInteractor.kt
@@ -1,0 +1,298 @@
+package com.bazel_diff.interactor
+
+import com.bazel_diff.hash.TargetHash
+import com.bazel_diff.interactor.CalculateImpactedTargetsInteractor.ImpactType
+import com.bazel_diff.log.Logger
+import java.util.ArrayDeque
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/** Why a root cause's own hash moved, independent of anything upstream of it. */
+enum class RootCauseKind {
+  /** The label exists in the final revision but not in the starting one. */
+  NEW_TARGET,
+  /** The label exists in both revisions and its own `directHash` changed. */
+  SELF_CHANGED,
+}
+
+/**
+ * One reason the queried target was impacted: a target whose *own* hash changed
+ * ([CalculateImpactedTargetsInteractor.ImpactType.DIRECT]) and from which the change propagates
+ * down to the queried target.
+ *
+ * [path] runs in impact-propagation order -- `[root, …, target]` -- so reading it left to right
+ * follows the change as it flows downstream. It is a shortest such path; there may be others of
+ * equal length, and [targetDistance] is its length in dependency hops.
+ *
+ * [packageHops] counts how many of those hops cross a Bazel package boundary *along [path]*.
+ * Deliberately not named `packageDistance`: `/impacted_targets_with_distances` reports the
+ * *minimum* package distance over all paths, which is independently minimised and can therefore be
+ * smaller than the package crossings on this (target-distance-minimal) path.
+ */
+data class RootCause(
+    val label: String,
+    val targetType: String,
+    val kind: RootCauseKind,
+    val targetDistance: Int,
+    val packageHops: Int,
+    val path: List<String>,
+)
+
+/** A node of the rendered blame subgraph. */
+data class ExplainNode(
+    val label: String,
+    val targetType: String,
+    val impactType: String,
+    val targetDistance: Int,
+    val isRootCause: Boolean,
+    val isQueriedTarget: Boolean,
+)
+
+/**
+ * An edge of the rendered blame subgraph, in impact-propagation direction: [from] is a dependency
+ * of [to], so a change in [from] flows into [to]. This is the reverse of the `--depEdgesFile`
+ * orientation, which maps a label to the deps it consumes.
+ */
+data class ExplainEdge(val from: String, val to: String)
+
+/**
+ * The answer to "why was this target impacted?" -- see
+ * [issue #479](https://github.com/Tinder/bazel-diff/issues/479).
+ *
+ * [rootCauses] is truncated to the caller's `maxRoots`; [totalRootCauses] is the count before
+ * truncation so no cap is ever silently applied. [nodes]/[edges] describe only the subgraph spanned
+ * by the *reported* root causes' paths.
+ */
+data class ImpactExplanation(
+    val target: String,
+    val targetType: String,
+    val impacted: Boolean,
+    /**
+     * True when the label exists in the starting revision but not the final one. bazel-diff never
+     * reports a deleted target as impacted (there is nothing left to build), so such a target is
+     * reported unimpacted -- but for a *different* reason than one whose hash simply did not move,
+     * and the two must not read the same.
+     */
+    val removed: Boolean,
+    val directlyChanged: Boolean,
+    val rootCauses: List<RootCause>,
+    val totalRootCauses: Int,
+    val truncated: Boolean,
+    val nodes: List<ExplainNode>,
+    val edges: List<ExplainEdge>,
+)
+
+/**
+ * Thrown when the queried label appears in neither revision's hash file -- almost always a typo.
+ */
+class UnknownTargetException(message: String) : Exception(message)
+
+/**
+ * Attributes an impacted target to the upstream target(s) actually responsible for its hash change.
+ *
+ * The traversal is a breadth-first walk *up* the dependency edges from the queried target, confined
+ * to labels that are themselves impacted. Every DIRECT label it reaches is a root cause, and the
+ * BFS tree yields a shortest propagation path from each. Confining the walk to impacted labels is
+ * what keeps it cheap on a monorepo graph: an unimpacted dep cannot have contributed to a hash
+ * change, so the visited set is bounded by the impacted subgraph reachable from one target rather
+ * than by the whole build graph.
+ *
+ * Note the walk continues *through* DIRECT labels rather than stopping at the first one. A target
+ * that changed itself may also have changed deps, and both are genuine reasons the queried target
+ * moved -- exactly the "service A can be triggered because of multiple reasons" case in the issue.
+ */
+class ExplainImpactInteractor : KoinComponent {
+  private val logger: Logger by inject()
+
+  /**
+   * @param depEdges label -> its direct deps, as written by `generate-hashes --depEdgesFile`.
+   * @param maxDepth stop the walk this many hops above the queried target; negative means no bound.
+   *   A bounded walk can miss root causes further upstream, which is reported to the caller via the
+   *   log rather than silently.
+   * @param maxRoots keep at most this many root causes (nearest first); non-positive means all.
+   */
+  fun explain(
+      from: Map<String, TargetHash>,
+      to: Map<String, TargetHash>,
+      depEdges: Map<String, List<String>>,
+      target: String,
+      maxDepth: Int = -1,
+      maxRoots: Int = 0,
+  ): ImpactExplanation {
+    if (target !in to && target !in from) {
+      throw UnknownTargetException(
+          "$target is not present in either hash file. Check the label spelling, and note that " +
+              "hashes generated with --targetType only contain the types you asked for.")
+    }
+
+    val targetType = typeOf(target, to, from)
+    val impactedLabels = CalculateImpactedTargetsInteractor().classifyImpactedLabels(from, to)
+
+    if (target !in impactedLabels) {
+      return ImpactExplanation(
+          target = target,
+          targetType = targetType,
+          impacted = false,
+          removed = target !in to,
+          directlyChanged = false,
+          rootCauses = emptyList(),
+          totalRootCauses = 0,
+          truncated = false,
+          nodes = emptyList(),
+          edges = emptyList())
+    }
+
+    val (distances, parents) = walkUpstream(target, depEdges, impactedLabels, maxDepth)
+
+    val allRoots =
+        distances.keys
+            .filter { impactedLabels[it] == ImpactType.DIRECT }
+            .map { root ->
+              val path = pathToTarget(root, parents)
+              RootCause(
+                  label = root,
+                  targetType = typeOf(root, to, from),
+                  kind = if (root in from) RootCauseKind.SELF_CHANGED else RootCauseKind.NEW_TARGET,
+                  targetDistance = distances.getValue(root),
+                  packageHops = path.zipWithNext().count { (a, b) -> packageOf(a) != packageOf(b) },
+                  path = path)
+            }
+            .sortedWith(compareBy({ it.targetDistance }, { it.label }))
+
+    val kept = if (maxRoots > 0) allRoots.take(maxRoots) else allRoots
+    if (kept.size < allRoots.size) {
+      logger.i {
+        "Reporting ${kept.size} of ${allRoots.size} root causes for $target (--maxRootCauses); " +
+            "pass --maxRootCauses=0 for all of them"
+      }
+    }
+
+    val (nodes, edges) = buildSubgraph(kept, target, distances, impactedLabels, depEdges, to, from)
+
+    return ImpactExplanation(
+        target = target,
+        targetType = targetType,
+        impacted = true,
+        removed = false,
+        directlyChanged = impactedLabels[target] == ImpactType.DIRECT,
+        rootCauses = kept,
+        totalRootCauses = allRoots.size,
+        truncated = kept.size < allRoots.size,
+        nodes = nodes,
+        edges = edges)
+  }
+
+  /**
+   * Breadth-first walk from [target] up the dependency edges, visiting only impacted labels.
+   * Returns each visited label's hop distance from [target] and its parent in the BFS tree (the
+   * label it was first reached from, i.e. one hop *downstream* of it).
+   */
+  private fun walkUpstream(
+      target: String,
+      depEdges: Map<String, List<String>>,
+      impactedLabels: Map<String, ImpactType>,
+      maxDepth: Int,
+  ): Pair<Map<String, Int>, Map<String, String>> {
+    val distances = HashMap<String, Int>().apply { put(target, 0) }
+    val parents = HashMap<String, String>()
+    val queue = ArrayDeque<String>().apply { add(target) }
+    var truncatedByDepth = false
+
+    while (queue.isNotEmpty()) {
+      val current = queue.poll()
+      val depth = distances.getValue(current)
+      if (maxDepth >= 0 && depth >= maxDepth) {
+        if (depEdges[current].orEmpty().any { it in impactedLabels && it !in distances }) {
+          truncatedByDepth = true
+        }
+        continue
+      }
+      for (dep in depEdges[current].orEmpty()) {
+        if (dep !in impactedLabels || dep in distances) continue
+        distances[dep] = depth + 1
+        parents[dep] = current
+        queue.add(dep)
+      }
+    }
+
+    if (truncatedByDepth) {
+      logger.w {
+        "Stopped the search at --maxDepth=$maxDepth hops above $target; root causes further " +
+            "upstream are not reported. Raise or drop --maxDepth for the complete attribution."
+      }
+    }
+    return Pair(distances, parents)
+  }
+
+  /** Unrolls the BFS parent chain into a `[root, …, target]` propagation path. */
+  private fun pathToTarget(root: String, parents: Map<String, String>): List<String> {
+    val path = ArrayList<String>()
+    var cursor: String? = root
+    while (cursor != null) {
+      path.add(cursor)
+      cursor = parents[cursor]
+    }
+    return path
+  }
+
+  /**
+   * Builds the subgraph spanned by the reported [roots]' paths. Nodes are exactly the labels on
+   * those paths; edges are *every* dependency edge between two included nodes, not just the path
+   * edges, so the rendered graph shows the real connectivity rather than a spanning tree.
+   */
+  private fun buildSubgraph(
+      roots: List<RootCause>,
+      target: String,
+      distances: Map<String, Int>,
+      impactedLabels: Map<String, ImpactType>,
+      depEdges: Map<String, List<String>>,
+      to: Map<String, TargetHash>,
+      from: Map<String, TargetHash>,
+  ): Pair<List<ExplainNode>, List<ExplainEdge>> {
+    val rootLabels = roots.mapTo(HashSet()) { it.label }
+    val included = LinkedHashSet<String>()
+    roots.forEach { included.addAll(it.path) }
+    included.add(target)
+
+    val nodes =
+        included
+            .map { label ->
+              ExplainNode(
+                  label = label,
+                  targetType = typeOf(label, to, from),
+                  impactType = impactedLabels.getValue(label).name.lowercase(),
+                  targetDistance = distances.getValue(label),
+                  isRootCause = label in rootLabels,
+                  isQueriedTarget = label == target)
+            }
+            .sortedWith(compareByDescending<ExplainNode> { it.targetDistance }.thenBy { it.label })
+
+    val edges =
+        included
+            .flatMap { consumer ->
+              depEdges[consumer]
+                  .orEmpty()
+                  .filter { it in included }
+                  .map { dep -> ExplainEdge(from = dep, to = consumer) }
+            }
+            .distinct()
+            .sortedWith(compareBy({ it.from }, { it.to }))
+
+    return Pair(nodes, edges)
+  }
+
+  /**
+   * The target's declared type, preferring the final revision. Empty when types were not hashed.
+   */
+  private fun typeOf(
+      label: String,
+      to: Map<String, TargetHash>,
+      from: Map<String, TargetHash>
+  ): String =
+      to[label]?.type?.takeIf { it.isNotEmpty() }
+          ?: from[label]?.type?.takeIf { it.isNotEmpty() }
+          ?: ""
+
+  /** The package part of a label, i.e. everything before the `:`. */
+  private fun packageOf(label: String): String = label.substringBefore(":")
+}

--- a/cli/src/main/kotlin/com/bazel_diff/interactor/ImpactGraphRenderer.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/interactor/ImpactGraphRenderer.kt
@@ -1,0 +1,229 @@
+package com.bazel_diff.interactor
+
+import com.google.gson.Gson
+
+/** Output shapes supported by `bazel-diff explain`. */
+enum class ExplainFormat {
+  TEXT,
+  JSON,
+  DOT,
+  MERMAID,
+}
+
+/**
+ * Renders an [ImpactExplanation] as human-readable text, JSON, or node-link graph source.
+ *
+ * ## Graph conventions
+ * Both graph formats draw edges in **impact-propagation** direction (root cause at the top, queried
+ * target at the bottom), which is the reverse of the `--depEdgesFile` orientation. Reading downward
+ * follows the change as it flows into the queried target.
+ *
+ * ## Color
+ * Node identity is carried by the **stroke**, using two hues validated for all-pairs CVD separation
+ * against both a light and a dark surface (worst pair ΔE 24.7 protan light / 26.8 dark, against a
+ * ≥8 target). Fills are deliberately a uniform near-white *surface* rather than three tints: tinted
+ * fills were measured at normal-vision ΔE 4.5 between the intermediate and root-cause shades, far
+ * under the ≥15 floor, so they cannot carry identity. Giving every node its own light surface also
+ * makes the output independent of the viewer's page background, which matters because DOT and
+ * Mermaid are static source rendered somewhere we do not control.
+ *
+ * Color is never the sole encoding: root causes and the queried target additionally differ in
+ * border shape/weight, are direct-labeled with their role, and DOT emits a legend.
+ */
+class ImpactGraphRenderer(private val gson: Gson) {
+
+  private companion object {
+    // Categorical slots 1 and 2 of the validated light-mode palette, plus a deliberately
+    // recessive neutral for intermediates (a pass-through node is context, not a peer category).
+    const val SURFACE = "#fcfcfb"
+    const val INK = "#0b0b0b"
+    const val INK_MUTED = "#52514e"
+    const val HUE_ROOT_CAUSE = "#eb6834" // orange -- where the change originates
+    const val HUE_QUERIED = "#2a78d6" // blue -- what the user asked about
+    const val HUE_INTERMEDIATE = "#6b6a66" // neutral -- carries the change through
+  }
+
+  fun render(explanation: ImpactExplanation, format: ExplainFormat): String =
+      when (format) {
+        ExplainFormat.TEXT -> renderText(explanation)
+        ExplainFormat.JSON -> gson.toJson(explanation) + "\n"
+        ExplainFormat.DOT -> renderDot(explanation)
+        ExplainFormat.MERMAID -> renderMermaid(explanation)
+      }
+
+  private fun renderText(e: ImpactExplanation): String = buildString {
+    val type = if (e.targetType.isEmpty()) "" else "  [${e.targetType}]"
+    if (!e.impacted) {
+      append("${e.target}$type\n")
+      append(
+          if (e.removed)
+              "NOT IMPACTED -- this target exists in the starting revision but not the final " +
+                  "one. Deleted targets are never reported as impacted; there is nothing left " +
+                  "to build.\n"
+          else "NOT IMPACTED -- its hash is identical between the two revisions.\n")
+      return@buildString
+    }
+
+    append("${e.target}$type\n")
+    append("IMPACTED ")
+    append(
+        if (e.directlyChanged) "(directly -- this target changed on its own)\n"
+        else "(indirectly -- the change came from its dependencies)\n")
+    append("\n")
+
+    if (e.rootCauses.isEmpty()) {
+      append(
+          "No root cause could be attributed. This target's hash changed but none of its deps in " +
+              "the dep-edges file are impacted -- most often because the hash JSON was filtered " +
+              "with --targetType while the dep-edges file was not.\n" +
+              "See https://github.com/Tinder/bazel-diff/issues/268\n")
+      return@buildString
+    }
+
+    append(
+        if (e.truncated)
+            "Root causes: ${e.totalRootCauses} (showing the ${e.rootCauses.size} nearest)\n"
+        else "Root causes: ${e.totalRootCauses}\n")
+    append("\n")
+
+    e.rootCauses.forEachIndexed { index, cause ->
+      val causeType = if (cause.targetType.isEmpty()) "" else "  [${cause.targetType}]"
+      val reason =
+          when (cause.kind) {
+            RootCauseKind.NEW_TARGET -> "new target in the final revision"
+            RootCauseKind.SELF_CHANGED -> selfChangedReason(cause.targetType)
+          }
+      append("  ${index + 1}. ${cause.label}$causeType\n")
+      append("     $reason\n")
+      append("     ${hops(cause.targetDistance, cause.packageHops)}\n")
+      append("     ${cause.path.joinToString(" -> ")}\n")
+      if (index != e.rootCauses.lastIndex) append("\n")
+    }
+
+    if (e.truncated) {
+      append("\n")
+      append("  ... and ${e.totalRootCauses - e.rootCauses.size} more. ")
+      append("Pass --maxRootCauses=0 to list every root cause.\n")
+    }
+  }
+
+  private fun selfChangedReason(targetType: String): String =
+      when (targetType) {
+        "SourceFile" -> "source file content changed"
+        "GeneratedFile" -> "generated file changed"
+        "Rule" -> "the rule's own definition or attributes changed"
+        else -> "the target's own hash changed"
+      }
+
+  private fun hops(targetDistance: Int, packageHops: Int): String {
+    if (targetDistance == 0) return "0 hops -- this is the queried target itself"
+    val hopWord = if (targetDistance == 1) "hop" else "hops"
+    val packageWord = if (packageHops == 1) "package boundary" else "package boundaries"
+    return "$targetDistance $hopWord ($packageHops $packageWord crossed)"
+  }
+
+  private fun renderDot(e: ImpactExplanation): String = buildString {
+    append("// bazel-diff explain -- why ${dotEscape(e.target)} was impacted\n")
+    append("// Edges point in impact-propagation direction: root cause -> ... -> queried target.\n")
+    append("digraph bazel_diff_impact {\n")
+    append("  rankdir=TB;\n")
+    append("  bgcolor=\"$SURFACE\";\n")
+    append("  node [shape=box, style=\"rounded,filled\", fillcolor=\"$SURFACE\", ")
+    append("fontname=\"Helvetica\", fontsize=10, fontcolor=\"$INK\", ")
+    append("color=\"$HUE_INTERMEDIATE\", penwidth=1];\n")
+    append("  edge [color=\"$INK_MUTED\", penwidth=1, arrowsize=0.7];\n")
+    append("\n")
+
+    val ids = e.nodes.withIndex().associate { (index, node) -> node.label to "n$index" }
+    e.nodes.forEach { node ->
+      val id = ids.getValue(node.label)
+      append("  $id [label=\"${dotEscape(nodeLabel(node))}\"")
+      when {
+        node.isQueriedTarget -> append(", color=\"$HUE_QUERIED\", penwidth=2")
+        node.isRootCause -> append(", color=\"$HUE_ROOT_CAUSE\", penwidth=2, peripheries=2")
+      }
+      append("];\n")
+    }
+
+    if (e.edges.isNotEmpty()) append("\n")
+    e.edges.forEach { edge ->
+      val from = ids[edge.from]
+      val to = ids[edge.to]
+      if (from != null && to != null) append("  $from -> $to;\n")
+    }
+
+    append("\n")
+    append("  subgraph cluster_legend {\n")
+    append("    label=\"Legend\"; fontname=\"Helvetica\"; fontsize=9; fontcolor=\"$INK_MUTED\";\n")
+    append("    color=\"$INK_MUTED\"; penwidth=1; style=dashed;\n")
+    append(
+        "    lg_root [label=\"root cause\", color=\"$HUE_ROOT_CAUSE\", penwidth=2, peripheries=2];\n")
+    append("    lg_mid [label=\"carries the change\"];\n")
+    append("    lg_target [label=\"queried target\", color=\"$HUE_QUERIED\", penwidth=2];\n")
+    append("    lg_root -> lg_mid -> lg_target [style=invis];\n")
+    append("  }\n")
+    append("}\n")
+  }
+
+  private fun renderMermaid(e: ImpactExplanation): String = buildString {
+    append("%% bazel-diff explain -- why ${e.target} was impacted\n")
+    append("%% Edges point in impact-propagation direction: root cause -> ... -> queried target.\n")
+    append("flowchart TD\n")
+
+    val ids = e.nodes.withIndex().associate { (index, node) -> node.label to "n$index" }
+    e.nodes.forEach { node ->
+      val id = ids.getValue(node.label)
+      val text = mermaidEscape(nodeLabel(node))
+      // Distinct bracket shapes so the three roles stay legible with no color at all.
+      val shaped =
+          when {
+            node.isQueriedTarget -> "$id([\"$text\"])"
+            node.isRootCause -> "$id[[\"$text\"]]"
+            else -> "$id[\"$text\"]"
+          }
+      append("  $shaped\n")
+    }
+
+    e.edges.forEach { edge ->
+      val from = ids[edge.from]
+      val to = ids[edge.to]
+      if (from != null && to != null) append("  $from --> $to\n")
+    }
+
+    append(
+        "  classDef rootCause fill:$SURFACE,stroke:$HUE_ROOT_CAUSE,stroke-width:2px,color:$INK\n")
+    append(
+        "  classDef intermediate fill:$SURFACE,stroke:$HUE_INTERMEDIATE,stroke-width:1px,color:$INK\n")
+    append("  classDef queried fill:$SURFACE,stroke:$HUE_QUERIED,stroke-width:2px,color:$INK\n")
+
+    fun assign(className: String, predicate: (ExplainNode) -> Boolean) {
+      val matching = e.nodes.filter(predicate).map { ids.getValue(it.label) }
+      if (matching.isNotEmpty()) append("  class ${matching.joinToString(",")} $className\n")
+    }
+    assign("queried") { it.isQueriedTarget }
+    assign("rootCause") { it.isRootCause && !it.isQueriedTarget }
+    assign("intermediate") { !it.isRootCause && !it.isQueriedTarget }
+  }
+
+  /**
+   * The node's caption. Root causes and the queried target are direct-labeled with their role on a
+   * second line, so the graph is fully readable in monochrome or by a viewer who cannot separate
+   * the two hues.
+   */
+  private fun nodeLabel(node: ExplainNode): String {
+    val role =
+        when {
+          node.isQueriedTarget && node.isRootCause -> "queried target - also a root cause"
+          node.isQueriedTarget -> "queried target"
+          node.isRootCause -> "root cause"
+          else -> null
+        }
+    return if (role == null) node.label else "${node.label}\n($role)"
+  }
+
+  private fun dotEscape(value: String): String =
+      value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+
+  private fun mermaidEscape(value: String): String =
+      value.replace("\"", "#quot;").replace("\n", "<br/>")
+}

--- a/cli/src/test/kotlin/com/bazel_diff/cli/ExplainCommandTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/cli/ExplainCommandTest.kt
@@ -1,0 +1,249 @@
+package com.bazel_diff.cli
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import picocli.CommandLine
+
+/**
+ * Drives the command through the real picocli parse so `--format`, defaults, and the parent
+ * command's `--verbose` inheritance are all exercised the way a user hits them.
+ */
+class ExplainCommandTest {
+  @get:Rule val temp: TemporaryFolder = TemporaryFolder()
+
+  // //common:util.py -> //common:lib -> //service/a:app
+  private fun write(name: String, contents: String): File =
+      File(temp.root, name).apply { writeText(contents) }
+
+  private fun fromHashes() =
+      write(
+          "from.json",
+          """
+          {
+            "//service/a:app": "Rule#app~app-direct",
+            "//common:lib": "Rule#lib~lib-direct",
+            "//common:util.py": "SourceFile#util~util"
+          }
+          """
+              .trimIndent())
+
+  private fun toHashes() =
+      write(
+          "to.json",
+          """
+          {
+            "//service/a:app": "Rule#app2~app-direct",
+            "//common:lib": "Rule#lib2~lib-direct",
+            "//common:util.py": "SourceFile#util2~util2"
+          }
+          """
+              .trimIndent())
+
+  private fun depEdges() =
+      write(
+          "deps.json",
+          """
+          {
+            "//service/a:app": ["//common:lib"],
+            "//common:lib": ["//common:util.py"]
+          }
+          """
+              .trimIndent())
+
+  private fun execute(vararg extraArgs: String): Int =
+      CommandLine(BazelDiff())
+          .execute(
+              "explain",
+              "-sh",
+              fromHashes().absolutePath,
+              "-fh",
+              toHashes().absolutePath,
+              "-d",
+              depEdges().absolutePath,
+              "-t",
+              "//service/a:app",
+              *extraArgs)
+
+  /**
+   * Runs `explain` and returns its rendered output.
+   *
+   * Always goes through `-o`: the command writes STDOUT via `FileWriter(FileDescriptor.out)` (as
+   * every other bazel-diff command does), which addresses file descriptor 1 directly and so is
+   * invisible to `System.setOut`. [writesToStdoutWhenNoOutputPathIsGiven] covers the STDOUT branch.
+   */
+  private fun run(vararg extraArgs: String): Pair<Int, String> {
+    val out = File(temp.root, "explain-output")
+    val exit = execute(*extraArgs, "-o", out.absolutePath)
+    return Pair(exit, if (out.exists()) out.readText() else "")
+  }
+
+  @Test
+  fun defaultsToTextAndNamesTheUpstreamRootCause() {
+    val (exit, out) = run()
+
+    assertThat(exit).isEqualTo(CommandLine.ExitCode.OK)
+    assertThat(out).contains("//service/a:app")
+    assertThat(out).contains("IMPACTED (indirectly")
+    assertThat(out).contains("//common:util.py")
+    assertThat(out).contains("//common:util.py -> //common:lib -> //service/a:app")
+  }
+
+  @Test
+  fun writesTheChosenFormatToTheOutputFile() {
+    val out = File(temp.root, "graph.dot")
+
+    val exit = execute("--format", "DOT", "-o", out.absolutePath)
+
+    assertThat(exit).isEqualTo(CommandLine.ExitCode.OK)
+    assertThat(out.readText()).contains("digraph bazel_diff_impact {")
+    assertThat(out.readText()).contains("(root cause)")
+  }
+
+  @Test
+  fun writesToStdoutWhenNoOutputPathIsGiven() {
+    // The default STDOUT branch: assert it completes cleanly and creates no stray file. The bytes
+    // themselves go to fd 1 and are covered by the -o tests above.
+    assertThat(execute()).isEqualTo(CommandLine.ExitCode.OK)
+    assertThat(File(temp.root, "explain-output").exists()).isEqualTo(false)
+  }
+
+  @Test
+  fun rendersMermaid() {
+    val (exit, out) = run("--format", "MERMAID")
+
+    assertThat(exit).isEqualTo(CommandLine.ExitCode.OK)
+    assertThat(out).contains("flowchart TD")
+    assertThat(out).contains("classDef rootCause")
+  }
+
+  @Test
+  fun rendersJson() {
+    val (exit, out) = run("--format", "JSON")
+
+    assertThat(exit).isEqualTo(CommandLine.ExitCode.OK)
+    assertThat(out).contains("\"rootCauses\"")
+    assertThat(out).contains("\"totalRootCauses\"")
+    assertThat(out).contains("\"packageHops\"")
+  }
+
+  @Test
+  fun maxDepthIsHonoured() {
+    // util.py is 2 hops up; a 1-hop budget cannot reach it, so nothing is attributed.
+    val (exit, out) = run("--maxDepth", "1")
+
+    assertThat(exit).isEqualTo(CommandLine.ExitCode.OK)
+    assertThat(out).contains("No root cause could be attributed")
+  }
+
+  @Test
+  fun usageErrorForALabelInNeitherHashFile() {
+    val originalErr = System.err
+    val captured = ByteArrayOutputStream()
+    System.setErr(PrintStream(captured, true))
+    val exit =
+        try {
+          CommandLine(BazelDiff())
+              .execute(
+                  "explain",
+                  "-sh",
+                  fromHashes().absolutePath,
+                  "-fh",
+                  toHashes().absolutePath,
+                  "-d",
+                  depEdges().absolutePath,
+                  "-t",
+                  "//typo:nope")
+        } finally {
+          System.setErr(originalErr)
+        }
+
+    assertThat(exit).isEqualTo(CommandLine.ExitCode.USAGE)
+    assertThat(captured.toString()).contains("is not present in either hash file")
+  }
+
+  @Test
+  fun usageErrorForAnUnreadableInputFile() {
+    val originalErr = System.err
+    val captured = ByteArrayOutputStream()
+    System.setErr(PrintStream(captured, true))
+    val exit =
+        try {
+          CommandLine(BazelDiff())
+              .execute(
+                  "explain",
+                  "-sh",
+                  File(temp.root, "missing.json").absolutePath,
+                  "-fh",
+                  toHashes().absolutePath,
+                  "-d",
+                  depEdges().absolutePath,
+                  "-t",
+                  "//service/a:app")
+        } finally {
+          System.setErr(originalErr)
+        }
+
+    assertThat(exit).isEqualTo(CommandLine.ExitCode.USAGE)
+    assertThat(captured.toString()).contains("Incorrect starting hashes")
+  }
+
+  @Test
+  fun usageErrorForAnUnreadableDepEdgesFile() {
+    val originalErr = System.err
+    val captured = ByteArrayOutputStream()
+    System.setErr(PrintStream(captured, true))
+    val exit =
+        try {
+          CommandLine(BazelDiff())
+              .execute(
+                  "explain",
+                  "-sh",
+                  fromHashes().absolutePath,
+                  "-fh",
+                  toHashes().absolutePath,
+                  "-d",
+                  File(temp.root, "missing-deps.json").absolutePath,
+                  "-t",
+                  "//service/a:app")
+        } finally {
+          System.setErr(originalErr)
+        }
+
+    assertThat(exit).isEqualTo(CommandLine.ExitCode.USAGE)
+    assertThat(captured.toString()).contains("Incorrect dep edges file")
+  }
+
+  @Test
+  fun explainIsRegisteredAsASubcommand() {
+    val subcommands = CommandLine(BazelDiff()).subcommands.keys
+    assertThat(subcommands.contains("explain")).isEqualTo(true)
+  }
+
+  @Test
+  fun maxRootCausesDefaultsTo25() {
+    val parsed =
+        CommandLine(BazelDiff())
+            .parseArgs(
+                "explain",
+                "-sh",
+                "/tmp/a.json",
+                "-fh",
+                "/tmp/b.json",
+                "-d",
+                "/tmp/d.json",
+                "-t",
+                "//a:b")
+    val command = parsed.subcommand().commandSpec().userObject() as ExplainCommand
+    assertThat(command.maxRootCauses).isEqualTo(25)
+    assertThat(command.maxDepth).isEqualTo(-1)
+    assertThat(command.format).isNotEqualTo(null)
+  }
+}

--- a/cli/src/test/kotlin/com/bazel_diff/cli/converter/ExplainFormatConverterTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/cli/converter/ExplainFormatConverterTest.kt
@@ -1,0 +1,36 @@
+package com.bazel_diff.cli.converter
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import com.bazel_diff.interactor.ExplainFormat
+import org.junit.Test
+import picocli.CommandLine.TypeConversionException
+
+class ExplainFormatConverterTest {
+  private val converter = ExplainFormatConverter()
+
+  @Test
+  fun acceptsTheLowerCaseSpellingUsedInTheDocs() {
+    assertThat(converter.convert("dot")).isEqualTo(ExplainFormat.DOT)
+    assertThat(converter.convert("mermaid")).isEqualTo(ExplainFormat.MERMAID)
+    assertThat(converter.convert("json")).isEqualTo(ExplainFormat.JSON)
+    assertThat(converter.convert("text")).isEqualTo(ExplainFormat.TEXT)
+  }
+
+  @Test
+  fun acceptsTheEnumSpellingAndMixedCaseAndSurroundingSpace() {
+    assertThat(converter.convert("DOT")).isEqualTo(ExplainFormat.DOT)
+    assertThat(converter.convert("MerMaid")).isEqualTo(ExplainFormat.MERMAID)
+    assertThat(converter.convert("  json  ")).isEqualTo(ExplainFormat.JSON)
+  }
+
+  @Test
+  fun rejectsAnUnknownFormatAndListsTheValidOnes() {
+    assertFailure { converter.convert("svg") }
+        .isInstanceOf(TypeConversionException::class)
+        .hasMessage("invalid format 'svg' (expected one of text, json, dot, mermaid)")
+  }
+}

--- a/cli/src/test/kotlin/com/bazel_diff/interactor/ExplainImpactInteractorTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/interactor/ExplainImpactInteractorTest.kt
@@ -1,0 +1,292 @@
+package com.bazel_diff.interactor
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.containsExactly
+import assertk.assertions.containsExactlyInAnyOrder
+import assertk.assertions.hasMessage
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isTrue
+import com.bazel_diff.hash.TargetHash
+import com.bazel_diff.testModule
+import org.junit.Rule
+import org.junit.Test
+import org.koin.test.KoinTest
+import org.koin.test.KoinTestRule
+
+/**
+ * The scenario throughout mirrors issue #479: a common module's generated sources feed a shared
+ * library, which feeds service A. Service A can be impacted because it changed itself, because the
+ * common module changed, or both.
+ */
+class ExplainImpactInteractorTest : KoinTest {
+  @get:Rule val koinTestRule = KoinTestRule.create { modules(testModule()) }
+
+  private val interactor = ExplainImpactInteractor()
+
+  // //common:util.py -> //common:gen -> //common:lib -> //service/a:app
+  private val depEdges =
+      mapOf(
+          "//service/a:app" to listOf("//common:lib", "//service/a:main.py"),
+          "//common:lib" to listOf("//common:gen"),
+          "//common:gen" to listOf("//common:util.py"),
+      )
+
+  private fun hashes(vararg entries: Pair<String, Pair<String, String>>) =
+      entries.associate { (label, pair) ->
+        val type = if (label.endsWith(".py")) "SourceFile" else "Rule"
+        label to TargetHash(type, pair.first, pair.second)
+      }
+
+  private fun unchangedBase() =
+      hashes(
+          "//service/a:app" to ("app" to "app-direct"),
+          "//service/a:main.py" to ("main" to "main"),
+          "//common:lib" to ("lib" to "lib-direct"),
+          "//common:gen" to ("gen" to "gen-direct"),
+          "//common:util.py" to ("util" to "util"),
+      )
+
+  @Test
+  fun attributesAnIndirectImpactToTheUpstreamSourceChange() {
+    val from = unchangedBase()
+    // util.py's content changed; the change propagates up through gen and lib into the app. Only
+    // util.py's directHash moves -- everything downstream sees a transitive-hash change only.
+    val to =
+        hashes(
+            "//service/a:app" to ("app2" to "app-direct"),
+            "//service/a:main.py" to ("main" to "main"),
+            "//common:lib" to ("lib2" to "lib-direct"),
+            "//common:gen" to ("gen2" to "gen-direct"),
+            "//common:util.py" to ("util2" to "util2"),
+        )
+
+    val result = interactor.explain(from, to, depEdges, "//service/a:app")
+
+    assertThat(result.impacted).isTrue()
+    assertThat(result.directlyChanged).isFalse()
+    assertThat(result.totalRootCauses).isEqualTo(1)
+    val cause = result.rootCauses.single()
+    assertThat(cause.label).isEqualTo("//common:util.py")
+    assertThat(cause.kind).isEqualTo(RootCauseKind.SELF_CHANGED)
+    assertThat(cause.targetDistance).isEqualTo(3)
+    // Every hop crosses //common -> //common -> //service/a, so exactly one boundary is crossed.
+    assertThat(cause.packageHops).isEqualTo(1)
+    assertThat(cause.path)
+        .containsExactly("//common:util.py", "//common:gen", "//common:lib", "//service/a:app")
+  }
+
+  @Test
+  fun reportsEveryReasonWhenATargetChangedItselfAndUpstream() {
+    // The exact ambiguity issue #479 asks about: service A changed AND the common module changed.
+    val from = unchangedBase()
+    val to =
+        hashes(
+            "//service/a:app" to ("app2" to "app-direct2"),
+            "//service/a:main.py" to ("main2" to "main2"),
+            "//common:lib" to ("lib2" to "lib-direct"),
+            "//common:gen" to ("gen2" to "gen-direct"),
+            "//common:util.py" to ("util2" to "util2"),
+        )
+
+    val result = interactor.explain(from, to, depEdges, "//service/a:app")
+
+    assertThat(result.directlyChanged).isTrue()
+    assertThat(result.rootCauses.map { it.label })
+        .containsExactlyInAnyOrder("//service/a:app", "//service/a:main.py", "//common:util.py")
+    // Nearest-first ordering: the target itself, then its own source, then the upstream module.
+    assertThat(result.rootCauses.map { it.targetDistance }).containsExactly(0, 1, 3)
+  }
+
+  @Test
+  fun walksThroughADirectlyChangedDepToFindFurtherRootCauses() {
+    // //common:gen changed its own definition AND consumes a changed source. Both are genuine
+    // reasons the app moved, so the walk must not stop at the first DIRECT label it reaches.
+    val from = unchangedBase()
+    val to =
+        hashes(
+            "//service/a:app" to ("app2" to "app-direct"),
+            "//service/a:main.py" to ("main" to "main"),
+            "//common:lib" to ("lib2" to "lib-direct"),
+            "//common:gen" to ("gen2" to "gen-direct2"),
+            "//common:util.py" to ("util2" to "util2"),
+        )
+
+    val result = interactor.explain(from, to, depEdges, "//service/a:app")
+
+    assertThat(result.rootCauses.map { it.label })
+        .containsExactlyInAnyOrder("//common:gen", "//common:util.py")
+  }
+
+  @Test
+  fun classifiesATargetAbsentFromTheStartingRevisionAsNew() {
+    val from = unchangedBase().filterKeys { it != "//common:util.py" }
+    val to =
+        hashes(
+            "//service/a:app" to ("app2" to "app-direct"),
+            "//service/a:main.py" to ("main" to "main"),
+            "//common:lib" to ("lib2" to "lib-direct"),
+            "//common:gen" to ("gen2" to "gen-direct"),
+            "//common:util.py" to ("util" to "util"),
+        )
+
+    val result = interactor.explain(from, to, depEdges, "//service/a:app")
+
+    assertThat(result.rootCauses.single().kind).isEqualTo(RootCauseKind.NEW_TARGET)
+  }
+
+  @Test
+  fun reportsAnUnimpactedTargetAsSuch() {
+    val base = unchangedBase()
+
+    val result = interactor.explain(base, base, depEdges, "//service/a:app")
+
+    assertThat(result.impacted).isFalse()
+    assertThat(result.rootCauses).isEmpty()
+    assertThat(result.nodes).isEmpty()
+    assertThat(result.edges).isEmpty()
+    assertThat(result.targetType).isEqualTo("Rule")
+  }
+
+  @Test
+  fun distinguishesADeletedTargetFromAnUnchangedOne() {
+    // bazel-diff never reports a deleted target as impacted, but "deleted" and "hash unchanged"
+    // are different facts and must not collapse into the same answer.
+    val from = unchangedBase()
+    val to = from.filterKeys { it != "//service/a:app" }
+
+    val result = interactor.explain(from, to, depEdges, "//service/a:app")
+
+    assertThat(result.impacted).isFalse()
+    assertThat(result.removed).isTrue()
+  }
+
+  @Test
+  fun anUnchangedTargetIsNotReportedAsRemoved() {
+    val base = unchangedBase()
+
+    assertThat(interactor.explain(base, base, depEdges, "//service/a:app").removed).isFalse()
+  }
+
+  @Test
+  fun rejectsALabelPresentInNeitherRevision() {
+    val base = unchangedBase()
+
+    assertFailure { interactor.explain(base, base, depEdges, "//typo:nope") }
+        .isInstanceOf(UnknownTargetException::class)
+        .hasMessage(
+            "//typo:nope is not present in either hash file. Check the label spelling, and note " +
+                "that hashes generated with --targetType only contain the types you asked for.")
+  }
+
+  @Test
+  fun truncatesToMaxRootCausesButStillReportsTheTotal() {
+    // Five independently-changed sources all feeding one app.
+    val sources = (1..5).map { "//common:s$it.py" }
+    val edges = mapOf("//app:app" to sources)
+    val from =
+        (sources.associateWith { TargetHash("SourceFile", "v1", "v1") } +
+            mapOf("//app:app" to TargetHash("Rule", "app", "app")))
+    val to =
+        (sources.associateWith { TargetHash("SourceFile", "v2", "v2") } +
+            mapOf("//app:app" to TargetHash("Rule", "app2", "app")))
+
+    val result = interactor.explain(from, to, edges, "//app:app", maxRoots = 2)
+
+    assertThat(result.rootCauses).hasSize(2)
+    assertThat(result.totalRootCauses).isEqualTo(5)
+    assertThat(result.truncated).isTrue()
+    // Nearest-first, then lexicographic -- so the cap is deterministic, not arbitrary.
+    assertThat(result.rootCauses.map { it.label })
+        .containsExactly("//common:s1.py", "//common:s2.py")
+    // The subgraph spans only the reported causes.
+    assertThat(result.nodes.map { it.label })
+        .containsExactlyInAnyOrder("//app:app", "//common:s1.py", "//common:s2.py")
+  }
+
+  @Test
+  fun maxDepthBoundsTheSearch() {
+    val from = unchangedBase()
+    val to =
+        hashes(
+            "//service/a:app" to ("app2" to "app-direct"),
+            "//service/a:main.py" to ("main" to "main"),
+            "//common:lib" to ("lib2" to "lib-direct"),
+            "//common:gen" to ("gen2" to "gen-direct"),
+            "//common:util.py" to ("util2" to "util2"),
+        )
+
+    // util.py sits 3 hops up; a 2-hop budget cannot reach it.
+    val result = interactor.explain(from, to, depEdges, "//service/a:app", maxDepth = 2)
+
+    assertThat(result.impacted).isTrue()
+    assertThat(result.rootCauses).isEmpty()
+  }
+
+  @Test
+  fun subgraphIncludesEveryEdgeBetweenIncludedNodesNotJustPathEdges() {
+    // Diamond: two independent paths from the changed source down to the app. The BFS tree keeps
+    // one parent per node, but the rendered subgraph must show both real edges.
+    val edges =
+        mapOf(
+            "//app:app" to listOf("//mid:a", "//mid:b"),
+            "//mid:a" to listOf("//src:x.py"),
+            "//mid:b" to listOf("//src:x.py"),
+        )
+    val from =
+        mapOf(
+            "//app:app" to TargetHash("Rule", "app", "app"),
+            "//mid:a" to TargetHash("Rule", "a", "a"),
+            "//mid:b" to TargetHash("Rule", "b", "b"),
+            "//src:x.py" to TargetHash("SourceFile", "x", "x"),
+        )
+    val to =
+        mapOf(
+            "//app:app" to TargetHash("Rule", "app2", "app"),
+            "//mid:a" to TargetHash("Rule", "a2", "a"),
+            "//mid:b" to TargetHash("Rule", "b2", "b"),
+            "//src:x.py" to TargetHash("SourceFile", "x2", "x2"),
+        )
+
+    val result = interactor.explain(from, to, edges, "//app:app")
+
+    assertThat(result.rootCauses.single().label).isEqualTo("//src:x.py")
+    // Only the BFS-tree parent of x.py is on the reported path, so just that mid node is included.
+    val nodeLabels = result.nodes.map { it.label }
+    assertThat(nodeLabels).contains("//app:app")
+    assertThat(nodeLabels).contains("//src:x.py")
+    // Every edge is oriented root -> target (the reverse of the dep-edges file).
+    result.edges.forEach { edge -> assertThat(edges.getValue(edge.to)).contains(edge.from) }
+  }
+
+  @Test
+  fun reportsNoRootCauseWhenNoDepIsImpacted() {
+    // The #268 shape: the hash JSON was filtered by --targetType so the changed source is absent,
+    // leaving an impacted Rule whose deps are all unimpacted. Must degrade, not crash.
+    val from = mapOf("//app:app" to TargetHash("Rule", "app", "app"))
+    val to = mapOf("//app:app" to TargetHash("Rule", "app2", "app"))
+
+    val result =
+        interactor.explain(from, to, mapOf("//app:app" to listOf("//src:x.py")), "//app:app")
+
+    assertThat(result.impacted).isTrue()
+    assertThat(result.directlyChanged).isFalse()
+    assertThat(result.rootCauses).isEmpty()
+  }
+
+  @Test
+  fun handlesAnEmptyTargetTypeWhenHashesWereGeneratedWithoutIt() {
+    val from = mapOf("//app:app" to TargetHash("", "app", "app"))
+    val to = mapOf("//app:app" to TargetHash("", "app2", "app2"))
+
+    val result = interactor.explain(from, to, emptyMap(), "//app:app")
+
+    assertThat(result.targetType).isEqualTo("")
+    assertThat(result.rootCauses.single().targetType).isEqualTo("")
+  }
+}

--- a/cli/src/test/kotlin/com/bazel_diff/interactor/ImpactGraphRendererTest.kt
+++ b/cli/src/test/kotlin/com/bazel_diff/interactor/ImpactGraphRendererTest.kt
@@ -1,0 +1,246 @@
+package com.bazel_diff.interactor
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
+import com.google.gson.GsonBuilder
+import org.junit.Test
+
+class ImpactGraphRendererTest {
+  private val renderer = ImpactGraphRenderer(GsonBuilder().disableHtmlEscaping().create())
+
+  private fun explanation(
+      impacted: Boolean = true,
+      removed: Boolean = false,
+      directlyChanged: Boolean = false,
+      rootCauses: List<RootCause> =
+          listOf(
+              RootCause(
+                  label = "//common:util.py",
+                  targetType = "SourceFile",
+                  kind = RootCauseKind.SELF_CHANGED,
+                  targetDistance = 2,
+                  packageHops = 1,
+                  path = listOf("//common:util.py", "//common:lib", "//service/a:app"))),
+      totalRootCauses: Int = 1,
+      truncated: Boolean = false,
+  ) =
+      ImpactExplanation(
+          target = "//service/a:app",
+          targetType = "Rule",
+          impacted = impacted,
+          removed = removed,
+          directlyChanged = directlyChanged,
+          rootCauses = rootCauses,
+          totalRootCauses = totalRootCauses,
+          truncated = truncated,
+          nodes =
+              listOf(
+                  ExplainNode("//common:util.py", "SourceFile", "direct", 2, true, false),
+                  ExplainNode("//common:lib", "Rule", "indirect", 1, false, false),
+                  ExplainNode("//service/a:app", "Rule", "indirect", 0, false, true)),
+          edges =
+              listOf(
+                  ExplainEdge("//common:lib", "//service/a:app"),
+                  ExplainEdge("//common:util.py", "//common:lib")))
+
+  @Test
+  fun textNamesTheRootCauseTheReasonAndThePath() {
+    val out = renderer.render(explanation(), ExplainFormat.TEXT)
+
+    assertThat(out).contains("IMPACTED (indirectly")
+    assertThat(out).contains("Root causes: 1")
+    assertThat(out).contains("//common:util.py  [SourceFile]")
+    assertThat(out).contains("source file content changed")
+    assertThat(out).contains("2 hops (1 package boundary crossed)")
+    assertThat(out).contains("//common:util.py -> //common:lib -> //service/a:app")
+  }
+
+  @Test
+  fun textSaysSoWhenTheTargetIsNotImpacted() {
+    val out =
+        renderer.render(
+            explanation(impacted = false, rootCauses = emptyList(), totalRootCauses = 0),
+            ExplainFormat.TEXT)
+
+    assertThat(out).contains("NOT IMPACTED -- its hash is identical")
+    assertThat(out).doesNotContain("Root causes")
+  }
+
+  @Test
+  fun textSaysADeletedTargetWasRemovedRatherThanUnchanged() {
+    val out =
+        renderer.render(
+            explanation(
+                impacted = false, removed = true, rootCauses = emptyList(), totalRootCauses = 0),
+            ExplainFormat.TEXT)
+
+    assertThat(out).contains("exists in the starting revision but not the final one")
+    assertThat(out).doesNotContain("hash is identical")
+  }
+
+  @Test
+  fun textSurfacesTheTruncatedCountRatherThanCappingSilently() {
+    val out =
+        renderer.render(explanation(totalRootCauses = 9, truncated = true), ExplainFormat.TEXT)
+
+    assertThat(out).contains("Root causes: 9 (showing the 1 nearest)")
+    assertThat(out).contains("... and 8 more")
+    assertThat(out).contains("--maxRootCauses=0")
+  }
+
+  @Test
+  fun textPointsAtIssue268WhenNothingCouldBeAttributed() {
+    val out =
+        renderer.render(
+            explanation(rootCauses = emptyList(), totalRootCauses = 0), ExplainFormat.TEXT)
+
+    assertThat(out).contains("No root cause could be attributed")
+    assertThat(out).contains("--targetType")
+    assertThat(out).contains("issues/268")
+  }
+
+  @Test
+  fun textDistinguishesADirectSelfChange() {
+    val out = renderer.render(explanation(directlyChanged = true), ExplainFormat.TEXT)
+
+    assertThat(out).contains("IMPACTED (directly -- this target changed on its own)")
+  }
+
+  @Test
+  fun dotEmitsNodesEdgesAndALegend() {
+    val out = renderer.render(explanation(), ExplainFormat.DOT)
+
+    assertThat(out).contains("digraph bazel_diff_impact {")
+    assertThat(out).contains("rankdir=TB;")
+    // Edges run root cause -> queried target: n0 is the most-distant node (util.py), n2 the target.
+    assertThat(out).contains("n0 [label=\"//common:util.py\\n(root cause)\"")
+    assertThat(out).contains("n2 [label=\"//service/a:app\\n(queried target)\"")
+    assertThat(out).contains("n0 -> n1;")
+    assertThat(out).contains("n1 -> n2;")
+    assertThat(out).contains("subgraph cluster_legend {")
+    assertThat(out).contains("root cause")
+    assertThat(out).contains("queried target")
+  }
+
+  @Test
+  fun dotColorsIdentityOnTheStrokeOverAUniformSurfaceFill() {
+    val out = renderer.render(explanation(), ExplainFormat.DOT)
+
+    // Identity lives on `color` (the stroke); every node shares one surface fill, so the graph
+    // reads the same on any page background and no tint has to carry meaning.
+    assertThat(out).contains("color=\"#eb6834\", penwidth=2, peripheries=2")
+    assertThat(out).contains("color=\"#2a78d6\", penwidth=2")
+    assertThat(out).contains("fillcolor=\"#fcfcfb\"")
+    assertThat(out).contains("bgcolor=\"#fcfcfb\";")
+  }
+
+  @Test
+  fun dotEscapesQuotesAndBackslashesInLabels() {
+    val awkward = "//weird:a\"b\\c"
+    val out =
+        renderer.render(
+            explanation()
+                .copy(
+                    nodes = listOf(ExplainNode(awkward, "Rule", "direct", 0, false, false)),
+                    edges = emptyList()),
+            ExplainFormat.DOT)
+
+    assertThat(out).contains("n0 [label=\"//weird:a\\\"b\\\\c\"];")
+  }
+
+  @Test
+  fun mermaidShapesEachRoleDistinctlySoColorIsNeverTheOnlyEncoding() {
+    val out = renderer.render(explanation(), ExplainFormat.MERMAID)
+
+    assertThat(out).contains("flowchart TD")
+    assertThat(out).contains("n0[[\"//common:util.py<br/>(root cause)\"]]")
+    assertThat(out).contains("n1[\"//common:lib\"]")
+    assertThat(out).contains("n2([\"//service/a:app<br/>(queried target)\"])")
+    assertThat(out).contains("n0 --> n1")
+    assertThat(out).contains("class n2 queried")
+    assertThat(out).contains("class n0 rootCause")
+    assertThat(out).contains("class n1 intermediate")
+  }
+
+  @Test
+  fun mermaidEscapesQuotesUsingTheEntityFormMermaidUnderstands() {
+    val out =
+        renderer.render(
+            explanation()
+                .copy(
+                    nodes = listOf(ExplainNode("//weird:a\"b", "Rule", "direct", 0, false, false)),
+                    edges = emptyList()),
+            ExplainFormat.MERMAID)
+
+    assertThat(out).contains("n0[\"//weird:a#quot;b\"]")
+  }
+
+  @Test
+  fun mermaidOmitsAClassLineForARoleWithNoNodes() {
+    val out =
+        renderer.render(
+            explanation()
+                .copy(
+                    nodes = listOf(ExplainNode("//app:app", "Rule", "direct", 0, true, true)),
+                    edges = emptyList()),
+            ExplainFormat.MERMAID)
+
+    assertThat(out).contains("class n0 queried")
+    assertThat(out).doesNotContain("class  intermediate")
+    assertThat(out).doesNotContain("class n0 rootCause")
+    // A node that is both the target and a root cause says so directly.
+    assertThat(out).contains("(queried target - also a root cause)")
+  }
+
+  @Test
+  fun jsonRoundTripsTheWholeExplanation() {
+    val gson = GsonBuilder().disableHtmlEscaping().create()
+    val out = ImpactGraphRenderer(gson).render(explanation(), ExplainFormat.JSON)
+
+    val parsed = gson.fromJson(out, ImpactExplanation::class.java)
+    assertThat(parsed).isEqualTo(explanation())
+  }
+
+  @Test
+  fun textPluralisesASingleHopCorrectly() {
+    val out =
+        renderer.render(
+            explanation(
+                rootCauses =
+                    listOf(
+                        RootCause(
+                            "//common:lib",
+                            "Rule",
+                            RootCauseKind.NEW_TARGET,
+                            1,
+                            0,
+                            listOf("//common:lib", "//service/a:app")))),
+            ExplainFormat.TEXT)
+
+    assertThat(out).contains("1 hop (0 package boundaries crossed)")
+    assertThat(out).contains("new target in the final revision")
+  }
+
+  @Test
+  fun textDescribesTheQueriedTargetItselfAsAZeroHopCause() {
+    val out =
+        renderer.render(
+            explanation(
+                directlyChanged = true,
+                rootCauses =
+                    listOf(
+                        RootCause(
+                            "//service/a:app",
+                            "Rule",
+                            RootCauseKind.SELF_CHANGED,
+                            0,
+                            0,
+                            listOf("//service/a:app")))),
+            ExplainFormat.TEXT)
+
+    assertThat(out).contains("0 hops -- this is the queried target itself")
+    assertThat(out).contains("the rule's own definition or attributes changed")
+  }
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -6,6 +6,7 @@ genrule(
         "help_root.txt",
         "help_generate_hashes.txt",
         "help_get_impacted_targets.txt",
+        "help_explain.txt",
         "help_serve.txt",
     ],
     cmd = """
@@ -13,6 +14,7 @@ genrule(
         $$BINARY --help > $(location help_root.txt) 2>&1 || true
         $$BINARY generate-hashes --help > $(location help_generate_hashes.txt) 2>&1 || true
         $$BINARY get-impacted-targets --help > $(location help_get_impacted_targets.txt) 2>&1 || true
+        $$BINARY explain --help > $(location help_explain.txt) 2>&1 || true
         $$BINARY serve --help > $(location help_serve.txt) 2>&1 || true
     """,
     tools = ["//cli:bazel-diff"],

--- a/tools/generate_readme.py
+++ b/tools/generate_readme.py
@@ -64,7 +64,7 @@ def inject_section(text: str, marker: str, content: str) -> str:
 # ---------------------------------------------------------------------------
 
 def build_cli_help_section(
-    help_root: str, help_gen: str, help_get: str, help_serve: str
+    help_root: str, help_gen: str, help_get: str, help_explain: str, help_serve: str
 ) -> str:
     lines = [
         "## CLI Interface",
@@ -85,6 +85,12 @@ def build_cli_help_section(
         "",
         "```terminal",
         help_get.rstrip(),
+        "```",
+        "",
+        "### `explain` command",
+        "",
+        "```terminal",
+        help_explain.rstrip(),
         "```",
         "",
         "### `serve` command",
@@ -289,6 +295,7 @@ def main() -> None:
     help_root = runfile("tools/help_root.txt").read_text()
     help_gen = runfile("tools/help_generate_hashes.txt").read_text()
     help_get = runfile("tools/help_get_impacted_targets.txt").read_text()
+    help_explain = runfile("tools/help_explain.txt").read_text()
     help_serve = runfile("tools/help_serve.txt").read_text()
 
     version = read_module_version(workspace_dir)
@@ -301,7 +308,9 @@ def main() -> None:
     print("Building contributors table...")
     contributors_section = build_contributors_section(workspace_dir, email_map)
 
-    cli_help_section = build_cli_help_section(help_root, help_gen, help_get, help_serve)
+    cli_help_section = build_cli_help_section(
+        help_root, help_gen, help_get, help_explain, help_serve
+    )
 
     readme = inject_section(template, "cli-help", cli_help_section)
     readme = inject_section(readme, "contributors", contributors_section)

--- a/tools/readme_template.md
+++ b/tools/readme_template.md
@@ -107,6 +107,90 @@ This will produce an impacted targets json list with target label, target distan
 ]
 ```
 
+## Explaining Why a Target Was Impacted
+
+`get-impacted-targets` tells you *that* `//service/a:app` needs rebuilding. It does not tell you
+*why* — and a service can be impacted for several reasons at once: it changed itself, a shared
+module it depends on changed, or both. `explain` answers that question by attributing the target's
+hash change to the upstream target(s) actually responsible, and by showing the dependency path the
+change travelled along. See [issue #479](https://github.com/Tinder/bazel-diff/issues/479).
+
+It reads the same three files `get-impacted-targets` consumes — it runs no `bazel query` and needs
+no workspace — so it is cheap to run after the fact on a CI machine that only kept the artifacts:
+
+```bash
+bazel-diff generate-hashes -w /path/to/workspace -b bazel --depEdgesFile deps.json final_hashes.json
+
+bazel-diff explain \
+  -sh starting_hashes.json \
+  -fh final_hashes.json \
+  -d deps.json \
+  --target //service/a:app
+```
+
+```text
+//service/a:app  [Rule]
+IMPACTED (directly -- this target changed on its own)
+
+Root causes: 3
+
+  1. //service/a:app  [Rule]
+     the rule's own definition or attributes changed
+     0 hops -- this is the queried target itself
+     //service/a:app
+
+  2. //service/a:main.py  [SourceFile]
+     source file content changed
+     1 hop (0 package boundaries crossed)
+     //service/a:main.py -> //service/a:app
+
+  3. //common/data:util.py  [SourceFile]
+     source file content changed
+     3 hops (2 package boundaries crossed)
+     //common/data:util.py -> //common:gen_srcs -> //common:lib -> //service/a:app
+```
+
+A **root cause** is a target whose *own* hash changed — its `directHash` moved, or it is new in the
+final revision. Everything between a root cause and the queried target merely carried the change
+downstream. This is the same DIRECT/INDIRECT classification that backs the distance metrics above,
+so `explain` and `--depEdgesFile` always agree on which targets are roots.
+
+`--depEdgesFile` is required: attribution is a walk over those edges. Generate it with
+`generate-hashes --depEdgesFile` (or, on the query service, fetch it from `GET /dependency_edges`).
+
+### Visualizing the blame graph
+
+`--format dot` and `--format mermaid` emit the blame subgraph — the queried target, the root causes,
+and the targets that carried the change between them. Only that subgraph is rendered, never the
+whole impacted set, which is what keeps the output readable on a monorepo.
+
+```bash
+bazel-diff explain -sh starting_hashes.json -fh final_hashes.json -d deps.json \
+  --target //service/a:app --format dot -o why.dot
+dot -Tsvg why.dot -o why.svg
+```
+
+Edges point in **impact-propagation** direction — root cause at the top, queried target at the
+bottom — so reading downward follows the change as it flows in. (This is the reverse of the
+`--depEdgesFile` orientation, which maps a label to the deps it consumes.)
+
+`--format mermaid` emits a `flowchart TD` that renders inline in a GitHub comment or PR description,
+which is handy for posting "here is why your PR rebuilt these targets" from CI. Each role has its
+own border color *and* node shape *and* an explicit role label, so the graph stays readable in
+monochrome and for viewers who cannot separate the two hues.
+
+`--format json` gives the same data structurally (root causes, paths, nodes, edges) for feeding
+another tool.
+
+### Bounding the output
+
+A target deep in a monorepo can have a great many root causes. Two knobs bound the work, and
+neither ever truncates silently — the full count is always reported:
+
+* `--maxRootCauses` (default `25`) reports only the nearest N root causes. `0` means all of them.
+* `--maxDepth` (default `-1`, unbounded) stops the search N dependency hops above the queried
+  target. When a bound cuts the search short, a warning says so.
+
 ## Query Service (experimental)
 
 Instead of running `generate-hashes` from scratch on every CI invocation, you can run `bazel-diff` as


### PR DESCRIPTION
Closes #479.

## The problem

`get-impacted-targets` tells you *that* `//service/a:app` needs rebuilding. It doesn't tell you *why* — and as the issue puts it, "service A can be triggered because of multiple reasons": it changed itself, a shared module it depends on changed, or both. There was no way to ask which.

## The approach

The attribution was already being computed and thrown away.

`CalculateImpactedTargetsInteractor` classifies every impacted label as **DIRECT** (its own `directHash` moved, or it's new — so it *is* a root cause) or **INDIRECT** (only its transitive hash moved, so blame lies upstream). `calculateDistance` then walks from an indirect target through its *impacted* deps to the nearest DIRECT ancestor — and keeps only the integer. Retaining the argmin predecessor turns that same traversal into a blame path.

So this needs **no new Bazel query, no new on-disk data, and no new `generate-hashes` flags**. The classification is extracted into `classifyImpactedLabels` and shared with the distance path, so the two can't drift on what counts as a root cause.

## `bazel-diff explain`

Reads the same three files `get-impacted-targets` already consumes. It runs no `bazel query` and needs no workspace, so it's cheap to run after the fact on a CI machine that kept only the artifacts.

```bash
bazel-diff explain -sh starting_hashes.json -fh final_hashes.json -d deps.json --target //service/a:app
```

```text
//service/a:app  [Rule]
IMPACTED (directly -- this target changed on its own)

Root causes: 4

  1. //service/a:app  [Rule]
     the rule's own definition or attributes changed
     0 hops -- this is the queried target itself
     //service/a:app

  2. //service/a:main.py  [SourceFile]
     source file content changed
     1 hop (0 package boundaries crossed)
     //service/a:main.py -> //service/a:app

  3. //common/data:util.py  [SourceFile]
     source file content changed
     3 hops (2 package boundaries crossed)
     //common/data:util.py -> //common:gen_srcs -> //common:lib -> //service/a:app
```

The walk deliberately continues *through* a DIRECT label rather than stopping at the first one — a target that changed itself may also have changed deps, and both are genuine reasons. That's what makes the "multiple reasons" case work.

`--format dot|mermaid|json` render the same data as a graph. Only the **blame subgraph** is drawn — the queried target, its root causes, and what carried the change between them — never the whole impacted set, which is what keeps it readable on a monorepo.

```mermaid
flowchart TD
  n0[["//common/data:schema.json<br/>(root cause)"]]
  n1[["//common/data:util.py<br/>(root cause)"]]
  n2["//common:gen_srcs"]
  n3["//common:lib"]
  n4[["//service/a:main.py<br/>(root cause)"]]
  n5(["//service/a:app<br/>(queried target - also a root cause)"])
  n0 --> n2
  n1 --> n2
  n2 --> n3
  n3 --> n5
  n4 --> n5
  classDef rootCause fill:#fcfcfb,stroke:#eb6834,stroke-width:2px,color:#0b0b0b
  classDef intermediate fill:#fcfcfb,stroke:#6b6a66,stroke-width:1px,color:#0b0b0b
  classDef queried fill:#fcfcfb,stroke:#2a78d6,stroke-width:2px,color:#0b0b0b
  class n5 queried
  class n0,n1,n4 rootCause
  class n2,n3 intermediate
```

Edges point in **impact-propagation** direction (root cause at top, queried target at bottom), the reverse of the `--depEdgesFile` orientation, so reading downward follows the change as it flows in.

## Design notes worth reviewing

* **`packageHops`, not `packageDistance`.** `/impacted_targets_with_distances` minimises package distance *independently* of target distance, so it can be smaller than the crossings on this (target-distance-minimal) path. Reusing the name would have been a latent bug report.
* **No silent caps.** `--maxRootCauses` (default 25) and `--maxDepth` (default unbounded) bound the output, but the pre-truncation total is always reported and a bounded search that cut something off logs a warning.
* **Graph colour.** Node identity is carried by the **stroke**, using a palette pair validated for all-pairs CVD separation in both modes (worst pair ΔE 24.7 protan light / 26.8 dark). An earlier pass used three tinted fills; measured, the intermediate↔root-cause tints came out at normal-vision ΔE 4.5 against a ≥15 floor, so fills can't carry identity here. Fills are a uniform surface instead, which also makes each node its own light surface — the output doesn't depend on the viewer's page background, which matters because DOT and Mermaid are static source rendered somewhere we don't control. Colour is never the sole encoding: roles also differ by node shape, carry a direct role label, and DOT emits a legend.
* **Degrades rather than crashes** on the [#268](https://github.com/Tinder/bazel-diff/issues/268) shape (hash JSON filtered by `--targetType` while the dep-edges file wasn't): reports no attribution with a message pointing at the likely cause.

Two bugs caught while testing and fixed here: `--format dot` (the lower-case spelling the docs use) was rejected by picocli's case-sensitive enum conversion; and a target deleted in the final revision reported "hash is identical between the two revisions", which is false — it now says it was removed.

## Testing

- 4 new test targets, 33 cases: attribution engine, renderers, CLI, format converter.
- Per-file line coverage clears the repo's 90% gate: `ExplainImpactInteractor.kt` 97.1%, `ImpactGraphRenderer.kt` 98.6%, `ExplainCommand.kt` 91.1%, `ExplainFormatConverter.kt` 100%.
- DOT output was rendered and visually inspected; Mermaid output was validated with the real mermaid parser.
- `bazel test //cli:all //tools:all` → 86 pass. The 4 failures (`E2ETest_*Cquery*`, `*ExternalRepo*`) are `Unable to run coursier: Unable to locate a Java Runtime` in the nested sandboxed Bazel — **confirmed failing identically on a clean stashed tree**, so environmental and pre-existing, not from this change.

## Not included

`--format html` (self-contained interactive report) and a `GET /explain` serve endpoint are the natural next increments; this PR is deliberately scoped to the attribution engine plus static formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
