### PR TITLE
docs: mark the serve query service as production ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,10 @@ neither ever truncates silently — the full count is always reported:
 * `--maxDepth` (default `-1`, unbounded) stops the search N dependency hops above the queried
   target. When a bound cuts the search short, a warning says so.
 
-## Query Service (experimental)
+## Query Service
+
+`bazel-diff serve` is production ready — it has been validated internally in production CI and is
+supported for production use.
 
 Instead of running `generate-hashes` from scratch on every CI invocation, you can run `bazel-diff` as
 a long-running HTTP service that answers affectedness queries between two git revisions and caches
@@ -242,8 +245,8 @@ curl 'http://localhost:8080/impacted_targets?from=main&to=my-feature-branch'
   as unchanged, turning an O(all source files) content read into O(changed files) — the same
   optimization as `generate-hashes --modified-filepaths`. The list must be a **superset** of what
   actually changed: a truly-changed file left off it is content-skipped on both sides and its
-  impacted targets are missed (hence experimental). Omit it (or send `[]`) for the full-content hash,
-  identical to the GET form. `POST /impacted_targets_with_distances` accepts the same body.
+  impacted targets are missed, so treat the list as a correctness contract. Omit it (or send `[]`)
+  for the full-content hash, identical to the GET form. `POST /impacted_targets_with_distances` accepts the same body.
 
 ```bash
 curl -X POST http://localhost:8080/impacted_targets \
@@ -343,7 +346,7 @@ revision are also harmless — entries are deterministic per key, so last-write-
 content. The `--cacheMax*` pruning flags bound the *local* tier only; bound the bucket with an S3
 lifecycle policy instead.
 
-Notes and current limitations:
+Notes and operational guidance:
 
 * Distance metrics (`/impacted_targets_with_distances`) and the generate-hashes graph
   (`/dependency_edges`) require the dependency-edge graph, which is
@@ -546,12 +549,11 @@ workspace.
                             hashes. Disabling it catches configuration issues
                             by failing loudly. Defaults to `false`
   -m, --modified-filepaths=<modifiedFilepaths>
-                          Experimental: A text file containing a newline
-                            separated list of filepaths (relative to the
-                            workspace) these filepaths should represent the
-                            modified files between the specified revisions and
-                            will be used to scope what files are hashed during
-                            hash generation.
+                          A text file containing a newline separated list of
+                            filepaths (relative to the workspace) these
+                            filepaths should represent the modified files
+                            between the specified revisions and will be used to
+                            scope what files are hashed during hash generation.
   -s, --seed-filepaths=<seedFilepaths>
                           A text file containing a newline separated list of
                             filepaths. Each file in this list will be read and

--- a/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
+++ b/cli/src/main/kotlin/com/bazel_diff/cli/GenerateHashesCommand.kt
@@ -179,7 +179,7 @@ open class GenerateHashesCommand : Callable<Int> {
       names = ["-m", "--modified-filepaths"],
       description =
           [
-              "Experimental: A text file containing a newline separated list of filepaths (relative to the workspace) these filepaths should represent the modified files between the specified revisions and will be used to scope what files are hashed during hash generation."])
+              "A text file containing a newline separated list of filepaths (relative to the workspace) these filepaths should represent the modified files between the specified revisions and will be used to scope what files are hashed during hash generation."])
   var modifiedFilepaths: File? = null
 
   @CommandLine.Option(

--- a/tools/readme_template.md
+++ b/tools/readme_template.md
@@ -191,7 +191,10 @@ neither ever truncates silently — the full count is always reported:
 * `--maxDepth` (default `-1`, unbounded) stops the search N dependency hops above the queried
   target. When a bound cuts the search short, a warning says so.
 
-## Query Service (experimental)
+## Query Service
+
+`bazel-diff serve` is production ready — it has been validated internally in production CI and is
+supported for production use.
 
 Instead of running `generate-hashes` from scratch on every CI invocation, you can run `bazel-diff` as
 a long-running HTTP service that answers affectedness queries between two git revisions and caches
@@ -242,8 +245,8 @@ curl 'http://localhost:8080/impacted_targets?from=main&to=my-feature-branch'
   as unchanged, turning an O(all source files) content read into O(changed files) — the same
   optimization as `generate-hashes --modified-filepaths`. The list must be a **superset** of what
   actually changed: a truly-changed file left off it is content-skipped on both sides and its
-  impacted targets are missed (hence experimental). Omit it (or send `[]`) for the full-content hash,
-  identical to the GET form. `POST /impacted_targets_with_distances` accepts the same body.
+  impacted targets are missed, so treat the list as a correctness contract. Omit it (or send `[]`)
+  for the full-content hash, identical to the GET form. `POST /impacted_targets_with_distances` accepts the same body.
 
 ```bash
 curl -X POST http://localhost:8080/impacted_targets \
@@ -343,7 +346,7 @@ revision are also harmless — entries are deterministic per key, so last-write-
 content. The `--cacheMax*` pruning flags bound the *local* tier only; bound the bucket with an S3
 lifecycle policy instead.
 
-Notes and current limitations:
+Notes and operational guidance:
 
 * Distance metrics (`/impacted_targets_with_distances`) and the generate-hashes graph
   (`/dependency_edges`) require the dependency-edge graph, which is


### PR DESCRIPTION
## What changed

The `serve` query service is no longer documented as experimental.

- **`README.md` / `tools/readme_template.md`** (kept in sync — the README is generated from the template):
  - `## Query Service (experimental)` → `## Query Service`, with a lead sentence stating it is production ready and supported for production use.
  - The `modifiedFilepaths` caveat no longer justifies itself with "hence experimental". The superset requirement is still stated in full — it is a correctness contract on the caller's list, not a marker of instability.
  - `Notes and current limitations:` → `Notes and operational guidance:`.
- **`GenerateHashesCommand.kt`**: dropped the `Experimental:` prefix from the `-m, --modified-filepaths` help text, whose semantics the serve `POST` body shares.

## Why

The service has been validated internally in production CI, so the experimental framing understates its status and discourages adoption.

## Notes for reviewers

- The README's CLI-help block is machine-generated. Rather than hand-wrapping the reflowed paragraph, I built `//tools:cli_help_output` and copied picocli's actual output; the full `generate-hashes` help section in `README.md` now matches `bazel-bin/tools/help_generate_hashes.txt` verbatim.
- Deliberately left alone: the bullet noting that containerization and multi-instance deployment manifests are not shipped (a factual gap, not a stability caveat), and the unrelated "experimental" references to the Rust candidate implementation.
- No test or Rust-side copy referenced the `Experimental:` label; the Rust CLI's `--modified-filepaths` carries no help string.
- Docs and one help string only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)