### PR TITLE
perf: catch and fix the static-musl allocator storm in generate-hashes

### DIFF
--- a/.github/workflows/perf-gate.yaml
+++ b/.github/workflows/perf-gate.yaml
@@ -17,10 +17,10 @@ name: Performance Gate
 #   * glibc -- the host-native dynamic build. Stable on any runner, so it is the blocking gate
 #     that proves the Rust logic is faster than Kotlin.
 #   * musl  -- the statically-linked binary actually published for Linux. musl's single-arena
-#     malloc serializes the parallel proto decode, so this leg guards allocator scalability. It
+#     malloc would serialize the parallel proto decode, so this leg guards allocator scalability:
+#     the release links mimalloc as its #[global_allocator], and this leg keeps it that way. It
 #     only reproduces with enough cores (>= 8; the free 2-vCPU runner cannot surface it), so it
-#     runs on a larger runner, over the allocator-sensitive workload, and is non-blocking until a
-#     scalable global allocator lands.
+#     runs on a larger runner over the allocator-sensitive workload.
 # See docs/kotlin-rust-perf-gate.md for the protocol and for what to do when this job fails.
 on:
   push:
@@ -33,8 +33,6 @@ jobs:
   perf-gate:
     name: ${{ matrix.title }}
     runs-on: ${{ matrix.runner }}
-    # The musl leg is informational until a scalable #[global_allocator] (jemalloc/mimalloc)
-    # lands; flip its continue_on_error to false in that same change.
     continue-on-error: ${{ matrix.continue_on_error }}
     timeout-minutes: 45
     strategy:
@@ -58,7 +56,7 @@ jobs:
             rust_build: --config=release-musl //release:bazel-diff-rust
             rust_binary: bazel-bin/release/bazel-diff-rust-linux-amd64
             gate_workloads: --workload generate-hashes-dense
-            continue_on_error: true
+            continue_on_error: false
     steps:
       # No host Rust toolchain: the Rust binary is built by Bazel, which brings
       # its own rustc pinned in MODULE.bazel.

--- a/.github/workflows/perf-gate.yaml
+++ b/.github/workflows/perf-gate.yaml
@@ -9,10 +9,19 @@ name: Performance Gate
 # flags rather than the code.
 #
 # Runs on every pull request: "Rust is faster" is a property of the code, and a regression is
-# cheapest to catch in the change that caused it. The runner is a shared 2-vCPU VM, so the gate
-# pairs its measurements (both binaries every round, alternating which goes first) and takes
-# medians over several rounds rather than trusting a single timing. See
-# docs/kotlin-rust-perf-gate.md for the protocol and for what to do when this job fails.
+# cheapest to catch in the change that caused it. The gate pairs its measurements (both binaries
+# every round, alternating which goes first) and takes medians over several rounds rather than
+# trusting a single timing.
+#
+# Two legs (see the matrix below):
+#   * glibc -- the host-native dynamic build. Stable on any runner, so it is the blocking gate
+#     that proves the Rust logic is faster than Kotlin.
+#   * musl  -- the statically-linked binary actually published for Linux. musl's single-arena
+#     malloc serializes the parallel proto decode, so this leg guards allocator scalability. It
+#     only reproduces with enough cores (>= 8; the free 2-vCPU runner cannot surface it), so it
+#     runs on a larger runner, over the allocator-sensitive workload, and is non-blocking until a
+#     scalable global allocator lands.
+# See docs/kotlin-rust-perf-gate.md for the protocol and for what to do when this job fails.
 on:
   push:
     branches: [ master ]
@@ -22,9 +31,34 @@ on:
 
 jobs:
   perf-gate:
-    name: Rust vs Kotlin performance gate
-    runs-on: ubuntu-latest
+    name: ${{ matrix.title }}
+    runs-on: ${{ matrix.runner }}
+    # The musl leg is informational until a scalable #[global_allocator] (jemalloc/mimalloc)
+    # lands; flip its continue_on_error to false in that same change.
+    continue-on-error: ${{ matrix.continue_on_error }}
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - title: Rust (glibc) vs Kotlin performance gate
+            libc: glibc
+            runner: ubuntu-latest
+            rust_build: -c opt //src:bazel-diff
+            rust_binary: bazel-bin/src/bazel-diff
+            gate_workloads: ""
+            continue_on_error: false
+          # `ubuntu-latest-8-cores` must map to an org-provisioned larger runner (or a
+          # self-hosted one) with at least 8 vCPUs -- the allocator storm does not appear
+          # below that, so a 2-vCPU runner here would be a false green. Rename to match the
+          # label your org exposes.
+          - title: Rust (musl) allocator-scalability gate
+            libc: musl
+            runner: ubuntu-latest-8-cores
+            rust_build: --config=release-musl //release:bazel-diff-rust
+            rust_binary: bazel-bin/release/bazel-diff-rust-linux-amd64
+            gate_workloads: --workload generate-hashes-dense
+            continue_on_error: true
     steps:
       # No host Rust toolchain: the Rust binary is built by Bazel, which brings
       # its own rustc pinned in MODULE.bazel.
@@ -41,15 +75,20 @@ jobs:
         run: go install github.com/bazelbuild/bazelisk@latest
       - uses: actions/checkout@v4
       - name: Unit-test the gate itself
+        # Implementation-agnostic, so run it once on the cheap runner only.
+        if: matrix.libc == 'glibc'
         env:
           USE_BAZEL_VERSION: '8.x'
           CARGO_BAZEL_ISOLATED: 'false'
         run: ~/go/bin/bazelisk test //tools:perf_gate_test
-      - name: Build both implementations
+      - name: Build Kotlin and Rust binaries
         env:
           USE_BAZEL_VERSION: '8.x'
           CARGO_BAZEL_ISOLATED: 'false'
-        run: ~/go/bin/bazelisk build -c opt //cli:bazel-diff //src:bazel-diff
+        # Kotlin is always the host build; only the Rust target/config varies per leg.
+        run: |
+          ~/go/bin/bazelisk build -c opt //cli:bazel-diff
+          ~/go/bin/bazelisk build ${{ matrix.rust_build }}
       - name: Run the performance gate
         env:
           USE_BAZEL_VERSION: '8.x'
@@ -60,26 +99,27 @@ jobs:
         run: |
           python3 tools/perf_gate.py \
             --kotlin-binary bazel-bin/cli/bazel-diff \
-            --rust-binary bazel-bin/src/bazel-diff \
+            --rust-binary ${{ matrix.rust_binary }} \
+            ${{ matrix.gate_workloads }} \
             --rounds 7 \
             --warmup-rounds 2 \
-            --json perf-gate.json \
-            | tee perf-gate.txt
+            --json perf-gate-${{ matrix.libc }}.json \
+            | tee perf-gate-${{ matrix.libc }}.txt
       - name: Publish summary
         if: always()
         run: |
           {
-            echo '## Rust vs Kotlin performance gate'
+            echo '## ${{ matrix.title }}'
             echo '```'
-            cat perf-gate.txt || echo 'the gate produced no report'
+            cat perf-gate-${{ matrix.libc }}.txt || echo 'the gate produced no report'
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: perf-gate-report
+          name: perf-gate-report-${{ matrix.libc }}
           path: |
-            perf-gate.json
-            perf-gate.txt
+            perf-gate-${{ matrix.libc }}.json
+            perf-gate-${{ matrix.libc }}.txt
           if-no-files-found: ignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "buffa-build",
  "clap",
  "hex",
+ "mimalloc",
  "protoc-bin-vendored",
  "rayon",
  "rust-s3",
@@ -459,7 +460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -729,6 +730,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +778,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1030,7 +1049,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1230,7 +1249,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1423,7 +1442,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0"
 buffa = "0.9.1"
 clap = { version = "4.5", features = ["derive", "env"] }
 hex = "0.4"
+mimalloc = "0.1"
 rayon = "1.10"
 rust-s3 = { version = "=0.36.0", default-features = false, features = ["sync-rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,24 @@ perf-gate:
 		$(if $(RSS_RUNS),--rss-runs "$(RSS_RUNS)",) \
 		$(if $(JSON),--json "$(JSON)",)
 
+# The gate against the statically-linked musl binary that actually ships for Linux, not the
+# host glibc build `perf-gate` uses. musl's single-arena malloc serializes the parallel proto
+# decode, so this exposes allocator-scalability regressions -- but only on a many-core host
+# (>= 8 cores); on a 2-core machine there is too little contention and it passes regardless.
+# Defaults to the allocator-sensitive workload; override with WORKLOAD= to run others.
+.PHONY: perf-gate-musl
+perf-gate-musl:
+	$(or $(BAZEL),bazel) build //cli:bazel-diff -c opt
+	$(or $(BAZEL),bazel) build //release:bazel-diff-rust --config=release-musl
+	python3 tools/perf_gate.py \
+		--kotlin-binary bazel-bin/cli/bazel-diff \
+		--rust-binary bazel-bin/release/bazel-diff-rust-linux-amd64 \
+		--workload "$(or $(WORKLOAD),generate-hashes-dense)" \
+		--rounds "$(or $(ROUNDS),7)" \
+		--warmup-rounds "$(or $(WARMUP),2)" \
+		--scale "$(or $(SCALE),1)" \
+		$(if $(JSON),--json "$(JSON)",)
+
 .PHONY: perf-gate-test
 perf-gate-test:
 	$(or $(BAZEL),bazel) test //tools:perf_gate_test

--- a/cargo-bazel-lock.json
+++ b/cargo-bazel-lock.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "706ee75673bec5e4d514fe0bc1ea91301131838f7d2e0c76e4dac7644a73a68f",
+  "checksum": "3e82b6e041284d57ac71bde0287bb29854b98f09fbade93a88d92536503e2310",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -870,6 +870,10 @@
             {
               "id": "hex 0.4.3",
               "target": "hex"
+            },
+            {
+              "id": "mimalloc 0.1.52",
+              "target": "mimalloc"
             },
             {
               "id": "rayon 1.12.0",
@@ -2896,7 +2900,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.52.0",
+                "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
               }
             ]
@@ -4699,6 +4703,83 @@
       ],
       "license_file": "LICENSE-APACHE"
     },
+    "libmimalloc-sys 0.1.49": {
+      "name": "libmimalloc-sys",
+      "version": "0.1.49",
+      "package_url": "https://github.com/purpleprotocol/mimalloc_rust/tree/master/libmimalloc-sys",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/libmimalloc-sys/0.1.49/download",
+          "sha256": "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "libmimalloc_sys",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "libmimalloc_sys",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "extra_deps": {
+          "common": [
+            ":build_script_build"
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.49"
+      },
+      "build_script_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "compile_data_glob_excludes": [
+          "**/*.rs"
+        ],
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "cc 1.4.0",
+              "target": "cc"
+            }
+          ],
+          "selects": {}
+        },
+        "links": "mimalloc"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE.txt"
+    },
     "linux-raw-sys 0.12.1": {
       "name": "linux-raw-sys",
       "version": "0.12.1",
@@ -4980,6 +5061,59 @@
         "Unlicense"
       ],
       "license_file": "LICENSE-MIT"
+    },
+    "mimalloc 0.1.52": {
+      "name": "mimalloc",
+      "version": "0.1.52",
+      "package_url": "https://github.com/purpleprotocol/mimalloc_rust",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/mimalloc/0.1.52/download",
+          "sha256": "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "mimalloc",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "mimalloc",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "default"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "libmimalloc-sys 0.1.49",
+              "target": "libmimalloc_sys"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.52"
+      },
+      "license": "MIT",
+      "license_ids": [
+        "MIT"
+      ],
+      "license_file": "LICENSE.txt"
     },
     "miniz_oxide 0.8.9": {
       "name": "miniz_oxide",
@@ -6713,7 +6847,7 @@
                 "alias": "libc_errno"
               },
               {
-                "id": "windows-sys 0.52.0",
+                "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
               }
             ],
@@ -8144,7 +8278,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.52.0",
+                "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
               }
             ],
@@ -9384,7 +9518,7 @@
           "selects": {
             "cfg(windows)": [
               {
-                "id": "windows-sys 0.52.0",
+                "id": "windows-sys 0.61.2",
                 "target": "windows_sys"
               }
             ]
@@ -9468,19 +9602,6 @@
         "compile_data_glob": [
           "**"
         ],
-        "crate_features": {
-          "common": [
-            "Win32",
-            "Win32_Foundation",
-            "Win32_Storage",
-            "Win32_Storage_FileSystem",
-            "Win32_System",
-            "Win32_System_Console",
-            "Win32_System_SystemInformation",
-            "default"
-          ],
-          "selects": {}
-        },
         "deps": {
           "common": [
             {
@@ -9593,8 +9714,11 @@
           "common": [
             "Win32",
             "Win32_Foundation",
+            "Win32_Storage",
+            "Win32_Storage_FileSystem",
             "Win32_System",
             "Win32_System_Console",
+            "Win32_System_SystemInformation",
             "default"
           ],
           "selects": {}
@@ -11148,6 +11272,7 @@
     "buffa-build 0.9.1",
     "clap 4.6.5",
     "hex 0.4.3",
+    "mimalloc 0.1.52",
     "protoc-bin-vendored 3.2.0",
     "rayon 1.12.0",
     "rust-s3 0.36.0",

--- a/docs/kotlin-rust-perf-gate.md
+++ b/docs/kotlin-rust-perf-gate.md
@@ -49,6 +49,7 @@ bytes and any difference in timing is a difference in code.
 | `startup` | `--version`: the fixed cost of launching each CLI (JVM boot vs `exec`) |
 | `generate-hashes-small` | 4,800 targets: proto decode, rule/source hashing, transitive digests |
 | `generate-hashes-large` | 24,000 targets: the same path where per-target cost dominates |
+| `generate-hashes-dense` | 192,000 targets, fan-in 12: sustained concurrent allocation in the parallel proto decode -- stresses allocator scalability (see below) |
 | `get-impacted-targets` | diffing 150,000 hashed targets |
 | `get-impacted-targets-distances` | the same diff plus build-graph distance metrics over dependency edges |
 
@@ -68,6 +69,35 @@ always measured, because the other workloads' adjusted numbers derive from it).
   fixture. No Bazel server starts, so the measured wall time is bazel-diff's own work;
 * **hash-file pairs** for the diff commands, where the second revision changes, adds and
   removes targets.
+
+### Allocator scalability (`generate-hashes-dense`)
+
+`generate-hashes` decodes the `streamed_proto` stream in parallel: each batch of messages
+is decoded across the Rayon pool, and every proto field (`rule_class`, each attribute, and
+one `rule_input` per dependency) becomes a short-lived heap allocation. With enough targets
+and fan-in, all worker threads allocate at once, so the run's speed becomes a function of
+how well the global allocator scales under concurrency.
+
+An allocator with per-thread arenas (glibc's default) absorbs this and the Rust build stays
+several times faster than Kotlin. An allocator with a single global lock serializes every
+worker on that lock; system time explodes and throughput scales *negatively* with core
+count. The published Rust release is a **static musl** binary, and musl's malloc uses a
+single arena -- so on a many-core host this workload can make the release binary as slow as,
+or slower than, Kotlin, while a glibc build of the same source passes comfortably.
+
+To observe it, point `--rust-binary` at the static-musl release on a many-core machine, or
+approximate it with a glibc build under `MALLOC_ARENA_MAX=1`. The smaller graphs do not
+reach a high enough concurrent allocation rate to surface this, which is why the dense graph
+exists as a separate load. A scalable global allocator (for example jemalloc or mimalloc via
+`#[global_allocator]`) removes the gap.
+
+The default CI run builds the host **glibc** binary, which is stable on any runner and never
+storms -- so it would not catch this by itself. The gate therefore runs as two legs (see
+`.github/workflows/perf-gate.yaml`): the glibc leg is the blocking "Rust is faster" gate,
+and a second leg builds the published `--config=release-musl` binary and runs the dense load
+against it. That leg needs a **many-core runner** -- the storm does not appear below ~8 cores,
+so a 2-vCPU runner would pass it regardless -- and is non-blocking until a scalable global
+allocator lands. Locally, `make perf-gate-musl` reproduces it on a many-core host.
 
 ## Protocol
 

--- a/docs/kotlin-rust-perf-gate.md
+++ b/docs/kotlin-rust-perf-gate.md
@@ -82,22 +82,23 @@ An allocator with per-thread arenas (glibc's default) absorbs this and the Rust 
 several times faster than Kotlin. An allocator with a single global lock serializes every
 worker on that lock; system time explodes and throughput scales *negatively* with core
 count. The published Rust release is a **static musl** binary, and musl's malloc uses a
-single arena -- so on a many-core host this workload can make the release binary as slow as,
-or slower than, Kotlin, while a glibc build of the same source passes comfortably.
+single arena -- so on a many-core host this workload would make the release binary as slow
+as, or slower than, Kotlin, while a glibc build of the same source passed comfortably. The
+release therefore links **mimalloc** as its `#[global_allocator]` (see `src/main.rs`), whose
+per-thread heaps restore scaling; this workload exists to keep it that way.
 
-To observe it, point `--rust-binary` at the static-musl release on a many-core machine, or
-approximate it with a glibc build under `MALLOC_ARENA_MAX=1`. The smaller graphs do not
-reach a high enough concurrent allocation rate to surface this, which is why the dense graph
-exists as a separate load. A scalable global allocator (for example jemalloc or mimalloc via
-`#[global_allocator]`) removes the gap.
+To reproduce the underlying problem, drop the `#[global_allocator]` and point `--rust-binary`
+at the static-musl release on a many-core machine, or approximate it with a glibc build under
+`MALLOC_ARENA_MAX=1`. The smaller graphs do not reach a high enough concurrent allocation
+rate to surface it, which is why the dense graph exists as a separate load.
 
 The default CI run builds the host **glibc** binary, which is stable on any runner and never
-storms -- so it would not catch this by itself. The gate therefore runs as two legs (see
-`.github/workflows/perf-gate.yaml`): the glibc leg is the blocking "Rust is faster" gate,
-and a second leg builds the published `--config=release-musl` binary and runs the dense load
-against it. That leg needs a **many-core runner** -- the storm does not appear below ~8 cores,
-so a 2-vCPU runner would pass it regardless -- and is non-blocking until a scalable global
-allocator lands. Locally, `make perf-gate-musl` reproduces it on a many-core host.
+storms -- so it would not catch an allocator regression by itself. The gate therefore runs as
+two legs (see `.github/workflows/perf-gate.yaml`): the glibc leg is the blocking "Rust is
+faster" gate, and a second leg builds the published `--config=release-musl` binary and runs
+the dense load against it. That leg needs a **many-core runner** -- the storm does not appear
+below ~8 cores, so a 2-vCPU runner would pass it regardless of the allocator. Locally,
+`make perf-gate-musl` reproduces it on a many-core host.
 
 ## Protocol
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,11 @@ use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+// The static-musl release shares one malloc arena, which serializes the parallel proto
+// decode in generate-hashes; mimalloc's per-thread heaps keep it scaling on many-core hosts.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Debug, Parser)]
 #[command(
     name = "bazel-diff",

--- a/tools/perf_gate.py
+++ b/tools/perf_gate.py
@@ -276,6 +276,13 @@ def default_workload_specs(scale: float) -> list[WorkloadSpec]:
     """
     small_graph = GraphSpec(packages=400).scaled(scale)
     large_graph = GraphSpec(packages=2000).scaled(scale)
+    # High fan-in makes each rule decode into many `rule_input` heap allocations, so the
+    # parallel proto decode sustains enough concurrent allocation to expose an allocator
+    # that does not scale across threads (e.g. musl's single-arena malloc in the static
+    # release build) -- a dimension the uniform small/large graphs do not reach.
+    dense_graph = GraphSpec(
+        packages=12000, rules_per_package=4, sources_per_rule=2, fanin=12
+    ).scaled(scale)
     diff_spec = HashFileSpec(targets=150_000).scaled(scale)
     distance_spec = HashFileSpec(targets=40_000, deps_per_target=4).scaled(scale)
     return [
@@ -301,6 +308,18 @@ def default_workload_specs(scale: float) -> list[WorkloadSpec]:
                 "generate-hashes-large",
                 f"hash a {large_graph.target_count}-target graph",
                 large_graph,
+                directory,
+            ),
+        ),
+        WorkloadSpec(
+            name="generate-hashes-dense",
+            description=(
+                f"hash a dependency-dense {dense_graph.target_count}-target graph"
+            ),
+            prepare=lambda directory: _prepare_generate_hashes(
+                "generate-hashes-dense",
+                f"hash a dependency-dense {dense_graph.target_count}-target graph",
+                dense_graph,
                 directory,
             ),
         ),

--- a/tools/perf_gate_test.py
+++ b/tools/perf_gate_test.py
@@ -827,6 +827,7 @@ class WorkloadSelectionTest(unittest.TestCase):
         names = [spec.name for spec in default_workload_specs(1.0)]
         self.assertIn(STARTUP_WORKLOAD, names)
         self.assertIn("generate-hashes-large", names)
+        self.assertIn("generate-hashes-dense", names)
         self.assertIn("get-impacted-targets", names)
         self.assertIn("get-impacted-targets-distances", names)
 


### PR DESCRIPTION
## What

Two commits:

1. **`feat(perf-gate)`** — extend the Kotlin-vs-Rust performance gate to exercise
   the binary we actually ship (static musl), on a dependency-dense workload, via
   a two-libc CI matrix.
2. **`fix(rust)`** — link `mimalloc` as the global allocator, which removes the
   regression that the new workload exposes, and flip the musl gate leg to blocking.

Kept as separate commits so the detection and the fix can be reviewed (and
reverted) independently.

## Why

The gate only ever built the host **glibc** binary. glibc's per-thread malloc
arenas hide a scalability problem that only the **static-musl** release — the
artifact published for Linux — actually has: musl's malloc uses a single arena,
so the parallel proto-decode in `generate-hashes` (one short-lived heap
allocation per proto field, including one `rule_input` per dependency) serializes
every Rayon worker on the arena lock. On a many-core host system time explodes and
throughput scales *negatively* with core count, and the release binary loses to
Kotlin — while a glibc build of the same source passes comfortably.

## The workload

`generate-hashes-dense` (192,000 targets, fan-in 12) sustains a high enough
concurrent allocation rate to surface the storm. It's realistic (keeps sources
per rule) rather than a synthetic zero-source shape, so it reflects real graphs.

The crossover is core-count-dependent — more cores make Kotlin faster *and* musl
slower — so the musl leg must run on a **≥8-vCPU runner**; below that there isn't
enough contention and it passes regardless. Measured (static-musl, pre-fix):

| cores | musl vs Kotlin | verdict |
|------:|---------------:|:--------|
| 2     | 2.15×          | pass    |
| 4     | 1.26×          | pass    |
| 8     | 0.95×          | **fail** |
| 32    | 0.72×          | **fail** |

## The fix

Link `mimalloc` as the binary's `#[global_allocator]` (`src/main.rs`). Its
per-thread heaps eliminate the arena contention. On a 32-core host the static-musl
release goes from **0.72× (gate failure) to 2.30× faster than Kotlin** on the
dense workload, with byte-identical output. `libmimalloc-sys`'s C library
cross-compiles cleanly for the musl target.

With the regression gone, the musl gate leg is flipped to blocking so it guards
the allocator choice from here on.

## CI shape

`.github/workflows/perf-gate.yaml` runs one job as a `{glibc, musl}` matrix
(`fail-fast: false`):

| leg   | runner                | Rust build                                      | workloads              | blocking |
|-------|-----------------------|-------------------------------------------------|------------------------|:--------:|
| glibc | `ubuntu-latest`       | `-c opt //src:bazel-diff`                        | full default set       | yes      |
| musl  | `ubuntu-latest-8-cores` | `--config=release-musl //release:bazel-diff-rust` | `generate-hashes-dense` | yes      |

`make perf-gate-musl` reproduces the musl leg locally on a many-core host.

## Notes for reviewers

- **`ubuntu-latest-8-cores` is a placeholder label** — please point it at whatever
  ≥8-vCPU runner this org exposes. On a 2-vCPU runner the musl leg is a false green.
- The gate unit test runs only on the glibc leg (it's implementation-agnostic).
- No `MODULE.bazel` change — adding the crate only touches `Cargo.toml`,
  `Cargo.lock`, and the checked-in `cargo-bazel-lock.json` (regenerate with
  `CARGO_BAZEL_REPIN=1 bazel build //:bazel-diff-rust`).

## Test plan

- [x] `bazel build //:bazel-diff-rust` (glibc, with mimalloc)
- [x] `bazel build //release:bazel-diff-rust --config=release-musl` (mimalloc C cross-compiles for musl)
- [x] Dense gate, static-musl+mimalloc vs Kotlin, 32-core host: **2.30× PASS** (was 0.72× FAIL)
- [x] `bazel test //tools:perf_gate_test`